### PR TITLE
dependabot: hold web tooling majors Next.js can't lint with yet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,16 @@ updates:
     groups:
       npm-dependencies:
         patterns: ["*"]
+    ignore:
+      # eslint 10 / typescript 7 crash eslint-config-next's typescript-eslint
+      # toolchain (TypeError reading 'Cjs'); revisit when Next.js supports them.
+      - dependency-name: eslint
+        update-types: ["version-update:semver-major"]
+      - dependency-name: typescript
+        update-types: ["version-update:semver-major"]
+      # @types/node tracks the runtime major (Node 24 in .nvmrc/Dockerfile).
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: pub
     directory: /mobile/flutter


### PR DESCRIPTION
Verified locally on #56: `tsc --noEmit` and `next build` pass, but `eslint` crashes with **`TypeError: Cannot read properties of undefined (reading 'Cjs')`** under eslint 10.7 / typescript 7.0 — the typescript-eslint toolchain bundled by `eslint-config-next` doesn't support those majors yet. `@types/node` should also track the runtime major (Node 24 per `.nvmrc`/Dockerfile), not jump to 26.

Adds dependabot `ignore` rules for those three majors (minors/patches still flow). Revisit when Next.js supports eslint 10 / TS 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)