### PR TITLE
chore: standardize shared config + community-health files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,16 +3,34 @@
 .git
 .github
 .gitignore
-**/.env
-**/.env.*
-**/firebase-secrets.json
-**/*service-account*.json
-**/*.pem
+.dockerignore
+
+# OS / editor
+**/.DS_Store
+*.swp
+*.swo
+
+# Dependencies & build output
 **/node_modules
 **/.next
+**/out
+**/dist
+**/build
+**/bin
+**/tmp
+**/.dart_tool
 **/__pycache__
 **/*.pyc
-**/.dart_tool
-**/build
-**/.DS_Store
+
+# Environment & secrets (never ship into an image)
+**/.env
+**/.env.*
+!**/.env.example
+**/*service-account*.json
+**/firebase-secrets.json
+**/*.pem
+**/*.tfvars
+
+# Logs & docs
+**/*.log
 *.md

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,18 @@
 root = true
 
 [*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
-charset = utf-8
-trim_trailing_whitespace = true
-insert_final_newline = true
+
+[*.go]
+indent_style = tab
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ labels: [bug]
 A clear and concise description of the bug.
 
 ## Affected area
-`api/common` / `api/measure` / `web` / `mobile` / `deploy` / other
+`api/common` / `api/<service>` / `web` / `mobile` / `deploy` / other
 
 ## Steps to reproduce
 1.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability
-    url: https://github.com/cuesoftinc/apparule/security/advisories/new
-    about: Please report security issues privately, not as public issues.
+    url: https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability
+    about: Please report security issues privately via the Security tab, not as public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,6 +14,6 @@ Describe the change you'd like.
 ## Alternatives considered
 
 ## Affected area
-`api/common` / `api/measure` / `web` / `mobile` / `deploy` / other
+`api/common` / `api/<service>` / `web` / `mobile` / `deploy` / other
 
 ## Additional context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,13 +14,13 @@
 
 ## Affected areas
 - [ ] `api/common` (Go)
-- [ ] `api/measure` (Python)
+- [ ] `api/<service>`
 - [ ] `web`
 - [ ] `mobile`
 - [ ] `deploy` / CI
 
 ## Checklist
-- [ ] I followed the [Contributing guide](../CONTRIBUTING.md).
+- [ ] I followed the Contributing guide.
 - [ ] Commits follow Conventional Commits (`feat:`, `fix:`, `chore:`…).
 - [ ] Lint and tests pass locally.
 - [ ] No secrets, credentials, or `.env` files are committed.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 version: 2
 updates:
-  # Go backend (main/shared service)
   - package-ecosystem: gomod
     directory: /api/common
     schedule:
@@ -9,7 +8,6 @@ updates:
       go-dependencies:
         patterns: ["*"]
 
-  # Python measurement service
   - package-ecosystem: pip
     directory: /api/measure
     schedule:
@@ -18,7 +16,6 @@ updates:
       python-dependencies:
         patterns: ["*"]
 
-  # Next.js web + dashboard
   - package-ecosystem: npm
     directory: /web
     schedule:
@@ -27,14 +24,7 @@ updates:
       npm-dependencies:
         patterns: ["*"]
 
-  # Flutter mobile app
   - package-ecosystem: pub
     directory: /mobile/flutter
-    schedule:
-      interval: weekly
-
-  # CI workflows
-  - package-ecosystem: github-actions
-    directory: /
     schedule:
       interval: weekly

--- a/.gitignore
+++ b/.gitignore
@@ -1,54 +1,64 @@
-# Dart/Flutter
-.dart_tool/
-.flutter-plugins
-.flutter-plugins-dependencies
-.packages
-pubspec.lock
-build/
-*.iml
-*.lock
-
-# IDE
-.vscode/
-.idea/
+# ── OS / editor ──
+.DS_Store
 *.swp
 *.swo
 *~
-.DS_Store
+.idea/
+.vscode/
+*.iml
 
-# OS
-*.log
+# ── Environment & secrets (never commit) ──
 .env
-.env.local
-
-# Build outputs
-dist/
-*.apk
-*.ipa
-*.app
-*.exe
-.next/
-out/
-
-# Node
-node_modules/
-npm-debug.log
-yarn-error.log
-
-# Python
-__pycache__/
-*.py[cod]
-venv/
-env/
-
-# Terraform
+.env.*
+!.env.example
+*.pem
+firebase-secrets.json
+*service-account*.json
+*.tfvars
 *.tfstate
 *.tfstate.*
 .terraform/
 
-# Docker
+# ── Go ──
+bin/
+.air.toml
 
-# Firebase Local Security Sandbox
-firebase-secrets.json
-# generated pose-detector output
-api/measure/output_landmarks.jpg
+# ── Python ──
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+env/
+
+# ── Node / Next.js ──
+node_modules/
+.next/
+out/
+dist/
+build/
+coverage/
+.eslintcache
+*.tsbuildinfo
+next-env.d.ts
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnp.js
+.vercel
+
+# ── Flutter / Dart ──
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+*.apk
+*.aab
+*.ipa
+*.app
+
+# ── Logs & temp ──
+*.log
+tmp/
+
+# NOTE: do NOT ignore .dockerignore; commit lockfiles (package-lock.json,
+# go.sum, pubspec.lock, .terraform.lock.hcl).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,30 @@
+# Changelog
 
+All notable changes to Apparule are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+- Standardized repository structure: `api/common` (Go) and `api/measure`
+  (Python), plus `web`, `mobile/{flutter,android,ios}`,
+  `deploy/{docker,helm,terraform}`, `docs`, and `scripts`.
+- Shared community-health files from the CueLABS standard (SECURITY,
+  CODE_OF_CONDUCT, CONTRIBUTING, CODEOWNERS, PR/issue templates) and a scoped
+  Dependabot config.
+- `docs/overview.md` and `docs/setup.md`.
+
+### Changed
+- Moved the Python measurement service from `api/common/measurement` to
+  `api/measure`.
+- Aligned `.gitignore`, `.editorconfig`, and `.dockerignore` to the shared
+  standard.
+
+### Removed
+- GitHub Actions CI workflow, the one-off `scripts/refactor-structure.sh`, stale
+  `docs/devops` planning docs, and a generated pose-detector artifact.
+
+### Security
+- Pinned `postcss` (XSS advisory) and updated `js-yaml`.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners of everything in the repo unless a later rule takes precedence
-* @hibeekaey @Mubiyn @chordzz
+* @hibeekaey @chordzz

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -28,8 +28,8 @@ Examples of unacceptable behavior:
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the maintainers listed in [CODEOWNERS](CODEOWNERS). All complaints
-will be reviewed and investigated promptly and fairly.
+reported to the maintainers listed in CODEOWNERS. All complaints will be
+reviewed and investigated promptly and fairly.
 
 ## Attribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,21 @@
-# Contributing to Apparule
+# Contributing
 
-Thanks for your interest in contributing! This guide covers how to propose
-changes.
+Thanks for your interest in contributing! This guide applies across CueLABS
+repositories, which share a common structure and conventions.
 
 ## Getting started
 
 1. Fork and clone the repository.
 2. Create a feature branch: `git checkout -b feature/short-description`.
-3. Install dependencies for the area you're working on — see
+3. Install dependencies for the area you're working on — see the repository's
    [docs/setup.md](docs/setup.md).
 
 ## Repository layout
 
-This is a monorepo. Work happens in one of:
+CueLABS repositories follow a shared standard:
 
 - `api/common` — Go backend (auth + core API)
-- `api/measure` — Python measurement service
+- `api/<service>` — additional services, named by function
 - `web` — Next.js web + dashboard
 - `mobile/flutter` — Flutter mobile app
 - `deploy`, `docs`, `scripts`

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
+MIT License
 
-The MIT License (MIT)
-
-Copyright (c) 2023 Cuesoft
+Copyright (c) 2026 Cuesoft Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -10,13 +9,13 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,30 +2,24 @@
 
 ## Supported Versions
 
-This project is under active development. Security fixes are applied to the
-`main` branch. Deployed environments are expected to track `main`.
+Security fixes are applied to the `main` branch. Deployed environments are
+expected to track `main`.
 
 ## Reporting a Vulnerability
 
 **Do not open a public issue for security vulnerabilities.**
 
-Instead, report privately using GitHub's
+Report privately using GitHub's
 [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
-(the **Security → Report a vulnerability** tab on this repository), or email the
-maintainers listed in [CODEOWNERS](CODEOWNERS).
+(the **Security → Report a vulnerability** tab), or email the maintainers listed
+in CODEOWNERS.
 
-Please include:
-
-- A description of the vulnerability and its impact.
-- Steps to reproduce (proof-of-concept if possible).
-- Affected component (`api/common`, `api/measure`, `web`, `mobile`, deploy, …).
-
-We aim to acknowledge reports within 3 business days and to provide a
-remediation timeline after triage.
+Please include a description and impact, steps to reproduce, and the affected
+component. We aim to acknowledge within 3 business days.
 
 ## Handling of Secrets
 
 - Never commit credentials, service-account keys, or `.env` files. These are
-  covered by [.gitignore](.gitignore) and [.dockerignore](.dockerignore).
-- Configuration such as `FIREBASE_CONFIG_PATH` must be supplied at runtime via
-  environment variables or a secret manager, never baked into an image.
+  covered by `.gitignore` and `.dockerignore`.
+- Supply configuration at runtime via environment variables or a secret
+  manager — never baked into an image.


### PR DESCRIPTION
Adopts the canonical CueLABS templates for byte-parity across repos (LICENSE, CODEOWNERS, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, .gitignore, .editorconfig, .dockerignore, PR/issue templates); drops the failing github-actions dependabot entry; populates CHANGELOG.md.