### PR TITLE
Align iOS bundle id with Android: io.cuesoft.apparule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   Python 3.12); optional `envFrom` secret hook in the Helm deployment template.
 - Flutter iOS project migrated by current tooling: minimum deployment target
   iOS 13, UIScene lifecycle, Swift Package Manager integration.
+- iOS bundle identifier aligned with Android: `com.example.apparule` →
+  `io.cuesoft.apparule` (`.RunnerTests` suffix included).
 
 ### Removed
 - 4.9MB of unreferenced test images from git; dead Flutter files (empty

--- a/mobile/flutter/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/flutter/ios/Runner.xcodeproj/project.pbxproj
@@ -377,7 +377,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.apparule;
+				PRODUCT_BUNDLE_IDENTIFIER = io.cuesoft.apparule;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -394,7 +394,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.apparule.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = io.cuesoft.apparule.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -412,7 +412,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.apparule.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = io.cuesoft.apparule.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -428,7 +428,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.apparule.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = io.cuesoft.apparule.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -555,7 +555,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.apparule;
+				PRODUCT_BUNDLE_IDENTIFIER = io.cuesoft.apparule;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -577,7 +577,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.apparule;
+				PRODUCT_BUNDLE_IDENTIFIER = io.cuesoft.apparule;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
Moves the iOS app off the `com.example.apparule` placeholder to `io.cuesoft.apparule`, matching Android's `applicationId`. All six `PRODUCT_BUNDLE_IDENTIFIER` entries updated (app + RunnerTests × Debug/Release/Profile); no other references existed (no Firebase plist).

Verified: `flutter build ios --simulator` builds under the new id.

Note: real-device/App Store signing will need a provisioning profile for the new id when that day comes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)