### PR TITLE
security: remove email_auth (client-side OTP) dependency

### DIFF
--- a/mobile/flutter/lib/verify_account.dart
+++ b/mobile/flutter/lib/verify_account.dart
@@ -2,7 +2,6 @@ import 'dart:ui';
 
 import 'package:apparule/home_screen.dart';
 import 'package:flutter/material.dart';
-import 'package:email_auth/email_auth.dart';
 import 'package:sms_autofill/sms_autofill.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
@@ -28,22 +27,12 @@ class _EmailVerificationPageState extends State<EmailVerificationPage> with Sing
   }
 
   void sendOTP() async {
-    EmailAuth emailAuth = new EmailAuth(sessionName: "Authentication");
-    var res = await emailAuth.sendOtp(recipientMail: _emailController.text);
-    if (res) {
-      print('OTP Sent');
-    } else {
-      print("We couldn't send the otp");
-    }
+    // TODO: request an OTP from the backend. Client-side OTP handling was
+    // removed for security — OTP send/verify must happen server-side.
   }
 
   void verifyOTP() {
-    var res = EmailAuth(sessionName: "Authentication").validateOtp(recipientMail: _emailController.text, userOtp: _otpController.text);
-    if (res) {
-      print('OTP verified');
-    } else {
-      print("Invalid OTP");
-    }
+    // TODO: verify the OTP against the backend (server-side).
   }
 
   @override

--- a/mobile/flutter/lib/verify_email.dart
+++ b/mobile/flutter/lib/verify_email.dart
@@ -1,7 +1,6 @@
 import 'package:apparule/home_screen.dart';
 import 'package:apparule/reset_password.dart';
 import 'package:flutter/material.dart';
-import 'package:email_auth/email_auth.dart';
 import 'package:sms_autofill/sms_autofill.dart';
 
 class VerifyEmailForPasswordReset extends StatefulWidget {
@@ -26,22 +25,12 @@ class _VerifyEmailForPasswordResetState extends State<VerifyEmailForPasswordRese
   }
 
   void sendOTP() async {
-    EmailAuth emailAuth = new EmailAuth(sessionName: "Authentication");
-    var res = await emailAuth.sendOtp(recipientMail: _emailController.text);
-    if (res) {
-      print('OTP Sent');
-    } else {
-      print("We couldn't send the otp");
-    }
+    // TODO: request an OTP from the backend. Client-side OTP handling was
+    // removed for security — OTP send/verify must happen server-side.
   }
 
   void verifyOTP() {
-    var res = EmailAuth(sessionName: "Authentication").validateOtp(recipientMail: _emailController.text, userOtp: _otpController.text);
-    if (res) {
-      print('OTP verified');
-    } else {
-      print("Invalid OTP");
-    }
+    // TODO: verify the OTP against the backend (server-side).
   }
 
   @override

--- a/mobile/flutter/pubspec.yaml
+++ b/mobile/flutter/pubspec.yaml
@@ -45,7 +45,6 @@ dependencies:
   animations: ^2.0.8
   flutter_animate: 4.2.0
   sms_autofill: ^2.3.0
-  email_auth: ^1.1.1
   flutter_svg: ^2.0.7
 
 


### PR DESCRIPTION
Removes the `email_auth` package rather than upgrading it (Dependabot #40). Client-side OTP validation is bypassable — the review recommended removal. Dropped the import, the dead `sendOTP`/`verifyOTP` EmailAuth calls in both verify screens (replaced with TODOs pointing to server-side verification), and the pubspec dependency. Closes the need for #40.