### PR TITLE
docs: PRD breakdown — product, architecture, data model, API, roadmap

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -101,3 +101,22 @@ server-side by api/common to the same API.
 - Idempotency keys accepted on session creation and instance requests
   (`Idempotency-Key` header) — measurement capture retries must not duplicate
   records on flaky mobile networks.
+
+---
+
+## 5. Social commerce surface (2026-07-16 expansion) **[Proposed]**
+
+All under `/api/v1`, workspace/account auth as §2. Deltas only:
+
+| Group | Endpoints |
+| --- | --- |
+| Posts | `POST /posts` (designer) · `GET /posts/{id}` · `GET /feed` (followed + ranked) · `GET /explore?q&tags&price_band` · `DELETE /posts/{id}` |
+| Social graph | `POST/DELETE /follows/{designer}` · `POST/DELETE /posts/{id}/like` · `POST/DELETE /posts/{id}/save` · `POST /posts/{id}/comments` · `GET /posts/{id}/comments` |
+| Requests | `POST /posts/{id}/requests` (body: vault snapshot selector, notes, budget) · `GET /requests?role=customer\|designer` · `GET /requests/{id}` · `POST /requests/{id}/quote` · `POST /requests/{id}/decline` · `POST /requests/{id}/status` (in_progress/shipped/delivered) · `POST /requests/{id}/messages` |
+| Payments | `POST /requests/{id}/pay` (provider session) · webhook `/webhooks/payments` · `POST /requests/{id}/confirm-delivery` (releases escrow) · `POST /requests/{id}/dispute` |
+| Designer | `POST /designer-profile` (enable + KYC start) · `GET /designer/earnings` · `POST /designer/payout-account` |
+| Notifications | `GET /notifications` · `POST /notifications/read` |
+
+Feed/explore are the only ranked endpoints (recency + follow affinity v1; no
+ML ranking until data exists). Likes/saves/follows are idempotent PUT-style
+toggles with optimistic-client semantics (design.md MI-18).

--- a/docs/api.md
+++ b/docs/api.md
@@ -87,7 +87,7 @@ server-side by api/common to the same API.
 | APP-003 SMPL demo | Nothing SMPL exists | Demo media first; pipeline later (PLAT-005) |
 | APP-004 API reference | FastAPI `/openapi.json` only; Go undocumented | OpenAPI spec for api/common (static YAML or swag), docs-site renderer with search |
 | APP-005 privacy disclosure | None | Web page + privacy.cuesoft.io clause link (D3) |
-| PLAT-001/002 records | Zero persistence | Postgres, repository layer, endpoints above |
+| PLAT-001/002 records | Zero persistence | Firestore data layer (X-5), repository layer, endpoints above |
 | PLAT-003 real auth | Stubs with TODOs | ID-token verification now; account.cuesoft.io when D1 lands |
 | PLAT-004 export | None | Export generation + object storage |
 | PLAT-005 SMPL | MediaPipe 2-D | Staged pipeline (architecture.md §5), licensing decision first |

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,103 @@
+# Apparule — API Surface
+
+> Current surface is verified against code; target surface implements the PRD
+> and the platform requirements (prd.md §3.3). Markers: **[Current]**, **[PRD]**,
+> **[Proposed]**.
+
+## 1. Current surface **[Current]**
+
+### api/common (Go, :8080)
+
+| Method & path | Request | Response | Notes |
+| --- | --- | --- | --- |
+| `GET /health` | — | `200` static | liveness |
+| `GET /ready` | — | `200` static | readiness |
+| `POST /api/auth/google` | `{"id_token": "..."}` | `200 {message, project, token}` | **Stub**: does not verify `id_token`; mints JWT for the service-account email (`TODO(security-prd)`), 500 if no service identity configured |
+| `POST /api/auth/email` | `{"email": "..."}` | `200 {message, email, scope}` | **Stub**: logs and returns; no link/OTP is sent |
+
+JWT: HS256, email subject, 24h expiry (`internal/auth/jwt.go`). No endpoint
+currently *requires* a token — there is nothing to protect yet.
+
+### api/measure (Python, :8081)
+
+| Method & path | Request | Response | Notes |
+| --- | --- | --- | --- |
+| `GET /health` / `GET /ready` | — | `200` | probes |
+| `POST /measure` | multipart: `image` (file), `user_height_cm` (form, default 170) | `MeasurementResponse` | 422 if no body detected or image undecodable |
+
+`MeasurementResponse`: `body_height_px`, `scale_factor`, `shoulder_width_px`,
+`shoulder_width_cm`, `hip_width_px`, `hip_width_cm`.
+
+FastAPI serves `/openapi.json` + `/docs` out of the box — the seed of APP-004.
+
+## 2. Target surface **[Proposed]** — `/api/v1`, all on api/common unless noted
+
+Authentication: bearer token from `account.cuesoft.io` (D1) — or the hardened
+local JWT until D1 lands. All routes below require auth unless marked public.
+Authorization scope: every resource is workspace-scoped; membership checked per
+request.
+
+### Auth & consent
+
+| Method & path | Purpose | Maps to |
+| --- | --- | --- |
+| `POST /api/v1/auth/exchange` | Exchange an `account.cuesoft.io` token for an Apparule session (until/unless the gateway validates directly) | APP-002, D1 |
+| `GET /api/v1/consent` | Current user's accepted document versions | PRD §7 |
+| `POST /api/v1/consent` | Record acceptance `{document, version}` | PRD §7 |
+
+### Customers & measurement records (PLAT-001/002)
+
+| Method & path | Purpose |
+| --- | --- |
+| `GET /api/v1/customers` · `POST /api/v1/customers` | list/create customers in the caller's workspace |
+| `GET /api/v1/customers/{id}` · `PATCH` · `DELETE` | manage one customer (soft delete; purge per retention policy) |
+| `POST /api/v1/customers/{id}/sessions` | create a measurement session: multipart image + `input_height_cm`; api/common stores the asset, calls api/measure internally, persists results |
+| `GET /api/v1/customers/{id}/sessions` | measurement history for a customer |
+| `GET /api/v1/sessions/{id}` | session detail incl. measurements + pipeline metadata |
+| `PATCH /api/v1/sessions/{id}/measurements` | append manual corrections (`source: manual_correction`) |
+| `POST /api/v1/sessions/{id}/exports` | generate `pdf`/`csv` export → signed URL (PLAT-004) |
+
+### Cloud access (APP-002)
+
+| Method & path | Purpose |
+| --- | --- |
+| `POST /api/v1/instance-requests` | request a cloud instance (consent-gated) |
+| `GET /api/v1/instance-requests` | caller's requests + status |
+
+### Events (ECO-ANALYTICS)
+
+Landing-page events ("Demo Starts", "GitHub Clicks") post **directly from the
+web client to Upstat's event API** (D2) — api/common does not proxy marketing
+analytics. Product metrics (sessions created, instance requests) are emitted
+server-side by api/common to the same API.
+
+### api/measure — internal contract evolution
+
+| Change | Why |
+| --- | --- |
+| `POST /measure` gains `method` selection + per-measurement `confidence`, `qc` block in the response (v2 schema, additive) | SMPL pipeline (PLAT-005) returns girths + confidence; 2-D method reports its QC verdicts |
+| Service becomes internal-only in cloud topology (ClusterIP, called by api/common) | api/common is the single writer; self-hosters may still expose it directly |
+
+## 3. Gap analysis — requirement → current → needed
+
+| Requirement | Current state | Gap |
+| --- | --- | --- |
+| APP-001 GitHub gateway | README/CONTRIBUTING exist; no landing page | Landing page links (web work only) |
+| APP-002 cloud access | Auth stubs; no consent, no instance model | D1 contract + consent endpoints + instance-requests + dashboard UI |
+| APP-003 SMPL demo | Nothing SMPL exists | Demo media first; pipeline later (PLAT-005) |
+| APP-004 API reference | FastAPI `/openapi.json` only; Go undocumented | OpenAPI spec for api/common (static YAML or swag), docs-site renderer with search |
+| APP-005 privacy disclosure | None | Web page + privacy.cuesoft.io clause link (D3) |
+| PLAT-001/002 records | Zero persistence | Postgres, repository layer, endpoints above |
+| PLAT-003 real auth | Stubs with TODOs | ID-token verification now; account.cuesoft.io when D1 lands |
+| PLAT-004 export | None | Export generation + object storage |
+| PLAT-005 SMPL | MediaPipe 2-D | Staged pipeline (architecture.md §5), licensing decision first |
+
+## 4. Conventions **[Proposed]**
+
+- Versioned base path `/api/v1`; additive changes only within a version.
+- Errors: `{"error": {"code": "...", "message": "..."}}` with stable codes —
+  the current ad-hoc `{"error": "text"}` shape migrates at v1.
+- All list endpoints paginate (`?cursor=` + `limit`, default 50).
+- Idempotency keys accepted on session creation and instance requests
+  (`Idempotency-Key` header) — measurement capture retries must not duplicate
+  records on flaky mobile networks.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,7 +60,7 @@ flowchart LR
     subgraph Apparule backend
         AC[api/common — Go<br/>records, customers, consent,<br/>instance requests]
         AM[api/measure — Python<br/>measurement pipeline<br/>MediaPipe today → SMPL later]
-        DB[(Postgres<br/>system of record)]
+        DB[(Firestore<br/>system of record — X-5)]
         OBJ[(Object storage<br/>capture images, exports)]
     end
 
@@ -93,11 +93,12 @@ Decisions embedded here (each ratifiable separately, see prd.md §8):
    app calls api/measure directly; that stays acceptable for self-hosted
    stateless use, but cloud record-keeping flows route through api/common.
    **[Proposed]**
-2. **Postgres as system of record**, object storage for images. Firestore
-   remains only if the account integration requires it. **[Proposed]**
-3. **Auth delegation**: `account.cuesoft.io` owns identity **[PRD]**; api/common
-   exchanges/validates its tokens and enforces per-workspace authorization
-   locally (see §4.2).
+2. **Firestore as system of record** (X-5; revised from Postgres), Cloud Storage
+   for capture images and exports. **[Decided]**
+3. **Identity (X-1, hardened)**: in-app **Google-only sign-in over Firebase Auth**
+   (`sandbox-e306a`); api/common verifies Firebase ID tokens and enforces
+   per-workspace authorization locally. The `account.cuesoft.io` facade fronts
+   the same Firebase project later (flows/auth.md).
 
 ## 3. Service breakdown
 
@@ -106,11 +107,11 @@ Decisions embedded here (each ratifiable separately, see prd.md §8):
 | Package | Today **[Current]** | Target additions **[Proposed]** |
 | --- | --- | --- |
 | `internal/config` | env loading | + DB/object-store/account-service settings |
-| `internal/auth` | JWT mint (stub logins) | token verification against `account.cuesoft.io`, workspace membership resolution |
+| `internal/auth` | JWT mint (stub logins) | Firebase ID-token verification (Google-only, X-1), workspace membership resolution |
 | `internal/handler` | `auth.go`, `health.go` | `customer.go`, `measurement.go`, `consent.go`, `instance_request.go`, `export.go` |
 | `internal/server` | routes + graceful shutdown | versioned `/api/v1` group, authn middleware, request scoping |
 | `internal/model` | — | domain structs mirroring data-model.md |
-| `internal/repository` | — | Postgres persistence |
+| `internal/repository` | — | Firestore persistence (Admin SDK) |
 | `internal/service` | — | orchestration: measurement session lifecycle, export generation, upstat event emission |
 
 ### 3.2 api/measure (Python, FastAPI) — measurement pipeline
@@ -152,7 +153,7 @@ architecture:
 /docs                 Developer documentation hub (deploy guides, SMPL notes)
 /docs/api             API reference (APP-004, searchable)
 /privacy              Measurement-data handling disclosure (APP-005)
-/cloud                Cloud access: sign-in via account.cuesoft.io,
+/cloud                Cloud access: Google sign-in (Firebase, X-1),
                       ToS consent gate, instance request (APP-002)
 /dashboard            Post-auth: customers, measurement records (PLAT-001/2)
 ```
@@ -218,7 +219,7 @@ sequenceDiagram
     participant F as Client (Flutter or dashboard)
     participant C as api/common
     participant M as api/measure
-    participant DB as Postgres/object storage
+    participant DB as Firestore/Cloud Storage
 
     T->>F: select customer, start session
     F->>C: POST /api/v1/customers/{id}/sessions (image, height)
@@ -275,8 +276,7 @@ Unchanged by this phase (validated on Docker Compose and a live k8s cluster):
   (probes, numeric runAsUser, optional `envFrom` secret hook).
 - `deploy/terraform`: cluster-agnostic (kubeconfig provider) helm release.
 
-Target-state additions land as: Postgres (external/managed, `MONGO`-style URI
-via values + secret hook), object storage credentials, and eventually a
+Target-state additions land as: Firestore + Cloud Storage (ADC on Cloud Run per X-3/X-5; self-host uses service-account JSON via the secret hook), and eventually a
 GPU-capable node pool for SMPL inference (cloud only). **[Proposed]**
 
 ## 7. Cross-repo dependencies

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,288 @@
+# Apparule — System Architecture
+
+> Companion to [prd.md](prd.md). Describes the system as it **is** (verified
+> against code) and as the PRD requires it to **become**. Markers: **[Current]**,
+> **[PRD]**, **[Proposed]**.
+
+## 1. Context — current state **[Current]**
+
+```mermaid
+flowchart LR
+    subgraph Clients
+        FL[Flutter app<br/>auth UI + measurement capture]
+        WEB[Next.js web<br/>create-next-app stub]
+    end
+
+    subgraph Backend
+        AC[api/common — Go/Gin :8080<br/>auth stubs + health]
+        AM[api/measure — Python/FastAPI :8081<br/>MediaPipe pose measurement]
+    end
+
+    subgraph External
+        GID[Google Identity]
+        FB[(Firebase project<br/>service-account JSON, optional)]
+    end
+
+    FL -->|POST /api/auth/google, /email| AC
+    FL -->|POST /measure image+height| AM
+    AC -.->|reads service account| FB
+    FL -.->|Google sign-in UI| GID
+
+    style WEB stroke-dasharray: 5 5
+```
+
+Key facts the target design must reckon with:
+
+- `POST /measure` is **stateless** — measurements are returned to the caller and
+  stored nowhere server-side. The only persistence in the whole system today is
+  the phone's `SharedPreferences` (name/email/phone + theme).
+- Both auth endpoints are **stubs** (`internal/auth/auth.go`,
+  `TODO(security-prd)`): Google login mints a JWT for the *service-account*
+  email without verifying the incoming ID token; email login logs and returns.
+- The web app is the unmodified create-next-app template.
+- Firestore is initialised from `FIREBASE_CONFIG_PATH` but not used as a data
+  store for any domain object.
+
+## 2. Context — target state **[PRD + Proposed]**
+
+```mermaid
+flowchart LR
+    subgraph Visitors & Users
+        V[Visitor]
+        T[Tailor / SME user]
+    end
+
+    subgraph apparule.cuesoft.io
+        LAND[Landing + docs hub<br/>Next.js, public]
+        DASH[Dashboard<br/>Next.js, authenticated]
+    end
+
+    subgraph Apparule backend
+        AC[api/common — Go<br/>records, customers, consent,<br/>instance requests]
+        AM[api/measure — Python<br/>measurement pipeline<br/>MediaPipe today → SMPL later]
+        DB[(Postgres<br/>system of record)]
+        OBJ[(Object storage<br/>capture images, exports)]
+    end
+
+    subgraph Cuesoft ecosystem — external
+        ACC[account.cuesoft.io<br/>identity & session]
+        UP[Upstat<br/>events & uptime]
+        CL[clients.cuesoft.io<br/>support]
+        PRIV[privacy.cuesoft.io<br/>privacy hub]
+    end
+
+    V --> LAND
+    LAND -->|Demo Starts, GitHub Clicks| UP
+    LAND -->|View on GitHub| GH[GitHub repo]
+    LAND --> PRIV
+    T --> DASH
+    T -->|Flutter app| AC
+    DASH -->|sign in| ACC
+    DASH --> AC
+    AC -->|verify session/token| ACC
+    AC --> DB
+    AC --> OBJ
+    AC -->|internal call| AM
+    DASH -.->|support| CL
+```
+
+Decisions embedded here (each ratifiable separately, see prd.md §8):
+
+1. **api/common is the only writer** — web/mobile clients talk to api/common;
+   api/common calls api/measure internally for pipeline runs. Today the Flutter
+   app calls api/measure directly; that stays acceptable for self-hosted
+   stateless use, but cloud record-keeping flows route through api/common.
+   **[Proposed]**
+2. **Postgres as system of record**, object storage for images. Firestore
+   remains only if the account integration requires it. **[Proposed]**
+3. **Auth delegation**: `account.cuesoft.io` owns identity **[PRD]**; api/common
+   exchanges/validates its tokens and enforces per-workspace authorization
+   locally (see §4.2).
+
+## 3. Service breakdown
+
+### 3.1 api/common (Go, Gin) — core API
+
+| Package | Today **[Current]** | Target additions **[Proposed]** |
+| --- | --- | --- |
+| `internal/config` | env loading | + DB/object-store/account-service settings |
+| `internal/auth` | JWT mint (stub logins) | token verification against `account.cuesoft.io`, workspace membership resolution |
+| `internal/handler` | `auth.go`, `health.go` | `customer.go`, `measurement.go`, `consent.go`, `instance_request.go`, `export.go` |
+| `internal/server` | routes + graceful shutdown | versioned `/api/v1` group, authn middleware, request scoping |
+| `internal/model` | — | domain structs mirroring data-model.md |
+| `internal/repository` | — | Postgres persistence |
+| `internal/service` | — | orchestration: measurement session lifecycle, export generation, upstat event emission |
+
+### 3.2 api/measure (Python, FastAPI) — measurement pipeline
+
+Today **[Current]**: single endpoint `POST /measure` (multipart image +
+`user_height_cm`), MediaPipe `pose_landmarker.task` (IMAGE mode, one pose),
+returns six values: body height (px), scale factor, shoulder width (px, cm),
+hip width (px, cm). Errors: 422 no-body / undecodable image.
+
+Pipeline internals:
+
+```mermaid
+flowchart LR
+    IMG[image bytes] --> DEC[cv2 decode + RGB]
+    DEC --> PL[MediaPipe PoseLandmarker<br/>33 landmarks, 1 pose]
+    PL --> MATH[measurement.py<br/>pixel distances]
+    MATH --> SCALE[scale = user_height_cm / body_height_px]
+    SCALE --> OUT[shoulder_cm, hip_cm, ...]
+```
+
+Known limitations **[Current]** (drive PLAT-005):
+
+- Single frontal 2-D image; widths are projected straight-line distances, not
+  circumferences — a garment needs chest/waist/hip girth, not landmark gaps.
+- Scale depends entirely on user-entered height and full head-to-ankle
+  visibility (nose→ankle proxy actually *underestimates* true height, biasing
+  the scale factor).
+- No pose-quality gating (arms raised, camera tilt, clothing bulk all silently
+  skew results); no confidence output.
+
+### 3.3 web (Next.js) — apparule.cuesoft.io
+
+Today **[Current]**: template stub. Target **[PRD §3]** information
+architecture:
+
+```
+/                     Hero, problem statement, interactive walkthrough,
+                      cloud-vs-open-source comparison, CTAs
+/docs                 Developer documentation hub (deploy guides, SMPL notes)
+/docs/api             API reference (APP-004, searchable)
+/privacy              Measurement-data handling disclosure (APP-005)
+/cloud                Cloud access: sign-in via account.cuesoft.io,
+                      ToS consent gate, instance request (APP-002)
+/dashboard            Post-auth: customers, measurement records (PLAT-001/2)
+```
+
+### 3.4 mobile/flutter — capture client
+
+Today **[Current]**: splash/welcome/home, full auth UI flow (login, signup,
+email/SMS/account verification, forgot/reset password), measurement guide +
+entry screens, local persistence, l10n (en/fr/es), light/dark themes.
+Target: wire auth to the real backend flow and measurement capture to
+session-creation against api/common (roadmap P2) — camera capture → upload →
+review results → save to customer record.
+
+## 4. Core sequences
+
+### 4.1 Measurement flow — current **[Current]**
+
+```mermaid
+sequenceDiagram
+    actor U as User (phone)
+    participant F as Flutter app
+    participant M as api/measure
+
+    U->>F: open measurement, enter height
+    F->>F: guide screen (pose instructions)
+    U->>F: capture/select full-body photo
+    F->>M: POST /measure (image, user_height_cm)
+    M->>M: MediaPipe landmarks → px→cm scaling
+    M-->>F: {shoulder_width_cm, hip_width_cm, ...}
+    F-->>U: display results
+    Note over F,M: nothing persisted anywhere
+```
+
+### 4.2 Cloud sign-in + instance request — target **[PRD APP-002, Proposed shape]**
+
+```mermaid
+sequenceDiagram
+    actor T as Tailor
+    participant W as apparule.cuesoft.io
+    participant A as account.cuesoft.io
+    participant C as api/common
+
+    T->>W: "Try Apparule Cloud"
+    W->>A: redirect to sign-in
+    A-->>W: session/token for T
+    W->>C: GET /api/v1/consent (has T accepted Apparule ToS?)
+    alt no consent on file
+        W-->>T: ToS + data-retention + accuracy disclaimer
+        T->>W: accept
+        W->>C: POST /api/v1/consent (records version + timestamp)
+    end
+    T->>W: request cloud instance
+    W->>C: POST /api/v1/instance-requests
+    C-->>W: 202 queued
+    Note over C: ops provisions via the existing helm chart;<br/>status transitions surface in the dashboard
+```
+
+### 4.3 Measurement record lifecycle — target **[Proposed]**
+
+```mermaid
+sequenceDiagram
+    actor T as Tailor
+    participant F as Client (Flutter or dashboard)
+    participant C as api/common
+    participant M as api/measure
+    participant DB as Postgres/object storage
+
+    T->>F: select customer, start session
+    F->>C: POST /api/v1/customers/{id}/sessions (image, height)
+    C->>DB: store capture image (object storage)
+    C->>M: POST /measure (internal)
+    M-->>C: raw measurements + method metadata
+    C->>DB: MeasurementSession + Measurement rows
+    C-->>F: session with measurements
+    T->>F: adjust/confirm, add manual tape values
+    F->>C: PATCH session (corrections, source=manual)
+    T->>F: export for production
+    F->>C: POST /api/v1/sessions/{id}/exports (pdf|csv)
+    C-->>F: signed download URL
+```
+
+## 5. SMPL pipeline — target measurement engine **[PRD §5, Proposed approach]**
+
+SMPL (Skinned Multi-Person Linear model) is a parametric 3-D body model: body
+shape is expressed as low-dimensional shape coefficients (β) from which a full
+3-D mesh is generated; girths (chest/waist/hip circumference, inseam, etc.) are
+then *measured on the mesh*, which is what garment production actually needs.
+
+Proposed staged integration, keeping the current pipeline as fallback:
+
+```mermaid
+flowchart LR
+    IMG[input image or images] --> QC[pose-quality gate<br/>MediaPipe landmarks]
+    QC -->|reject + reason| ERR[422 with guidance]
+    QC --> FIT[SMPL fitting<br/>shape β + pose θ regression]
+    FIT --> MESH[3-D mesh reconstruction]
+    MESH --> GIRTH[mesh circumference extraction<br/>chest, waist, hip, inseam, ...]
+    GIRTH --> CONF[per-measurement confidence]
+    CONF --> OUT[MeasurementSet v2]
+```
+
+- The existing MediaPipe step is retained as the quality gate and fallback
+  method (`method: mediapipe_2d` vs `smpl_v1` recorded per session —
+  data-model.md).
+- Fitting from a single image is an ML-heavy problem (HMR-family regressors);
+  expect GPU inference for the cloud offering. Self-hosters keep the CPU-only
+  2-D method by default.
+- **Risk R1 — licensing**: SMPL weights are research-licensed; commercial use
+  requires a Meshcapade/MPI license. Resolve before the cloud pipeline ships
+  (prd.md §8.3).
+- APP-003 only requires *demonstrating* the pipeline on the landing page —
+  pre-rendered demo media precedes the production pipeline by design.
+
+## 6. Deployment view **[Current]**
+
+Unchanged by this phase (validated on Docker Compose and a live k8s cluster):
+
+- `docker-compose.yml`: api-common :8080, api-measure :8081, web :3000.
+- `deploy/helm`: one standard-form chart deploying all services
+  (probes, numeric runAsUser, optional `envFrom` secret hook).
+- `deploy/terraform`: cluster-agnostic (kubeconfig provider) helm release.
+
+Target-state additions land as: Postgres (external/managed, `MONGO`-style URI
+via values + secret hook), object storage credentials, and eventually a
+GPU-capable node pool for SMPL inference (cloud only). **[Proposed]**
+
+## 7. Cross-repo dependencies
+
+| Dependency | Needed by | Status |
+| --- | --- | --- |
+| D1 `account.cuesoft.io` contract | APP-002, PLAT-003 | External; not in any repo. Blocks final auth shape; interim hardened local JWT proposed. |
+| D2 Upstat event-ingestion API | ECO-ANALYTICS | Upstat has no generic event endpoint today — tracked in upstat's roadmap (its PRD names it the ecosystem tracking service). |
+| D3 `privacy.cuesoft.io` Apparule clause | APP-005 | Content dependency; page links out. |

--- a/docs/capture-qc.md
+++ b/docs/capture-qc.md
@@ -1,0 +1,79 @@
+# Apparule — Capture QC & Measurement Confidence Contract
+
+> The numeric thresholds behind flows/vault.md's QC gate and the confidence
+> value stored per measurement (data-model.md `MEASUREMENT.confidence`).
+> Grounded in the current MediaPipe pipeline (33 pose landmarks, each with a
+> `visibility` score 0–1). Thresholds are **[Decided defaults]** — tuneable
+> constants in one config block, revisited against the accuracy benchmark
+> (roadmap Phase 5 harness), never scattered magic numbers.
+
+## 1. Image pre-checks (before pose detection)
+
+| Check | Threshold | Fail code |
+| --- | --- | --- |
+| Decodable | cv2 decode succeeds | `undecodable_image` |
+| Resolution | short edge ≥ 480px | `low_resolution` (new code) |
+| Brightness | mean luma in [40, 215] | `poor_lighting` (new code) |
+| Blur | Laplacian variance ≥ 60 | `blurry` (new code) |
+
+## 2. Pose QC (after detection)
+
+Let `vis(i)` = landmark i visibility. Key sets: HEAD = {nose}, SHOULDERS =
+{11,12}, HIPS = {23,24}, ANKLES = {27,28}.
+
+| Check | Rule | Fail code |
+| --- | --- | --- |
+| Body present | detector returns ≥1 pose | `no_body` |
+| Single subject | exactly 1 pose (`num_poses=2` probe run; if 2 detected → fail) | `multiple_bodies` |
+| Full body | min vis over HEAD∪SHOULDERS∪HIPS∪ANKLES ≥ 0.5 | `partial_body` |
+| In-frame margins | all key landmarks within [2%, 98%] of both axes | `partial_body` |
+| Frontality | shoulder-width\_px ÷ hip-width\_px ∈ [0.9, 2.2] AND both shoulders' z within 0.15 of each other | `not_frontal` (new code) |
+| Upright | angle of nose→ankle-midpoint axis within 15° of vertical | `camera_tilt` (new code) |
+| Arms clearance | wrist landmarks ≥ 5% image-width away from hip landmarks horizontally (arms slightly out, not fused to torso) | `arms_position` (new code) |
+| Scale sanity | body_height_px ≥ 40% of image height | `too_far` (new code) |
+
+Each code carries guidance copy (flows/vault.md table extends with the new
+codes). Multiple failures report the **first by the table order above** —
+one actionable instruction beats a list.
+
+## 3. Height-scale plausibility
+
+`scale = user_height_cm / body_height_px` uses the nose→ankle-midpoint
+distance, which is ~93% of true stature (nose≠crown, ankle≠sole). Corrected:
+`scale = (user_height_cm × 0.93) / body_height_px` **[Decided: apply the
+anthropometric correction that the current code omits — flagged as a v-next
+pipeline change since it shifts all outputs ~7%]**. Plausibility band: if the
+implied crown-to-sole pixel height maps outside 0.75–1.33× of the claimed
+height when cross-checked against torso proportions (shoulder-to-hip ÷
+stature expected ≈ 0.25±0.08), flag `pipeline_meta.qc.height_suspect = true`
+(session still saves; UI shows "double-check your height" hint).
+
+## 4. Per-measurement confidence (2-D method)
+
+```
+confidence(m) = clamp01( mean_vis(m) × frontality_factor × sharpness_factor )
+  mean_vis(m)        = mean visibility of the landmarks defining m
+  frontality_factor  = 1.0 if shoulder/hip ratio in [1.2, 1.9]; else 0.85
+  sharpness_factor   = 1.0 if Laplacian var ≥ 120; 0.9 if ≥ 60
+```
+
+Stored per `MEASUREMENT` row; UI renders <0.7 with a "low confidence —
+consider retaking" chip. Manual entries have `confidence = null` (human
+truth isn't scored). SMPL-era confidences (Phase 5) replace this formula
+per-method — the field is method-agnostic by design.
+
+## 5. Config block (single source)
+
+All constants above live in `app/config.py :: QCThresholds` (one dataclass),
+logged (as config, not per-image) at service start, echoed into
+`pipeline_meta.qc.thresholds_version` per session so historical sessions
+remain interpretable after tuning.
+
+## 6. Acceptance
+
+- [ ] Golden image set: ≥1 fixture per fail code + 5 passing fixtures; CI-run
+- [ ] Threshold changes bump `thresholds_version`; old sessions untouched
+- [ ] First-failure-only reporting verified (multi-fault fixture)
+- [ ] Confidence values populate and render; manual rows null
+- [ ] Height correction ships behind `pipeline_meta.method` rev with the
+      benchmark harness comparing before/after against tape measurements

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -144,3 +144,63 @@ Modeling notes:
 Deletion semantics: deleting a `CUSTOMER` soft-deletes then hard-purges
 sessions, measurements, and capture assets on a fixed schedule (columns above);
 Upstat events must only ever carry anonymous counters, never measurement data.
+
+---
+
+## 5. Social commerce entities (2026-07-16 expansion) **[Proposed]**
+
+```mermaid
+erDiagram
+    ACCOUNT ||--o| DESIGNER_PROFILE : "may enable"
+    ACCOUNT ||--o{ FOLLOW : follows
+    DESIGNER_PROFILE ||--o{ POST : publishes
+    POST ||--o{ POST_MEDIA : carries
+    POST ||--o{ LIKE : receives
+    POST ||--o{ SAVE : receives
+    POST ||--o{ COMMENT : receives
+    POST ||--o{ REQUEST : "commissioned via"
+    ACCOUNT ||--o{ REQUEST : places
+    REQUEST ||--|| MEASUREMENT_SNAPSHOT : "carries (immutable)"
+    REQUEST ||--o{ ORDER_EVENT : "timeline"
+    REQUEST ||--o{ THREAD_MESSAGE : discusses
+    REQUEST ||--o| PAYMENT : "paid by"
+    PAYMENT ||--o| PAYOUT : "released as"
+    DESIGNER_PROFILE ||--o{ PAYOUT : earns
+
+    DESIGNER_PROFILE { uuid id PK
+        uuid account_id FK
+        string display_name
+        string bio
+        string payout_account "provider ref, KYC state"
+        bool verified }
+    POST { uuid id PK
+        uuid designer_id FK
+        string caption
+        json style_tags
+        int base_price_cents "nullable = quote on request"
+        int turnaround_days
+        datetime created_at }
+    REQUEST { uuid id PK
+        uuid post_id FK
+        uuid customer_id FK
+        string status "requested|quoted|paid|in_progress|shipped|delivered|declined|disputed|cancelled"
+        int quote_cents
+        datetime due_at }
+    MEASUREMENT_SNAPSHOT { uuid id PK
+        uuid request_id FK
+        json values "frozen copy of vault values + method + measured_at"
+        datetime created_at }
+    PAYMENT { uuid id PK
+        uuid request_id FK
+        string provider "paystack|stripe — to ratify"
+        string state "authorized|held|released|refunded"
+        int amount_cents
+        int platform_fee_cents }
+```
+
+Rules: measurement snapshots are **frozen copies** (vault changes never
+mutate an order); vault data is never public — a snapshot exists only inside
+a request the customer initiated (privacy story for APP-005); social counters
+(likes/saves) are denormalized on POST with periodic reconciliation; payments
+follow escrow: `held` at pay, `released` on delivery confirmation (dispute
+pauses release).

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -128,7 +128,7 @@ Modeling notes:
 
 | Concern | Choice | Rationale |
 | --- | --- | --- |
-| System of record | Postgres (Aiven, already in the declared stack) | Relational integrity across workspace/customer/session; the README's infra line names it. |
+| System of record | **Firestore** (default DB, `sandbox-e306a`) — **[Decided X-5]**, revising the earlier Postgres proposal | Firebase-native stack; real-time listeners for feed/threads/notifications; the relational entities in §2 map to collections with the workspace/customer/session hierarchy as document paths. Payments-ledger Postgres escape hatch per X-5. |
 | Capture images + exports | Object storage (Firebase Storage today, S3-compatible acceptable) | Large binaries out of the DB; signed URLs for downloads. |
 | Cache/queues (later) | Valkey/Redis (declared stack) | Instance-request queue, export jobs — not needed for P0. |
 | Firestore | Only if `account.cuesoft.io` integration demands it | Avoid two systems of record. |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,146 @@
+# Apparule — Data Model
+
+> Companion to [prd.md](prd.md) and [architecture.md](architecture.md).
+> Markers: **[Current]**, **[PRD]**, **[Proposed]**.
+
+## 1. Current state **[Current]**
+
+There is no server-side domain persistence. The complete inventory of data at
+rest today:
+
+| Store | Data | Location |
+| --- | --- | --- |
+| Phone `SharedPreferences` | `name`, `email`, `phone` (from signup), `isDark` theme flag | Flutter `src/services/persistence.dart` |
+| — | Measurement results | **Not stored** — `POST /measure` responses are displayed and discarded |
+| Firebase project | Service-account JSON read at boot for auth stubs | Not used as a datastore |
+
+Transient shapes in flight:
+
+- `MeasurementResponse` (api/measure): `body_height_px`, `scale_factor`,
+  `shoulder_width_px`, `shoulder_width_cm`, `hip_width_px`, `hip_width_cm`.
+- JWT payload (api/common): email subject (currently the service-account email
+  — stub), expiry.
+
+## 2. Target entity model **[Proposed]** (satisfies PLAT-001/002, APP-002, §7 compliance)
+
+```mermaid
+erDiagram
+    ACCOUNT ||--o{ WORKSPACE_MEMBER : "belongs to"
+    WORKSPACE ||--o{ WORKSPACE_MEMBER : has
+    WORKSPACE ||--o{ CUSTOMER : manages
+    WORKSPACE ||--o{ INSTANCE_REQUEST : submits
+    ACCOUNT ||--o{ CONSENT_RECORD : signs
+    CUSTOMER ||--o{ MEASUREMENT_SESSION : "is measured in"
+    MEASUREMENT_SESSION ||--o{ MEASUREMENT : produces
+    MEASUREMENT_SESSION ||--o{ CAPTURE_ASSET : "captured from"
+    MEASUREMENT_SESSION ||--o{ EXPORT : "exported as"
+
+    ACCOUNT {
+        uuid id PK
+        string subject "account.cuesoft.io subject id"
+        string email
+        datetime created_at
+    }
+    WORKSPACE {
+        uuid id PK
+        string name "the SME / tailor shop"
+        string plan "oss | cloud"
+        datetime created_at
+    }
+    WORKSPACE_MEMBER {
+        uuid workspace_id FK
+        uuid account_id FK
+        string role "owner | member"
+    }
+    CUSTOMER {
+        uuid id PK
+        uuid workspace_id FK
+        string display_name
+        string contact "optional email/phone"
+        string notes
+        datetime created_at
+        datetime deleted_at "soft delete"
+    }
+    MEASUREMENT_SESSION {
+        uuid id PK
+        uuid customer_id FK
+        string method "mediapipe_2d | smpl_v1 | manual"
+        float input_height_cm
+        string status "pending | complete | failed"
+        json pipeline_meta "model version, confidence, QC flags"
+        datetime created_at
+    }
+    MEASUREMENT {
+        uuid id PK
+        uuid session_id FK
+        string name "shoulder_width | hip_width | chest_girth | ..."
+        float value_cm
+        string source "pipeline | manual_correction"
+        float confidence "nullable"
+    }
+    CAPTURE_ASSET {
+        uuid id PK
+        uuid session_id FK
+        string object_key "object storage reference"
+        string kind "image"
+        datetime retention_until "deletion deadline"
+    }
+    EXPORT {
+        uuid id PK
+        uuid session_id FK
+        string format "pdf | csv"
+        string object_key
+        datetime created_at
+    }
+    INSTANCE_REQUEST {
+        uuid id PK
+        uuid workspace_id FK
+        string status "queued | provisioning | active | rejected"
+        string notes
+        datetime created_at
+    }
+    CONSENT_RECORD {
+        uuid id PK
+        uuid account_id FK
+        string document "tos | privacy"
+        string version
+        datetime accepted_at
+    }
+```
+
+Modeling notes:
+
+- **Measurement names are an open vocabulary** (a `name` string + registry
+  table later, not an enum): the 2-D method produces `shoulder_width`/`hip_width`;
+  SMPL adds girths; tailors add manual tape values. Each row carries its
+  `source` so pipeline output and human corrections coexist per session
+  (sequence 4.3 in architecture.md).
+- **Sessions are immutable captures; corrections append** — an audit-friendly
+  history rather than destructive edits, given production garments hang off
+  these numbers.
+- **`CONSENT_RECORD` is deliberately account-scoped, not workspace-scoped** —
+  the PRD's ToS gate (§7) binds the person accepting.
+- **`CAPTURE_ASSET.retention_until`** operationalizes the retention disclosure:
+  source images are the most sensitive artifact and get the shortest default
+  retention (e.g. 30 days **[Proposed]**), while derived measurements persist.
+
+## 3. Storage mapping **[Proposed]**
+
+| Concern | Choice | Rationale |
+| --- | --- | --- |
+| System of record | Postgres (Aiven, already in the declared stack) | Relational integrity across workspace/customer/session; the README's infra line names it. |
+| Capture images + exports | Object storage (Firebase Storage today, S3-compatible acceptable) | Large binaries out of the DB; signed URLs for downloads. |
+| Cache/queues (later) | Valkey/Redis (declared stack) | Instance-request queue, export jobs — not needed for P0. |
+| Firestore | Only if `account.cuesoft.io` integration demands it | Avoid two systems of record. |
+
+## 4. Data classification & handling **[PRD §7]**
+
+| Class | Data | Rules |
+| --- | --- | --- |
+| High-sensitivity | Capture images, measurements, customer identity | Encrypted at rest; never logged (no image bytes, no measurement values in logs); shortest retention for images; deletion honours `retention_until`; export/delete rights surfaced in dashboard. |
+| Sensitive | Account email, consent records | Standard PII handling; consent rows immutable. |
+| Operational | Session status, pipeline metadata, event counters | No special handling; safe for logs/metrics. |
+
+Deletion semantics: deleting a `CUSTOMER` soft-deletes then hard-purges
+sessions, measurements, and capture assets on a fixed schedule (columns above);
+Upstat events must only ever carry anonymous counters, never measurement data.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -99,3 +99,9 @@ before public launch. Alternative: commission the brand pass first.
 - **X-2 Docs platform**: GitBook org with **one space per product**,
   Git-synced from each repo's `docs/`; API refs rendered by **Scalar** from
   OpenAPI, embedded in each docs space. ☑
+- **X-3 Cloud deployment target (RATIFIED, directive)**: all backend
+  services run on **Google Cloud Run** (per-service containers — the same
+  `cuesoft/<repo>-<service>` images), following the cueprise pattern
+  (IaC precedent in `cuesoft-iac`); frontends deploy to **Firebase App
+  Hosting**. Helm + terraform in `deploy/` remain the **self-host** path —
+  cloud and self-host share images, not manifests. ☑

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -46,6 +46,10 @@ Custom KYC only if the provider's proves insufficient.
 
 ## A-4 · System of record — gates Phase 2 (Vault)
 
+> **REVISED by X-5 (2026-07-16): Firestore**, not Postgres — see the
+> cross-cutting section. The original recommendation below is kept for the
+> audit trail.
+
 **Recommendation ⭐: Postgres** (Aiven, already in the declared stack) for all
 domain entities; object storage for capture media; Firestore not used as a
 datastore (auth-only artifacts until D1). Mongo not introduced here — the
@@ -120,3 +124,19 @@ before public launch. Alternative: commission the brand pass first.
   consumer-API keys to third-party AI vendors in cloud deployments — data
   stays inside GCP, which strengthens every privacy disclosure. Self-host
   fallback: bring-your-own Gemini/Groq key via env (existing code path). ☑
+- **X-5 Data plane (RATIFIED 2026-07-16, per-product DB decided by delegation)**:
+  **Firestore** (default database, project `sandbox-e306a`) as the system of
+  record — **revises A-4 (Postgres)**: Firebase-native stack + real-time
+  listeners/offline sync are decisive for a social mobile app (feed, order
+  threads, notifications without websocket infra). Escape hatch: the payments
+  ledger alone may carve out to Aiven Postgres if Firestore transaction
+  guarantees ever pinch. Media stays on Firebase Storage.
+  **Shared Redis**: the sandbox **Aiven Redis** instance, tenancy by
+  **`REDIS_DB` index** (the irealty pattern: discrete `REDIS_HOST/PORT/
+  USERNAME/PASSWORD/TLS/DB` vars; e.g. irealty prd=0, stg/dev=1) — indices
+  per product/config assigned in Doppler by the owner. **Doppler is the env
+  source of truth**: project `apparule` with `dev / dev_personal / stg / prd`
+  configs (already created). **Object storage**: the **default Cloud Storage bucket** in
+  `sandbox-e306a` (per-product prefixes `apparule/<env>/…`) for capture
+  media, exports, and artifacts. Self-host compose keeps its bundled
+  stores. ☑

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -91,8 +91,11 @@ before public launch. Alternative: commission the brand pass first.
 - **X-1 account.cuesoft.io / identity (RATIFIED)**: interim + sandbox identity
   is **Firebase Authentication on GCP project `sandbox-e306a`** ("sandbox") —
   Google sign-in + email flows come from Firebase; services verify Firebase ID
-  tokens (OIDC-compatible). The `account.cuesoft.io` facade fronts this later
-  without contract changes. Environment/secrets live in **Doppler**
+  tokens (OIDC-compatible). `account.cuesoft.io` **is not built yet** — each app replicates the
+  sign-in/sign-up screens **in-app** (own UI per its design system,
+  Firebase Auth underneath: Google sign-in + email/password flows). The
+  central facade fronts the same Firebase project later without contract
+  changes; in-app screens then become optional, not obsolete. Environment/secrets live in **Doppler**
   (`cueprise/cuesoft_stg`; see also the `cuesoft-iac` project) — CLI token
   currently expired (`doppler login` to refresh); config names to be mirrored
   into docs once readable. ☑

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,92 @@
+# Apparule — Decision Sheet
+
+> Every open decision gating the build, in one place. Ratify by checking a
+> box (or telling the docs owner); each ratified decision flips its
+> **[Proposed]** tags across the doc set to **[Decided]** and unblocks the
+> listed phases. Status: ☐ open · ☑ ratified.
+
+## A-1 · Payment provider & escrow model — gates Phase 4 (Commerce)
+
+**Question:** who moves the money, and how is "designers get paid" structured?
+
+| Option | For | Against |
+| --- | --- | --- |
+| **(a) Paystack primary (NG rails) + Stripe later for international** ⭐ | Strong NG card/bank/transfer coverage; Stripe-owned (stability); subaccounts + Transfers API fit the payout flow; local currency settlement | True escrow isn't a Paystack product — we implement it as a **platform ledger**: charge to platform account at `paid`, payout via transfer at `delivered` |
+| (b) Flutterwave | Broader multi-Africa coverage | Weaker fit if NG-first; same ledger requirement |
+| (c) Stripe only | One provider globally | NG acquiring/settlement is the weak spot for the core market |
+
+**Also ratify with it:** platform fee (recommend **10%** of quote, fee on
+designer side, revisit at scale) · payout timing (**on delivery confirmation**,
+no instant-payout v1) · refunds from platform ledger.
+
+☐ Ratified: option ___ · fee ___%
+
+## A-2 · Designer KYC — gates Phase 4
+
+**Recommendation ⭐:** use the provider's KYC (Paystack subaccount/transfer
+recipient verification: BVN/bank resolution) rather than building our own.
+Gate: KYC must be complete **before** a designer's posts can accept requests.
+Custom KYC only if the provider's proves insufficient.
+
+☐ Ratified
+
+## A-3 · SMPL licensing (R1) — gates Phase 5 for cloud
+
+| Option | For | Against |
+| --- | --- | --- |
+| (a) Meshcapade/MPI commercial license now | Unblocks the real pipeline | Cost unknown; procurement before product proof |
+| **(b) Launch phases 0–4 on the existing MediaPipe 2-D method; pursue a licensing quote in parallel; SMPL demo media clearly labeled "preview"** ⭐ | Nothing else waits on this; commerce works with 2-D + manual tape values; decision made with revenue data | Girth measurements arrive later |
+| (c) Open-model alternatives | No license fee | Most credible body models trace back to MPI licensing anyway; research risk |
+
+☐ Ratified: option ___
+
+## A-4 · System of record — gates Phase 2 (Vault)
+
+**Recommendation ⭐: Postgres** (Aiven, already in the declared stack) for all
+domain entities; object storage for capture media; Firestore not used as a
+datastore (auth-only artifacts until D1). Mongo not introduced here — the
+relational integrity of workspace→customer→session→snapshot is the point.
+
+☐ Ratified
+
+## A-5 · Cloud instance model — gates Phase 1 (APP-002)
+
+**Recommendation ⭐:** v1 = **request queue + manual provisioning** (helm chart
+per instance, ops-driven), status surfaced in dashboard. Multi-tenant SaaS is
+a later re-architecture decision made with real demand data.
+
+☐ Ratified
+
+## A-6 · Trust & safety baseline — ships WITH Phase 3 (Social)
+
+**Recommendation ⭐:** report post/user, block user, designer-verification
+badge, and a minimal admin moderation queue (hide post, suspend account) are
+**launch-blocking for the social phase** — UGC without them doesn't go public.
+Automated media moderation deferred.
+
+☐ Ratified
+
+## A-7 · Commerce timing defaults
+
+**Recommendation ⭐:** quote expiry **7 days** · auto-confirm delivery
+**T+14 days** (2 reminders) · dispute window closes at delivery confirmation ·
+order threads close 30 days after terminal state. (order-lifecycle.md)
+
+☐ Ratified (or adjust: ___)
+
+## A-8 · Brand accent
+
+**Recommendation ⭐:** keep the adapted Instagram gradient (#E1306C→#F77737,
+now in `apparule/tokens`) as the working accent; schedule a proper brand pass
+before public launch. Alternative: commission the brand pass first.
+
+☐ Ratified
+
+## Cross-cutting (shared with expendit/upstat)
+
+- **X-1 account.cuesoft.io**: recommend **OIDC** as the target contract;
+  until it exists, hardened local JWT (Phase 1) with the documented
+  link-on-first-login migration. ☐
+- **X-2 Docs platform**: GitBook org with **one space per product**,
+  Git-synced from each repo's `docs/`; API refs rendered by **Scalar** from
+  OpenAPI, embedded in each docs space. ☐

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -95,7 +95,12 @@ before public launch. Alternative: commission the brand pass first.
   sign-in/sign-up screens **in-app** (own UI per its design system,
   Firebase Auth underneath: Google sign-in + email/password flows). The
   central facade fronts the same Firebase project later without contract
-  changes; in-app screens then become optional, not obsolete. Environment/secrets live in **Doppler**
+  changes; in-app screens then become optional, not obsolete. **HARDENED
+  2026-07-16: Google sign-in is the ONLY method — no username/password
+  signup or login, product-wide.** Email/Password provider disabled at
+  the Firebase project; backends reject non-Google-provider tokens
+  (`provider-not-allowed`); UI ships exactly one auth CTA. Full contract:
+  [flows/auth.md](flows/auth.md). Environment/secrets live in **Doppler**
   (`cueprise/cuesoft_stg`; see also the `cuesoft-iac` project) — CLI token
   currently expired (`doppler login` to refresh); config names to be mirrored
   into docs once readable. ☑

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -140,3 +140,11 @@ before public launch. Alternative: commission the brand pass first.
   `sandbox-e306a` (per-product prefixes `apparule/<env>/…`) for capture
   media, exports, and artifacts. Self-host compose keeps its bundled
   stores. ☑
+- **X-6 Environments & deploy gating (RATIFIED 2026-07-16, deliberate
+  deviation from the cueprise norm)**: `stg` = **sandbox** and is the ONLY
+  environment — no production deployment exists for these products. Secrets
+  live in Doppler `<project>/stg`. Because these repos are **open source**,
+  merge-to-main must NOT deploy: main-merge runs build+test only. **Deploys
+  happen exclusively on tag creation (`v*`)**, treated as production-grade:
+  a GitHub tag ruleset restricts `v*` creation to owner-level access, and the
+  deploy workflow additionally runs in a protected GitHub environment. ☑

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -113,3 +113,10 @@ before public launch. Alternative: commission the brand pass first.
   (IaC precedent in `cuesoft-iac`); frontends deploy to **Firebase App
   Hosting**. Helm + terraform in `deploy/` remain the **self-host** path —
   cloud and self-host share images, not manifests. ☑
+- **X-4 AI platform (RATIFIED, directive 2026-07-16)**: AI features use
+  **Vertex AI** (Gemini via `{region}-aiplatform.googleapis.com`, ADC from the
+  service account — the `cuesoft-iac/functions/cueprise-gemini-proxy` pattern;
+  reference model `gemini-2.5-flash-lite`, region `us-central1`). No
+  consumer-API keys to third-party AI vendors in cloud deployments — data
+  stays inside GCP, which strengthens every privacy disclosure. Self-host
+  fallback: bring-your-own Gemini/Groq key via env (existing code path). ☑

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -5,6 +5,10 @@
 > **[Proposed]** tags across the doc set to **[Decided]** and unblocks the
 > listed phases. Status: ☐ open · ☑ ratified.
 
+> **RATIFIED 2026-07-16** — all recommendations approved wholesale ("decisions
+> look solid"). Where other docs still carry **[Proposed]** on these topics,
+> this sheet governs; tags flip to **[Decided]** as docs are next touched.
+
 ## A-1 · Payment provider & escrow model — gates Phase 4 (Commerce)
 
 **Question:** who moves the money, and how is "designers get paid" structured?
@@ -19,7 +23,7 @@
 designer side, revisit at scale) · payout timing (**on delivery confirmation**,
 no instant-payout v1) · refunds from platform ledger.
 
-☐ Ratified: option ___ · fee ___%
+☑ Ratified: option (a) Paystack + platform ledger · fee 10%
 
 ## A-2 · Designer KYC — gates Phase 4
 
@@ -28,7 +32,7 @@ recipient verification: BVN/bank resolution) rather than building our own.
 Gate: KYC must be complete **before** a designer's posts can accept requests.
 Custom KYC only if the provider's proves insufficient.
 
-☐ Ratified
+☑ Ratified
 
 ## A-3 · SMPL licensing (R1) — gates Phase 5 for cloud
 
@@ -38,7 +42,7 @@ Custom KYC only if the provider's proves insufficient.
 | **(b) Launch phases 0–4 on the existing MediaPipe 2-D method; pursue a licensing quote in parallel; SMPL demo media clearly labeled "preview"** ⭐ | Nothing else waits on this; commerce works with 2-D + manual tape values; decision made with revenue data | Girth measurements arrive later |
 | (c) Open-model alternatives | No license fee | Most credible body models trace back to MPI licensing anyway; research risk |
 
-☐ Ratified: option ___
+☑ Ratified: option (b) launch on 2-D, licensing quote in parallel
 
 ## A-4 · System of record — gates Phase 2 (Vault)
 
@@ -47,7 +51,7 @@ domain entities; object storage for capture media; Firestore not used as a
 datastore (auth-only artifacts until D1). Mongo not introduced here — the
 relational integrity of workspace→customer→session→snapshot is the point.
 
-☐ Ratified
+☑ Ratified
 
 ## A-5 · Cloud instance model — gates Phase 1 (APP-002)
 
@@ -55,7 +59,7 @@ relational integrity of workspace→customer→session→snapshot is the point.
 per instance, ops-driven), status surfaced in dashboard. Multi-tenant SaaS is
 a later re-architecture decision made with real demand data.
 
-☐ Ratified
+☑ Ratified
 
 ## A-6 · Trust & safety baseline — ships WITH Phase 3 (Social)
 
@@ -64,7 +68,7 @@ badge, and a minimal admin moderation queue (hide post, suspend account) are
 **launch-blocking for the social phase** — UGC without them doesn't go public.
 Automated media moderation deferred.
 
-☐ Ratified
+☑ Ratified
 
 ## A-7 · Commerce timing defaults
 
@@ -72,7 +76,7 @@ Automated media moderation deferred.
 **T+14 days** (2 reminders) · dispute window closes at delivery confirmation ·
 order threads close 30 days after terminal state. (order-lifecycle.md)
 
-☐ Ratified (or adjust: ___)
+☑ Ratified as recommended
 
 ## A-8 · Brand accent
 
@@ -80,13 +84,18 @@ order threads close 30 days after terminal state. (order-lifecycle.md)
 now in `apparule/tokens`) as the working accent; schedule a proper brand pass
 before public launch. Alternative: commission the brand pass first.
 
-☐ Ratified
+☑ Ratified
 
 ## Cross-cutting (shared with expendit/upstat)
 
-- **X-1 account.cuesoft.io**: recommend **OIDC** as the target contract;
-  until it exists, hardened local JWT (Phase 1) with the documented
-  link-on-first-login migration. ☐
+- **X-1 account.cuesoft.io / identity (RATIFIED)**: interim + sandbox identity
+  is **Firebase Authentication on GCP project `sandbox-e306a`** ("sandbox") —
+  Google sign-in + email flows come from Firebase; services verify Firebase ID
+  tokens (OIDC-compatible). The `account.cuesoft.io` facade fronts this later
+  without contract changes. Environment/secrets live in **Doppler**
+  (`cueprise/cuesoft_stg`; see also the `cuesoft-iac` project) — CLI token
+  currently expired (`doppler login` to refresh); config names to be mirrored
+  into docs once readable. ☑
 - **X-2 Docs platform**: GitBook org with **one space per product**,
   Git-synced from each repo's `docs/`; API refs rendered by **Scalar** from
-  OpenAPI, embedded in each docs space. ☐
+  OpenAPI, embedded in each docs space. ☑

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -31,9 +31,14 @@
 
 | Workflow | Trigger | Does |
 | --- | --- | --- |
-| `build-and-test.yml` | PRs | build + tests per service |
-| `build-push-and-release-staging.yml` | push to `main` | matrix over services: buildx (GHA cache) → push `cuesoft/apparule-<service>` (tags: `latest` + `sha`) → Cloud Run deploy **by image digest** via WIF |
-| `build-push-and-release-production.yml` | GitHub Release | same, pinned to the release commit; frontend rollout via `firebase-tools apphosting:rollouts:create --git-commit` |
+| `build-and-test.yml` | PRs **and** push to `main` | build + tests per service — **no deploy, no image push** (X-6: open-source repos; merges must be inert) |
+| `release.yml` | **tag `v*` created** | matrix over services: buildx (GHA cache) → push `cuesoft/apparule-<service>` (tags: `latest`, `sha`, version) → Cloud Run deploy **by image digest** via WIF → App Hosting rollout pinned to the tag commit |
+
+**Gating (X-6):** `stg` (sandbox) is the only environment and is treated as
+production. Two independent gates: (1) a GitHub **tag ruleset** restricts
+creating `v*` tags to owner-level access; (2) the deploy job runs in a
+protected GitHub **environment** (`Sandbox`) with required reviewers. A merged
+PR never reaches the sandbox on its own.
 
 Two hard-won rules inherited from cueprise, non-negotiable:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,54 @@
+# Deployment — Cloud Contract
+
+> Implements decision X-3. Cloud deploys follow the proven cueprise/getpp
+> patterns (workflows verified 2026-07-16); provisioning goes through the
+> **cuesoft-iac** Pulumi ecosystem — never ad-hoc gcloud. Self-hosting via
+> `deploy/` (compose/helm/terraform) is unchanged and shares only images.
+
+## 1. Topology
+
+| Surface | Runs on | Provisioned by |
+| --- | --- | --- |
+| `api/common` (Go) | Cloud Run | cuesoft-iac stack `apparule` |
+| `api/measure` (Python) | Cloud Run | cuesoft-iac stack `apparule` |
+| `web` (Next.js) | **Firebase App Hosting** | App Hosting backend (project per X-1 sandbox → prod project later) |
+| `mobile/flutter` | App/Play stores | out of band |
+
+## 2. Provisioning (cuesoft-iac)
+
+- **Pulumi, bun runtime**; state in `gs://cuesoft-iac-pulumi-state-bucket`;
+  per-product stack (`Pulumi.<product>.yaml`) added alongside existing ones
+  (getpp, swaves, …).
+- Cloud Run services instantiate the shared module
+  `common/modules/gcp/cloud-run-service.ts`; the GitHub→GCP deploy identity
+  uses **Workload Identity Federation** (`common/helpers/wif.ts`) — no
+  service-account keys in GitHub.
+- Secrets/env flow from **Doppler** (`cueprise/cuesoft_stg` pattern) into
+  Cloud Run env; the repo's `.env.example` files document the variable
+  names, Doppler owns values.
+
+## 3. CI/CD (GitHub Actions, cueprise/getpp pattern)
+
+| Workflow | Trigger | Does |
+| --- | --- | --- |
+| `build-and-test.yml` | PRs | build + tests per service |
+| `build-push-and-release-staging.yml` | push to `main` | matrix over services: buildx (GHA cache) → push `cuesoft/apparule-<service>` (tags: `latest` + `sha`) → Cloud Run deploy **by image digest** via WIF |
+| `build-push-and-release-production.yml` | GitHub Release | same, pinned to the release commit; frontend rollout via `firebase-tools apphosting:rollouts:create --git-commit` |
+
+Two hard-won rules inherited from cueprise, non-negotiable:
+
+1. **Deploy by digest, never by tag** — Cloud Run pulls Docker Hub images
+   through the `mirror.gcr.io` cache, which has served stale manifests for
+   tags; the staging workflow threads `steps.build.outputs.digest` into the
+   deploy step.
+2. **WIF only** (`google-github-actions/auth@v3` with
+   `workload_identity_provider` + `service_account`) — no JSON keys.
+
+GitHub environments (`Staging <Project>`, `Production`) gate the deploy
+jobs and carry the URLs.
+
+## 4. Not in this phase
+
+Writing these workflows + the Pulumi stack is **implementation work**, out of
+scope for the docs phase — this document is the contract they'll be built
+against. Docker Hub repos already exist for every image name above.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,128 @@
+# Apparule — Design Language
+
+> Reference feel: **instagram.com** — Apparule is a social network where users
+> capture/manage their measurements and designers post outfits; users like,
+> save, share, and commission outfits with their measurements attached, and
+> designers get paid. This document defines the visual system and the
+> microinteraction vocabulary that every page/screen in [pages.md](pages.md)
+> draws from. Markers: **[Directive]** = user-stated direction (2026-07-16),
+> **[Proposed]** = ratifiable design decision.
+
+## 1. Design principles
+
+1. **Content is the chrome** — outfit imagery dominates; UI recedes to thin
+   bars and overlays (Instagram's core trick). No decorated containers around
+   media.
+2. **One-thumb first** — every core action (like, save, request) reachable in
+   the bottom half of a phone screen; desktop dashboard is an adaptation, not
+   the origin.
+3. **Measurement data feels personal, not clinical** — the vault is styled
+   like a profile feature (cards, avatars, history), not a spreadsheet.
+4. **Commerce with social manners** — requests/payments use the same visual
+   language as the feed (cards, threads), never a bolted-on checkout look.
+
+## 2. Foundations
+
+### Color **[Proposed]**
+
+| Token | Light | Dark | Use |
+| --- | --- | --- | --- |
+| `bg` | #FFFFFF | #000000 | app background (true black dark mode, IG-style) |
+| `bg-elev` | #FFFFFF | #121212 | sheets, cards, modals |
+| `border` | #DBDBDB | #262626 | hairline dividers (1px) |
+| `text` | #111111 | #FAFAFA | primary text |
+| `text-2` | #737373 | #A8A8A8 | secondary/meta |
+| `accent` | #E1306C→#F77737 gradient | same | the "Apparule gradient" — story rings, primary CTAs, active states (IG gradient adapted; final hues from brand pass) |
+| `link` | #00376B | #E0F1FF | usernames, links |
+| `like` | #ED4956 | #ED4956 | heart active |
+| `success/warn/error` | #2E7D32 / #B26A00 / #C62828 | brightened equivalents | order states, payment states |
+| Afrocentric pattern | 4–6% opacity geometric line pattern | — | section backgrounds on home page + empty states only (PRD §2 nuance without noise) |
+
+### Type
+
+- Family: system stack (`-apple-system, Roboto, …`) on app surfaces; a display
+  serif/geometric (brand pass) only on the public home page hero. **[Proposed]**
+- Scale: 12 / 13 / 14 (base) / 16 / 20 / 24 / 32. Weights 400/600/700.
+  Usernames 600; numerals tabular for measurements and money.
+
+### Layout
+
+- Mobile: single column, media full-bleed; bottom tab bar (5 slots); safe-area
+  aware.
+- Desktop dashboard: IG-desktop pattern — slim left icon rail (72px, expands
+  to 244px on ≥1264px) + centered content column (max 630px feed / 935px
+  profile) + right meta column where useful.
+- Media ratios: 1:1 default, 4:5 portrait max in feed (IG rules); carousels up
+  to 10 images.
+- Radii: 8px cards/sheets, full-round avatars/pills. Hairline borders over
+  shadows; shadows only on floating layers (sheets, popovers).
+
+### Iconography & imagery
+
+- 24px stroke icons (outline default, filled = active state — IG convention).
+- Avatars: 32 (lists) / 44 (bars) / 56 (story ring context) / 96+ (profiles).
+- Story-ring gradient reserved for: designers with new outfits, and the
+  user's own "measurement freshness" ring (see §4.6). **[Proposed]**
+
+## 3. Component inventory (shared)
+
+| Component | Anatomy | Notes |
+| --- | --- | --- |
+| `PostCard` | header (avatar, username, badge, ⋯) · media carousel · action row (♥ 💬 ↗ ⌁save) · like count · caption (2-line clamp, "more") · request CTA · timestamp | The request CTA ("Request this outfit") is Apparule's one addition to the IG anatomy — a full-width quiet button under the action row on designer posts |
+| `StoryRail` | horizontal scroll of gradient-ringed avatars | reused as "fresh outfits" rail |
+| `RequestCard` | outfit thumb · status pill · designer/customer · price · next-action button | states in §4.4 |
+| `MeasurementCard` | metric name · value + unit (tabular) · source chip (scan/manual) · sparkline of history | tap → history sheet |
+| `Sheet` | bottom sheet mobile / centered modal desktop | all secondary flows live in sheets |
+| `TabBar` | Home · Explore · ➕ Create · Orders · Profile | Create is a raised gradient FAB-in-bar |
+| `Toast` | icon + text, bottom, auto-dismiss 3s | optimistic-action failures re-toast with Retry |
+| `EmptyState` | pattern-bg illustration + one-line + one CTA | every list defines one |
+| `Skeleton` | shimmer blocks matching final layout | feed: header line + square + action row |
+
+## 4. Microinteraction catalog
+
+Numbered so pages.md can reference them as `MI-n`.
+
+| ID | Interaction | Spec |
+| --- | --- | --- |
+| MI-1 | **Double-tap to like** | double-tap media → 96px heart scales 0→1.2→1 with 8° tilt, fades 300ms; action-row heart fills simultaneously; count ticks +1 with 120ms slide-up; haptic light (mobile). Optimistic; rollback re-empties heart + error toast |
+| MI-2 | **Like button** | tap: scale 1→0.8→1.15→1 (240ms spring), outline→filled `like` red; unlike: no animation (IG asymmetry) |
+| MI-3 | **Save/bookmark** | icon dips -4px then fills; first-ever save shows "Saved to your looks" toast with link |
+| MI-4 | **Carousel** | horizontal snap, 1px progress dots (active dot 6px, gradient); desktop: hover chevrons; edge-resist bounce at ends |
+| MI-5 | **Pull-to-refresh** | gradient spinner grows with pull distance (threshold 72px), haptic on trigger |
+| MI-6 | **Infinite scroll** | prefetch at 3 cards from end; skeleton x2 during fetch; "You're all caught up ✓" divider after 48h-old content (IG pattern) |
+| MI-7 | **Follow button** | "Follow" gradient-filled → on tap morphs 150ms to quiet "Following"; unfollow via confirm sheet (prevents accidental) |
+| MI-8 | **Story ring** | 2px gradient ring; consumed → 1px `border` gray; subtle 1.5s rotation on ring while loading content |
+| MI-9 | **Share** | native share sheet (mobile) / copy-link popover (desktop); post flashes 1px gradient border 400ms on copy |
+| MI-10 | **Request stepper** | 3-step sheet (Measurements → Notes/Budget → Review); progress bar fills with 300ms ease; step transitions slide 24px; final CTA shows inline spinner then ✓ morph + confetti burst ≤ 800ms (once per order) |
+| MI-11 | **Measurement freshness ring** | profile avatar ring: gradient if measured <30d, amber 30–90d, gray >90d; tooltip "Measured 12 days ago — retake?" |
+| MI-12 | **Capture flow** | camera overlay silhouette guide pulses gently; countdown 3-2-1 rings; processing state: landmark constellation animates over photo (the "AI is working" moment — also the SMPL demo asset); results cards stagger-in 60ms apart |
+| MI-13 | **Manual measure input** | tape-measure themed slider + numeric field; value change animates sparkline preview; unit toggle cm/in flips with 3D x-rotation 200ms |
+| MI-14 | **Order status pill** | status changes pulse once (scale 1→1.06→1) + color crossfade; timeline dot draws its connector line 400ms |
+| MI-15 | **Payment states** | pay button → inline spinner → shield-check morph; escrow explainer expands beneath on first payment |
+| MI-16 | **Badge counts** | Orders tab badge increments with springy scale; clears on tab visit |
+| MI-17 | **Typing/response** | request thread shows designer "responding…" three-dot pulse |
+| MI-18 | **Optimistic everywhere** | likes, saves, follows, comments post instantly; server failures roll back with toast — never blocking spinners on social actions |
+| MI-19 | **Skeleton shimmer** | 1.2s linear shimmer, 8% white overlay; never longer than 3 cycles before error state |
+| MI-20 | **Haptics (mobile)** | light: like/save; medium: request submitted, payment success; error buzz: capture failed |
+
+## 5. Accessibility & motion rules
+
+- All MI animations respect `prefers-reduced-motion` (fall back to opacity
+  crossfades ≤150ms).
+- Hit targets ≥44px; action row icons 24px with 12px padding.
+- Like/save state changes announced via aria-live polite ("Liked. 214 likes").
+- Contrast: `text-2` on `bg` ≥ 4.5:1 both themes; gradient CTAs carry #fff
+  text with 4.5:1 minimum against mid-gradient.
+- Media requires alt text at post creation (designer prompt, skippable with
+  default "Outfit by {designer}").
+
+## 6. Platform parity map
+
+| Surface | Now | Target |
+| --- | --- | --- |
+| Home (public) | template stub | §pages.md Part A |
+| Dashboard (web app) | — | §pages.md Part B — same IA as mobile, desktop-adapted |
+| Mobile (Flutter) | auth + capture screens | §pages.md Part C — the primary social surface |
+
+Component naming is shared across web/Flutter (PostCard ⇄ `post_card.dart`)
+so design tokens and specs translate 1:1. **[Proposed]**

--- a/docs/design.md
+++ b/docs/design.md
@@ -130,8 +130,7 @@ so design tokens and specs translate 1:1. **[Proposed]**
 ## 7. Figma Style Guide (source of truth for tokens)
 
 The design system lives in the product's Figma file on a dedicated **Style
-Guide** page, backed by a variable collection **`apparule/tokens`** with
-**Light** and **Dark** modes. Every color token in §2 exists as a Figma
+Guide** page, backed by a variable collection **`apparule/tokens`**. The file's plan allows a single variable mode, so themes are expressed as **`light/` and `dark/` variable groups** (same token names in each) rather than modes — migrate to true modes if the plan changes. Every color token in §2 exists as a Figma
 variable (scopes: frame/shape/text fills + strokes) so designs bind to tokens,
 never raw hexes; the Style Guide page renders swatches (both modes), the type
 scale, and status/accent samples. Token changes happen in Figma first, then

--- a/docs/design.md
+++ b/docs/design.md
@@ -126,3 +126,14 @@ Numbered so pages.md can reference them as `MI-n`.
 
 Component naming is shared across web/Flutter (PostCard ⇄ `post_card.dart`)
 so design tokens and specs translate 1:1. **[Proposed]**
+
+## 7. Figma Style Guide (source of truth for tokens)
+
+The design system lives in the product's Figma file on a dedicated **Style
+Guide** page, backed by a variable collection **`apparule/tokens`** with
+**Light** and **Dark** modes. Every color token in §2 exists as a Figma
+variable (scopes: frame/shape/text fills + strokes) so designs bind to tokens,
+never raw hexes; the Style Guide page renders swatches (both modes), the type
+scale, and status/accent samples. Token changes happen in Figma first, then
+sync back into this document — the two must never diverge. Type styles and
+component samples are the next Style Guide iteration.

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -1,0 +1,100 @@
+# Apparule — Engineering Contracts
+
+> Cross-cutting contracts the flow specs assume: error envelope + catalog,
+> authorization matrix, rate limits, testing strategy, logging rules.
+> Ecosystem-shared conventions originate here and are mirrored by the other
+> products' engineering.md files.
+
+## 1. Error envelope (ecosystem standard)
+
+```json
+{ "error": { "code": "snake_case_stable", "message": "human copy", "details": {} } }
+```
+
+- `code` is the API contract (clients switch on it); `message` is display
+  copy and may change freely; `details` is optional structured context.
+- gRPC-less product: HTTP only. Status ↔ code families:
+
+| HTTP | Family |
+| --- | --- |
+| 400 | `invalid_*` (malformed input) |
+| 401 | `unauthenticated`, `token_expired` |
+| 403 | `provider_not_allowed`, `email_unverified`, `consent_required`, `forbidden`, `account_disabled`, `kyc_incomplete` |
+| 404 | `not_found` (never distinguishes "exists but not yours") |
+| 409 | `duplicate_request`, `post_unavailable`, `already_linked`, `name_taken` |
+| 422 | QC codes (capture-qc.md §1–2), `snapshot_invalid`, `ts_out_of_range` |
+| 429 | `rate_limited` (+ `Retry-After`) |
+| 5xx | `internal`, `pipeline_busy`, `provider_unavailable` |
+
+Full product catalog = the union of codes in flows/* and capture-qc.md; new
+codes land in those docs first, never invented ad-hoc in code review.
+
+## 2. Authorization matrix
+
+Roles: **visitor** (unauthenticated), **user** (account), **designer**
+(user + verified designer profile), **moderator** (staff), plus workspace
+membership for vault-of-customers use (SME mode).
+
+| Resource / action | visitor | user | designer | moderator |
+| --- | --- | --- | --- | --- |
+| Feed/explore read, post detail | ✓ (public posts) | ✓ | ✓ | ✓ |
+| Like/save/comment/follow | — | ✓ (verified email for comment) | ✓ | ✓ |
+| Create post | — | — | ✓ (KYC complete) | — |
+| Own vault (read/write) | — | ✓ self only — **no role ever reads another's vault** | ✓ self | — |
+| Workspace customers/sessions | — | workspace members | — | — |
+| Create request | — | ✓ (verified, vault non-empty, consent) | ✓ as customer | — |
+| Request read/messages | — | party only (customer or that designer) | party only | on dispute |
+| Quote/decline/status | — | — | ✓ own requests | dispute resolution |
+| Pay / confirm delivery / dispute | — | ✓ own orders | — | resolve |
+| Earnings/payout account | — | — | ✓ self | — |
+| Reports/blocks | — | ✓ | ✓ | queue + actions |
+
+Enforcement: middleware resolves `{account, designer?, workspace?}` from the
+verified token once per request; handlers declare required capability —
+no inline ad-hoc checks.
+
+## 3. Rate limits (per account unless stated)
+
+| Surface | Limit |
+| --- | --- |
+| `POST sessions` (capture) | 10/min, 100/day |
+| Likes/saves/follows | 60/min combined (anti-spam), silent absorb over-limit for idempotent toggles |
+| Comments | 10/min |
+| Requests | 10 open total (flows/request.md), 20 created/day |
+| Posts (designer) | 20/day |
+| Auth attempts | Firebase-managed |
+| Media upload bandwidth | 100 MB/day/account |
+
+429 + `Retry-After`; limits enforced in api/common (shared Redis, X-5).
+
+## 4. Testing strategy
+
+| Layer | Scope | Non-negotiables |
+| --- | --- | --- |
+| Unit (Go table-driven; pytest) | handlers, services, QC math | capture-qc golden images (1 per QC code); order state-machine transition table (every legal + illegal edge); confidence formula fixtures |
+| Contract | error catalog | every documented code producible by a test |
+| Integration (compose) | api/common ↔ api/measure ↔ Firestore emulator | idempotency: duplicate session/request/payment under concurrent retry |
+| E2E smoke (per release tag) | auth → capture → save → request → quote → pay(sandbox) → deliver | runs against sandbox before the tag deploy completes (release.yml gate) |
+| Money invariants | platform ledger | property-based: Σ(payments) = Σ(payouts + fees + refunds + held) at all times |
+
+Firestore rules tests: vault documents unreadable cross-account by
+construction (emulator rule tests are part of CI, not optional).
+
+## 5. Logging & observability
+
+- slog JSON (Go) / structlog-style (Python); every request logs one line:
+  `request_id, route, status, duration_ms, account_id?` — **account id only,
+  never email**.
+- **Never-log list** (CI grep-gated): measurement values, capture image
+  bytes/URLs with tokens, Firebase ID tokens, payment provider payloads,
+  message bodies.
+- Events → Upstat per flow specs (counters only). Cloud Run structured
+  logging picks up slog JSON natively.
+
+## 6. Acceptance
+
+- [ ] Error catalog test suite covers every code in flows/* + capture-qc
+- [ ] Authz matrix encoded as middleware capability table + tests per row
+- [ ] Firestore emulator rules tests in CI
+- [ ] Money invariant property test present before Phase 4 merges
+- [ ] Never-log grep gate wired into build-and-test.yml

--- a/docs/flows/auth.md
+++ b/docs/flows/auth.md
@@ -1,0 +1,77 @@
+# Flow: Authentication (Google-only, Firebase-backed)
+
+> Implements decision X-1 as hardened 2026-07-16: **Google sign-in is the
+> only authentication method** — no username/password signup or login,
+> product-wide. Firebase Auth on `sandbox-e306a` underneath; in-app screens.
+> Replaces the current stub endpoints (`POST /api/auth/google` and `/email`)
+> — the email stub is deleted with no successor.
+
+## 1. Hard rule & enforcement
+
+- **Google provider only.** Enforced at three layers:
+  1. Firebase console: Email/Password provider **disabled** on the project;
+  2. Backend: token verification rejects any token whose
+     `firebase.sign_in_provider ≠ google.com` → `403 provider-not-allowed`;
+  3. UI: exactly one auth CTA — "Continue with Google".
+- Consequences embraced: no password storage, no reset flow, no credential
+  enumeration surface, and `email_verified` is always true (Google-asserted),
+  so no separate verification gate exists.
+
+## 2. Session model
+
+- Flutter (`google_sign_in` + `firebase_auth`) / web (Firebase JS SDK popup,
+  redirect fallback for in-app browsers) hold the session; SDK auto-refreshes
+  ID tokens (~1h).
+- API calls send `Authorization: Bearer <Firebase ID token>`; api/common
+  verifies (Admin SDK/JWKS, audience `sandbox-e306a`, provider check §1),
+  then upserts the `ACCOUNT` row by `firebase_uid` (idempotent).
+- `401 token-expired` → silent refresh → retry once → sign-out on repeat.
+- Sign-out: SDK signOut + purge local caches; unsaved capture drafts warn.
+
+## 3. Sequence (first sign-in)
+
+```mermaid
+sequenceDiagram
+    actor U as User
+    participant A as App (Flutter/web)
+    participant G as Google / Firebase
+    participant C as api/common
+
+    U->>A: Continue with Google
+    A->>G: signIn (native sheet / popup)
+    G-->>A: Firebase user + ID token (email_verified: true)
+    A->>C: GET /api/v1/me (Bearer)
+    C->>C: verify token + provider, upsert ACCOUNT
+    C-->>A: account {consent: none}
+    A-->>U: straight into the app (consent gate on first protected action)
+```
+
+## 4. Errors & edge cases
+
+| Case | Behaviour |
+| --- | --- |
+| Popup/sheet dismissed | silent return, screen unchanged |
+| `network-request-failed` | offline toast + retry |
+| `user-disabled` | "This account has been disabled" + support link |
+| Token with wrong provider (crafted email/password token from another tool) | `403 provider-not-allowed`; log server-side |
+| Google account without Play Services (Android edge) | `google_sign_in` fallback to web flow |
+| In-app browsers blocking popups (IG/Twitter webviews — likely for a social app!) | `signInWithRedirect` fallback; tested explicitly |
+| Account deletion | in-app: deletes ACCOUNT + vault per retention rules, then Firebase user; Google access revoked via SDK |
+
+## 5. Screen inventory impact **[flags removals]**
+
+`login_page` becomes the single auth screen (Google CTA + legal links).
+`sign_up_form`, `sign_up_screen`, `forgot_password`, `reset_password`,
+`verify_email`, `sms_verification`, `verify_account` are **retired** in the
+social redesign (pages.md C1 updates accordingly) — phone verification may
+return later for designer KYC, which Paystack owns anyway (A-2).
+
+## 6. Instrumentation & acceptance
+
+Events: `auth_signin_completed`, `auth_signin_failed` — counters only.
+
+- [ ] Email/Password provider disabled in Firebase console (verified)
+- [ ] Backend rejects non-Google-provider tokens (test with crafted token)
+- [ ] Redirect fallback works inside IG/webview browsers on both platforms
+- [ ] Stub endpoints deleted; retired screens removed from the router
+- [ ] Exactly one ACCOUNT row under concurrent first-login race

--- a/docs/flows/request.md
+++ b/docs/flows/request.md
@@ -1,0 +1,93 @@
+# Flow: Commission Request (customer side)
+
+> UI + contract layer over the state machine in
+> [order-lifecycle.md](../order-lifecycle.md). Covers the request stepper
+> (pages.md C5/B3, MI-10), payment, and every edge case. Preconditions:
+> authed + email verified (auth §4.3) + non-empty vault + consent on file.
+
+## 1. The stepper (3 steps, sheet/modal)
+
+| Step | Content | Validation | Errors |
+| --- | --- | --- | --- |
+| 1 · Measurements | vault snapshot picker: latest session preselected; freshness warning if >90d ("Measurements are 4 months old — retake?") — warning, not block; shows exactly which values will be shared | ≥1 measurement in selection; session must be `complete` | vault empty → redirect to vault flow with return-path |
+| 2 · Details | notes (0–500 chars), budget (optional, ≥ post base price if designer set one — soft warning below), delivery city/address ref, target date (≥ designer turnaround, soft warning) | notes length; date ≥ today+turnaround → else "Designer's typical turnaround is 14 days" warning | |
+| 3 · Review | outfit summary, snapshot values (expandable), notes, budget; legal line: accuracy disclaimer + "measurements shared only with this designer for this order" | — | post deleted/designer deactivated since step 1 → `409 post-unavailable` → "This outfit is no longer available" + close |
+
+Submit: `POST /api/v1/posts/{id}/requests` with `Idempotency-Key` (UUID per
+stepper session) — double-taps and retries create exactly one request.
+Success: MI-10 confetti + "View order". Failure taxonomy:
+
+| Code | Cause | UX |
+| --- | --- | --- |
+| `409 duplicate-request` | open request already exists for this customer+post | jump to existing order |
+| `409 post-unavailable` | deleted/paused/designer KYC-lapsed | copy above |
+| `403 email-unverified` | — | verify sheet |
+| `422 snapshot-invalid` | session deleted between steps | back to step 1, picker refreshed |
+| `429` | >10 open requests **[Decided default cap]** | "You have too many open requests" |
+
+## 2. Snapshot semantics (privacy-critical)
+
+- Snapshot is a **server-side frozen copy** created at submit — the client
+  sends a session id, never raw values.
+- Designer sees values only from `requested` on, only for this order
+  (order-lifecycle.md §2 matrix).
+- Withdrawing (`cancelled`) or `declined` requests: snapshot hard-deleted
+  after 30 days terminal-state retention.
+
+## 3. Quote & payment (customer side)
+
+```mermaid
+sequenceDiagram
+    actor C as Customer
+    participant A as App
+    participant API as api/common
+    participant P as Paystack
+
+    Note over C,API: designer quoted (push received)
+    C->>A: open order, review quote (price + due date)
+    alt accept
+        C->>A: Pay
+        A->>API: POST /requests/{id}/pay (Idempotency-Key)
+        API->>P: initialize transaction (platform account)
+        P-->>A: checkout (inline/redirect)
+        C->>P: complete payment
+        P->>API: webhook charge.success (signature verified)
+        API->>API: PAYMENT held · REQUEST→paid · notify both
+    else reject / ignore 7d
+        A->>API: decline quote → cancelled (or expiry job cancels)
+    end
+```
+
+Edge cases:
+
+| Case | Behaviour |
+| --- | --- |
+| Payment window races quote expiry | expiry job skips orders with a pending payment intent (grace 1h) |
+| Webhook lost | reconciliation poll on order open + hourly sweep verifies pending intents against Paystack |
+| Double webhook | idempotent by provider reference — second is a no-op |
+| Charge succeeds, webhook signature invalid | log + alert ops; order stays `quoted`; reconciliation sweep resolves; NEVER trust unverified webhooks |
+| Partial/failed payment | Paystack handles retry UX; order remains `quoted` |
+| Customer pays after designer deactivated mid-window | charge refunded automatically, order → `cancelled`, apology copy |
+
+## 4. Delivery confirmation & dispute (customer side)
+
+- `shipped` push → order shows "Confirm delivery" + "Something wrong?".
+- Confirm: type nothing, single tap + confirm dialog → `delivered`, payout
+  releases, review prompt **[Later]**.
+- Auto-confirm T+14d with reminders at T+7 and T+12 (order-lifecycle.md).
+- Dispute: reason picker (not received / not as described / size wrong /
+  other + text) → freezes payout, opens support thread; size-wrong disputes
+  attach the snapshot for arbitration (the immutability pays off here).
+
+## 5. Instrumentation
+
+`request_started`, `request_submitted`, `request_paid`, `request_disputed{reason}`,
+`request_delivered` — counters; amounts never in events.
+
+## 6. Acceptance checklist
+
+- [ ] Stepper survives: post deletion mid-flow, vault edits mid-flow, app kill (draft restored)
+- [ ] Exactly-one request under retry; exactly-one charge under double-tap
+- [ ] Webhook signature verification + reconciliation sweep proven by test
+- [ ] Snapshot invisible to designer pre-request, purged post-terminal
+- [ ] Auto-confirm + reminders fire on schedule; disputes freeze payout

--- a/docs/flows/vault.md
+++ b/docs/flows/vault.md
@@ -1,0 +1,84 @@
+# Flow: Measurement Vault (capture, manual entry, history)
+
+> The vault is the profile's data spine (pages.md B4/C6/C7; data-model.md §2).
+> Covers camera capture, manual entry, history, retention — with every edge
+> case an implementer needs. Requires auth (flows/auth.md) + verified email
+> is NOT required (measuring yourself is private); consent (`tos`,`privacy`)
+> IS required before the first session persists.
+
+## 1. Capture flow (camera → pipeline → save)
+
+```mermaid
+flowchart TD
+    S[Start: vault Retake / onboarding CTA] --> H{height on file?}
+    H -->|no| HEIGHT[height input, 100–230 cm, unit toggle]
+    H -->|yes| GUIDE
+    HEIGHT --> GUIDE[guide screen: silhouette, lighting, distance tips]
+    GUIDE --> CAM[camera, silhouette overlay + 3-2-1 countdown MI-12]
+    CAM --> UP[upload session: POST customers/me/sessions]
+    UP --> QC{server QC}
+    QC -->|no body detected| E1[422 guidance: full body, better light → retake]
+    QC -->|multiple bodies| E2[422: make sure you are alone in frame]
+    QC -->|cut off / partial| E3[422: include head to ankles]
+    QC -->|pass| RESULTS[results: measurement cards stagger-in]
+    RESULTS --> SAVE[Save to vault]
+    RESULTS --> RETAKE[Retake — discards session]
+    SAVE --> DONE[vault updated, freshness ring resets MI-11]
+```
+
+### Step contracts
+
+| Step | Contract |
+| --- | --- |
+| Height input | 100–230 cm (39–91 in); stored per account, editable in vault; changing height NEVER retro-scales old sessions (they froze their `input_height_cm`) |
+| Upload | multipart image ≤ 10 MB, JPEG/PNG/HEIC; client compresses to ≤2048px long edge before upload; `Idempotency-Key` header (UUID per capture attempt) — retries on flaky mobile MUST NOT create duplicate sessions |
+| QC failures | always `422 {error:{code, message, guidance}}`; codes: `no_body`, `multiple_bodies`, `partial_body`, `undecodable_image`; each maps to specific retake copy — never a generic "failed" |
+| Unsaved results | server session rows created with `status: pending_save`; auto-purged after 24h unsaved **[Decided default]**; "Retake" purges immediately |
+| Save | flips `status: complete`; capture image begins its 30-day `retention_until` clock; measurements persist indefinitely |
+
+### Edge cases
+
+| Case | Behaviour |
+| --- | --- |
+| Network dies mid-upload | client retries ×3 w/ backoff (same idempotency key); then "Saved to drafts — retry from vault" (draft = local image + height, encrypted at rest on device) |
+| App killed after capture, before save | draft persists locally; vault shows "1 unsaved capture" chip on next open |
+| Pipeline timeout (>30s) | `503 pipeline-busy`; client offers retry; session row marked `failed` |
+| User with no vault opens request flow | redirected here with "You need measurements first" (flows/request.md §2) |
+| Camera permission denied | inline explainer + settings deep-link + "enter manually instead" |
+| Consent not yet recorded | consent sheet interposes before first upload; declining aborts save (capture stays local draft) |
+
+## 2. Manual entry & corrections
+
+- Manual entry (MI-13): any measurement from the open vocabulary
+  (`shoulder_width`, `hip_width`, `chest_girth`, …) as `method: manual`
+  sessions; values validated 10–200 cm per measure with per-measure sanity
+  ranges (server-side table, e.g. shoulder 25–75 cm) — out-of-range prompts
+  "double-check" confirm, not a hard block (bodies vary).
+- Corrections on pipeline sessions append `source: manual_correction` rows;
+  original pipeline values are never mutated (audit trail, data-model.md §2).
+- Unit display cm/in is a view preference; storage is always cm.
+
+## 3. History & retention
+
+- Vault shows latest value per measurement + sparkline; history sheet lists
+  sessions (date, method chip, values); deleting a session soft-deletes then
+  hard-purges w/ its capture asset; deleting the *latest* session promotes
+  the previous one to "current".
+- Freshness ring (MI-11): <30d gradient · 30–90d amber · >90d gray; ring
+  state computed from latest `complete` session.
+- Retention job: capture assets past `retention_until` hard-deleted daily;
+  measurements remain. Export/delete-all rights per data-model.md §4.
+
+## 4. Instrumentation
+
+`vault_capture_started`, `vault_qc_failed{code}`, `vault_session_saved{method}`,
+`vault_manual_entry` — counters only, never values.
+
+## 5. Acceptance checklist
+
+- [ ] Full capture→save on Flutter + webcam path on dashboard
+- [ ] Each QC code produces its specific guidance copy
+- [ ] Duplicate-session impossible under retry storms (idempotency verified)
+- [ ] Unsaved sessions purge at 24h; drafts survive app kill
+- [ ] Corrections append, never overwrite; unit toggle pure-view
+- [ ] Height change does not alter historical sessions

--- a/docs/order-lifecycle.md
+++ b/docs/order-lifecycle.md
@@ -1,0 +1,100 @@
+# Apparule — Commission Order Lifecycle
+
+> The full state machine behind SOC-004/005/006 (pages.md B3/C5/C8,
+> data-model.md §5 `REQUEST`). **[Proposed]** — this is the contract the
+> commerce phase implements; payments/escrow specifics gated on the provider
+> decision.
+
+## 1. State machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> requested : customer submits (snapshot frozen)
+    requested --> quoted : designer quotes (price + due date)
+    requested --> declined : designer declines (reason)
+    requested --> cancelled : customer withdraws
+    quoted --> paid : customer pays (escrow hold)
+    quoted --> cancelled : customer rejects quote / quote expires (7d)
+    paid --> in_progress : designer starts work
+    in_progress --> shipped : designer ships (tracking optional)
+    shipped --> delivered : customer confirms OR auto-confirm T+14d
+    delivered --> [*] : payout released
+    paid --> disputed : either party (before delivery confirm)
+    in_progress --> disputed
+    shipped --> disputed
+    disputed --> delivered : resolved for designer (payout releases)
+    disputed --> refunded : resolved for customer
+    refunded --> [*]
+    declined --> [*]
+    cancelled --> [*]
+```
+
+Rules:
+
+- **Measurement snapshot freezes at `requested`** — later vault changes never
+  mutate an order; a re-measure prompts a *new* request.
+- **Quotes expire** after 7 days un-actioned (state → `cancelled`, both
+  parties notified) **[default to ratify]**.
+- **Auto-confirm**: `shipped` → `delivered` at T+14 days without customer
+  action, after two reminders — protects designer payout from ghosting
+  **[default to ratify]**.
+- **Dispute window** ends at delivery confirmation; disputes freeze payout
+  and open a support thread (routes to `clients.cuesoft.io` when live).
+- Cancellation after `paid` is a refund path, not a `cancelled` transition —
+  money movements only ever resolve through `delivered` (payout) or
+  `refunded`.
+
+## 2. Permissions matrix
+
+| Action | Customer | Designer | System |
+| --- | --- | --- | --- |
+| submit request | ✓ (with owned snapshot) | — | — |
+| quote / decline | — | ✓ | quote expiry |
+| pay | ✓ | — | — |
+| start / ship | — | ✓ | — |
+| confirm delivery | ✓ | — | auto-confirm T+14 |
+| open dispute | ✓ | ✓ | — |
+| resolve dispute | — | — | support/admin only |
+| view snapshot values | ✓ (own) | ✓ (this order only) | — |
+
+The snapshot-visibility rule is the privacy core: a designer sees a
+customer's measurements **only inside an order that customer initiated**,
+and only that frozen copy.
+
+## 3. Money movement (escrow model, provider-gated)
+
+| Event | Movement |
+| --- | --- |
+| `paid` | full quote captured to platform escrow; `PAYMENT.state = held` |
+| `delivered` | payout = quote − platform fee → designer payout account; `released` |
+| `refunded` | escrow returns to customer (fee handling per provider rules) |
+
+Platform fee % and payout timing (instant vs T+2) are provider-dependent —
+decide with the provider (Paystack-first for NG rails, Stripe for
+international **[Proposed]**). Designer payouts require completed KYC
+(`DESIGNER_PROFILE.payout_account` verified) *before* their posts can accept
+requests — not at payout time, when it's too late.
+
+## 4. Notifications map (SOC-008)
+
+| Transition | Customer | Designer |
+| --- | --- | --- |
+| requested | receipt confirmation | **push + badge: new request** |
+| quoted | **push: quote received** (+T-2d expiry reminder) | — |
+| paid | payment receipt | **push: order funded — start work** |
+| in_progress | status update | — |
+| shipped | **push: shipped** (+tracking) | — |
+| delivered−2d (pending auto-confirm) | reminder ×2 | — |
+| delivered | confirmation + review prompt **[Later]** | **push: payout released** |
+| declined / cancelled / disputed / refunded | push | push |
+
+All notifications also land in the in-app activity sheet (pages.md C10);
+email mirrors only money events (paid, payout, refund) **[Proposed]**.
+
+## 5. Thread messaging scope
+
+Each request carries one message thread (SOC-005), open from `requested`
+until 30 days after terminal state. Attachments: images only (reference
+photos, progress shots). No payment links in threads (anti-fee-evasion +
+safety); the pay CTA is only ever the order's own payment box. Full DMs
+outside orders remain out of scope (SOC-010).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -37,3 +37,5 @@ See [setup.md](setup.md) to run the stack locally, and the
 - [design.md](design.md) + [pages.md](pages.md) — design language, screens, microinteractions
 - [order-lifecycle.md](order-lifecycle.md) — commission order state machine, permissions, notifications
 - [decisions.md](decisions.md) — the open-decision register: ratify to unblock phases
+- [deployment.md](deployment.md) — Cloud Run + App Hosting contract (cuesoft-iac provisioning, CI/CD pattern)
+- flows/ — feature flow specs with edge cases: [auth](flows/auth.md), [vault](flows/vault.md), [request](flows/request.md)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -34,3 +34,5 @@ See [setup.md](setup.md) to run the stack locally, and the
 - [data-model.md](data-model.md) — entities, storage mapping, data classification
 - [api.md](api.md) — current + target API surface and gap analysis
 - [roadmap.md](roadmap.md) — phased plan with cross-repo dependencies
+- [design.md](design.md) + [pages.md](pages.md) — design language, screens, microinteractions
+- [order-lifecycle.md](order-lifecycle.md) — commission order state machine, permissions, notifications

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -40,3 +40,4 @@ See [setup.md](setup.md) to run the stack locally, and the
 - [deployment.md](deployment.md) — Cloud Run + App Hosting contract (cuesoft-iac provisioning, CI/CD pattern)
 - flows/ — feature flow specs with edge cases: [auth](flows/auth.md), [vault](flows/vault.md), [request](flows/request.md)
 - [capture-qc.md](capture-qc.md) — QC thresholds + measurement-confidence formulas
+- [engineering.md](engineering.md) — error catalog, authz matrix, rate limits, testing strategy, logging rules

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -36,3 +36,4 @@ See [setup.md](setup.md) to run the stack locally, and the
 - [roadmap.md](roadmap.md) — phased plan with cross-repo dependencies
 - [design.md](design.md) + [pages.md](pages.md) — design language, screens, microinteractions
 - [order-lifecycle.md](order-lifecycle.md) — commission order state machine, permissions, notifications
+- [decisions.md](decisions.md) — the open-decision register: ratify to unblock phases

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -39,3 +39,4 @@ See [setup.md](setup.md) to run the stack locally, and the
 - [decisions.md](decisions.md) — the open-decision register: ratify to unblock phases
 - [deployment.md](deployment.md) — Cloud Run + App Hosting contract (cuesoft-iac provisioning, CI/CD pattern)
 - flows/ — feature flow specs with edge cases: [auth](flows/auth.md), [vault](flows/vault.md), [request](flows/request.md)
+- [capture-qc.md](capture-qc.md) — QC thresholds + measurement-confidence formulas

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -22,7 +22,7 @@ flutter mobile ────────────┘  Google auth
 - **`api/common`** — Go service: authentication and core API (Cloud Run).
 - **`api/measure`** — Python service: MediaPipe pose-based body measurement.
 - **Auth** — Firebase Authentication / Google sign-in.
-- **Data** — Firebase Firestore & Storage; Aiven Postgres & Valkey (Redis).
+- **Data** — Firestore (system of record, X-5) & Cloud Storage; shared Aiven Redis (REDIS_DB tenancy).
 
 See [setup.md](setup.md) to run the stack locally, and the
 [repository structure](../README.md#repository-structure) in the README.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -26,3 +26,11 @@ flutter mobile ────────────┘  Google auth
 
 See [setup.md](setup.md) to run the stack locally, and the
 [repository structure](../README.md#repository-structure) in the README.
+
+## Product & design documentation
+
+- [prd.md](prd.md) — product requirements breakdown (personas, requirements, compliance, open questions)
+- [architecture.md](architecture.md) — current vs target system design, sequences, SMPL pipeline
+- [data-model.md](data-model.md) — entities, storage mapping, data classification
+- [api.md](api.md) — current + target API surface and gap analysis
+- [roadmap.md](roadmap.md) — phased plan with cross-repo dependencies

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -1,0 +1,135 @@
+# Apparule — Pages, Screens & Features
+
+> Every surface of the product, to component level, referencing the design
+> system and microinteractions in [design.md](design.md) (`MI-n`). Three
+> parts: **A** public home page, **B** web dashboard, **C** mobile app.
+> The social model (posts, likes, requests, payments) is the 2026-07-16
+> scope expansion **[Directive]**; entities in [data-model.md](data-model.md) §5.
+
+## Part A — Public home page (apparule.cuesoft.io)
+
+Standard CueLABS open-source product site (shared pattern across the three
+products **[Directive]**): present the product → developers can set it up →
+community links → preview → dual CTA **Try Cloud** / **Self Host**.
+
+| # | Section | Content & components | Interactions |
+| --- | --- | --- | --- |
+| A1 | Nav bar | logo · Product · Docs (GitBook) · Community · GitHub (star count badge) · Sign in · **Try Cloud** (gradient) | sticky, blurs on scroll; star count fetched client-side, animates count-up once |
+| A2 | Hero | H1 "Precision measurement meets social fashion" (copy pass pending); subcopy; dual CTA **Try Cloud** / **Self Host**; hero visual: phone frame auto-playing a silent feed→capture→request loop | CTA hover lifts 2px; visual loop pauses on hover/reduced-motion |
+| A3 | Problem strip | 3 stat cards (manual-measurement error, fragmented records, lost designer reach) | cards fade-up on scroll-into-view (once) |
+| A4 | Product walkthrough | 4-step horizontal scroll-jacked panel (Capture → Vault → Discover → Commission), each step = screenshot + 2 lines | step dots + keyboard arrows; scroll-jack disabled on mobile (vertical stack) |
+| A5 | SMPL/AI section (APP-003) | short explainer "AI-assisted body modeling", looping landmark-constellation animation (same asset as MI-12), link → GitBook deep-dive | |
+| A6 | For designers | split panel: "Post outfits, get commissioned, get paid" + earnings screenshot | |
+| A7 | Open source section | `docker compose up` snippet with copy button · architecture mini-diagram · GitHub + CONTRIBUTING links | copy button ✓ morph |
+| A8 | Community | Discord card (member count), roadmap link, CueLABS note | |
+| A9 | Cloud vs Self-host table (PRD §3) | feature comparison; Cloud column ends in Try Cloud CTA, OSS column in Self Host (→ docs quickstart) | |
+| A10 | Footer | product/docs/community columns · privacy (APP-005) · terms · `privacy.cuesoft.io` clause link · language | |
+
+Analytics events (→ Upstat, D2): `page_view`, `demo_start` (A4 engage),
+`github_click` (A1/A7), `try_cloud_click`, `self_host_click`. **[PRD + Directive]**
+
+Docs: hosted on **GitBook** (Git-synced from this `docs/` folder) **[Directive]**;
+API reference via **Scalar** rendering the OpenAPI specs (api.md) embedded at
+`/docs/api`. **[Proposed]**
+
+## Part B — Web dashboard (app.apparule.cuesoft.io or /app)
+
+Desktop adaptation of the mobile IA (design.md §2 layout). Left rail: Home,
+Explore, Create, Orders, Vault, Profile, Settings; bottom of rail: theme
+toggle, support (`clients.cuesoft.io`).
+
+### B1 `/app` — Feed
+- Story rail (fresh outfits from followed designers, MI-8) above feed.
+- `PostCard` column (630px): MI-1/2/3/4/9 all active; "Request this outfit"
+  CTA on designer posts → request stepper (MI-10) in modal.
+- Right column: own measurement-freshness card (MI-11) + suggested designers
+  (Follow, MI-7).
+- States: skeleton (MI-19) · empty ("Follow designers to fill your feed" +
+  explore CTA) · caught-up divider (MI-6).
+
+### B2 `/app/explore` — Discover
+- Search bar (designers, styles, tags) with recent-searches dropdown.
+- Masonry grid of outfit posts (1:1 crops); hover: like/comment counts
+  overlay fade-in 120ms; click → post modal (IG desktop pattern: media left,
+  detail right).
+- Filter chips: style tags, price band, turnaround time, "near me" **[Proposed]**.
+
+### B3 `/app/orders` — Requests & orders (both roles)
+- Tabs: **As customer** / **As designer** (designer tab only when creator
+  profile enabled).
+- `RequestCard` list; status pills (MI-14): `requested → quoted → paid →
+  in_progress → shipped → delivered` (+ `declined`, `disputed`, `cancelled`).
+- Click → order detail: outfit summary · **measurement snapshot** (the exact
+  values sent, immutable) · thread (MI-17) · timeline (MI-14) · payment box
+  (MI-15: quote → pay → escrow-held → released on delivery confirm)
+  **[Proposed payment model — ratify]**.
+- Designer actions per state: quote (price + due date) / decline with reason /
+  mark in-progress / mark shipped (tracking optional) ; customer: pay, confirm
+  delivery (releases payout), open dispute.
+
+### B4 `/app/vault` — Measurement vault
+- Header: freshness ring avatar (MI-11) + "Retake" CTA → capture options
+  (webcam upload / phone hand-off QR **[Proposed]** / manual entry MI-13).
+- `MeasurementCard` grid (shoulder, hip, +SMPL girths when available) with
+  history sparklines; tap → history sheet (sessions list, method chips,
+  delete session).
+- Consent + retention notice inline (data-model.md §4); "Download my data" /
+  "Delete all" links (rights parity with expendit **[Proposed]**).
+
+### B5 `/app/create` — Post an outfit (designer)
+- Dropzone (≤10 media, reorder by drag; MI-4 preview) → details form
+  (caption, style tags, base price or "quote on request", turnaround days,
+  fabric notes) → publish.
+- Non-creator users see the creator-profile upsell here ("Become a designer").
+
+### B6 `/app/{username}` — Profiles
+- Designer: avatar + story ring, follower/following/posts counts, Follow
+  (MI-7), Request CTA, bio, grid/saved tabs; earnings tab visible only to
+  self (payout balance, payout account setup, transaction list) **[Proposed]**.
+- Regular user: private vault indicator (measurements NEVER public), saved
+  looks tab, order history link. Privacy default: vault visible to no one;
+  a measurement snapshot is shared **only** inside a request (APP-005 story).
+
+### B7 `/app/settings`
+- Account (via `account.cuesoft.io` when D1 lands), creator profile toggle,
+  payout account (designer), notifications, privacy & data (export/delete,
+  consent history), language, theme.
+
+## Part C — Mobile app (Flutter) — primary surface
+
+Bottom tab bar: **Home · Explore · ➕ · Orders · Profile** (design.md §3).
+Existing screens (splash/welcome/auth/capture) remain the entry path.
+
+| # | Screen | Spec |
+| --- | --- | --- |
+| C1 | Onboarding | existing auth flow; post-signup interstitial: "Take your first measurement" (→C6) or "Explore outfits" — skippable |
+| C2 | Home feed | = B1 minus right column; story rail on top; MI-1/2/3/4/5/6/16/18/20 all active |
+| C3 | Explore | search + 3-col grid; long-press peek preview (scale 0.97 + dim, MI haptic light); pull-to-refresh MI-5 |
+| C4 | Post detail | full-bleed carousel; action row; caption; comments sheet (swipe-up); Request CTA pinned bottom (safe-area) |
+| C5 | Request stepper | MI-10 sheet: Step 1 pick measurement set (vault snapshot picker, freshness warnings); Step 2 notes + budget + delivery; Step 3 review → submit; success: confetti + "view order" |
+| C6 | Capture | existing guide screens restyled: silhouette overlay + countdown (MI-12); processing constellation; results screen: measurement cards stagger-in, "Save to vault" primary, "Retake" quiet; manual-entry fallback (MI-13) |
+| C7 | Vault | = B4 adapted; entry from Profile tab header ring |
+| C8 | Orders | = B3 list + detail; push notifications drive re-entry (badge MI-16) |
+| C9 | Profile | own: vault ring header, grid of liked/saved, settings gear; others: designer profile = B6 |
+| C10 | Notifications sheet | activity list (likes, follows, quotes, status changes); grouped by day; swipe-to-clear |
+
+Push notifications **[Proposed]**: quote received, payment confirmed, status
+changes, delivery confirm reminder (customer), new request (designer).
+
+## Feature register delta (extends prd.md §3)
+
+| ID | Feature | Priority | Surfaces |
+| --- | --- | --- | --- |
+| SOC-001 | Designer posts (media, tags, price, turnaround) | Must | B5, C2–C4 |
+| SOC-002 | Follow graph + home feed + explore | Must | B1/B2, C2/C3 |
+| SOC-003 | Likes, saves, shares, comments | Must | feed/post surfaces |
+| SOC-004 | Commission request with measurement snapshot | Must | B3, C5 |
+| SOC-005 | Order lifecycle + thread messaging | Must | B3, C8 |
+| SOC-006 | Payments: customer pay, escrow hold, designer payout, platform fee | Must | B3, B6 earnings **[payment provider + fee % to ratify]** |
+| SOC-007 | Creator profiles (role toggle, earnings) | Must | B6, B7 |
+| SOC-008 | Notifications (in-app + push) | Should | C10 |
+| SOC-009 | Comments moderation, report/block | Should | trust & safety baseline for UGC **[Proposed — required before public launch]** |
+| SOC-010 | Full DMs beyond order threads | Later | — |
+
+Cross-refs: data model additions → data-model.md §5; API additions →
+api.md §5; sequencing → roadmap.md (revised phases).

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -91,7 +91,7 @@ toggle, support (`clients.cuesoft.io`).
   a measurement snapshot is shared **only** inside a request (APP-005 story).
 
 ### B7 `/app/settings`
-- Account (via `account.cuesoft.io` when D1 lands), creator profile toggle,
+- Account (Google sign-in via Firebase per X-1; `account.cuesoft.io` facade later), creator profile toggle,
   payout account (designer), notifications, privacy & data (export/delete,
   consent history), language, theme.
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -110,7 +110,7 @@ capabilities beyond the web property. Made explicit so they can be scheduled:
 
 ## 8. Open questions
 
-1. **`account.cuesoft.io` contract** — protocol (OIDC? opaque token introspection?),
+1. ~~**`account.cuesoft.io` contract**~~ **RESOLVED (X-1)**: in-app Google-only sign-in over Firebase Auth (`sandbox-e306a`); the facade comes later. Original question — protocol (OIDC? opaque token introspection?),
    token audience/claims, and timeline. Blocks APP-002 and PLAT-003's final shape
    (roadmap D1). Interim: local JWT auth hardened enough for records **[Proposed]**.
 2. **Cloud instance model** — "request a cloud instance" reads as
@@ -121,7 +121,7 @@ capabilities beyond the web property. Made explicit so they can be scheduled:
    requires a license from Meshcapade/MPI. The hosted commercial cloud likely
    needs SMPL commercial licensing or an alternative body model. Must be resolved
    before PLAT-005 ships in cloud (roadmap risk R1).
-4. **Where records live** — README names both Firestore and Aiven Postgres.
+4. ~~**Where records live**~~ **RESOLVED (X-5)**: Firestore. Original question — README names both Firestore and Aiven Postgres.
    data-model.md proposes Postgres as the system of record; confirm.
 5. **Figma designs** — Home canvas is empty; landing implementation (roadmap P0)
    needs the design pass, or we proceed with a standards-based layout and

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,0 +1,128 @@
+# Apparule — Product Requirements Breakdown
+
+> Source: "Apparule Product Requirement Document" (provided 2026-07-15) combined
+> with the repository state on `main`. The linked
+> [Figma file](https://www.figma.com/design/34GbYXm8TpxMMUaAGGuwMM/Apparule)
+> currently contains an empty "Home" canvas, so the PRD's component table is the
+> authoritative sitemap until designs land.
+>
+> Markers used throughout the docs set: **[PRD]** = stated requirement,
+> **[Current]** = verified repository fact, **[Proposed]** = design decision
+> introduced by this breakdown that needs ratification.
+
+## 1. Product definition
+
+Apparule is an open-source measurement and apparel platform: it collects,
+stores, and manages customer physical dimensions and bridges that body data
+into garment-production workflows. **[PRD]**
+
+Two distinct things carry the name and must not be conflated:
+
+| Surface | What it is | Commercial status |
+| --- | --- | --- |
+| The open-source product (this repo) | Go core API, Python measurement service, Next.js web, Flutter mobile | Free, self-hostable |
+| Apparule Cloud | Hosted instances of the same stack, managed by Cuesoft | Separate commercial offering **[PRD §5]** |
+
+`apparule.cuesoft.io` is the single web property serving both: product-led
+landing, documentation hub, and the cloud access point. **[PRD §1.1]**
+
+## 2. Personas and jobs-to-be-done
+
+| Persona | Job-to-be-done | Primary surface |
+| --- | --- | --- |
+| Fashion SMEs & tailors | Replace paper/manual measurement records; retrieve a customer's dimensions when producing a garment | Mobile app (capture) + cloud dashboard (manage) |
+| Apparel product evaluators | Assess whether Apparule fits their workflow before committing | Landing page, interactive walkthrough, demo booking |
+| Software engineers | Integrate measurement APIs into their own apps; contribute to the project | Developer docs, API reference, GitHub |
+| Internal Cuesoft teams (CueLABS™) | Product experimentation and talent development | Whole stack |
+
+Mobile-first bias: tailors and fashion SMEs predominantly operate on phones, so
+measurement entry must be touch-friendly and responsive. **[PRD §5]**
+
+## 3. Functional requirements
+
+### 3.1 Stated requirements (web property)
+
+| ID | Requirement | Priority | Expanded acceptance criteria |
+| --- | --- | --- | --- |
+| APP-001 | Open-Source Gateway | Must | Prominent GitHub link + contribution guidelines from the landing page; repository README/CONTRIBUTING are the landing targets. |
+| APP-002 | Cloud Access Flow | Must | Sign-in via `account.cuesoft.io`; authenticated users can request a cloud instance; request is tracked and acknowledged. Users must accept product-specific ToS (data retention + accuracy disclaimer) before cloud access. **[PRD §7]** |
+| APP-003 | SMPL Pipeline Demo | Should | Visual/video walkthrough of the SMPL-based measurement process embedded on the landing page. |
+| APP-004 | API Reference | Should | Searchable API documentation for third-party integration. |
+| APP-005 | Privacy Disclosure | Must | Explicit page/section describing how measurements and personal physical data are handled, linking to the Apparule clause in `privacy.cuesoft.io`. |
+
+### 3.2 Ecosystem requirements
+
+| ID | Requirement | Notes |
+| --- | --- | --- |
+| ECO-AUTH | All login/session management via `account.cuesoft.io` | External service — does not exist in this repo; see roadmap dependency D1. **[PRD §4.2]** |
+| ECO-SUPPORT | Route active users needing help to `clients.cuesoft.io` | Link-out only in v1. |
+| ECO-ANALYTICS | Track "Demo Starts" and "GitHub Clicks" via Upstat | Depends on Upstat exposing a generic event-ingestion API (cross-repo dependency D2 — Upstat currently has none). |
+
+### 3.3 Implied platform requirements **[Proposed]**
+
+The executive summary ("collecting, storing, and managing customer physical
+dimensions … actionable garment production workflows") implies product
+capabilities beyond the web property. Made explicit so they can be scheduled:
+
+| ID | Requirement | Rationale |
+| --- | --- | --- |
+| PLAT-001 | Server-side measurement records | Today `POST /measure` is stateless; nothing is stored anywhere but the phone. "Storing and managing" requires persistent records. |
+| PLAT-002 | Customer management | A tailor manages many customers, each with measurement history. |
+| PLAT-003 | Real authentication | Both current auth endpoints are stubs (`TODO(security-prd)` in `internal/auth/auth.go`): Google login does not verify the ID token; email login is a logged no-op. Real identity is a precondition for storing sensitive records. |
+| PLAT-004 | Garment-workflow export | The "bridge to production" — export measurement sets in shareable/printable form (v1: PDF/CSV export; later: size-chart mapping). |
+| PLAT-005 | SMPL measurement pipeline | Upgrade from the current 2-D landmark approach to SMPL-based 3-D body modeling (see architecture.md §5 for the technical gap and licensing note). |
+
+## 4. Non-goals (v1)
+
+- Building `account.cuesoft.io`, `clients.cuesoft.io`, or `privacy.cuesoft.io`
+  themselves — they are ecosystem dependencies, consumed not implemented here.
+- E-commerce/checkout, garment CAD, or pattern drafting.
+- Real-time in-browser 3-D fitting; the SMPL demo is pre-rendered media. **[PRD APP-003]**
+- Direct integrations with garment factories (v1 bridges via exports).
+
+## 5. Brand & content requirements
+
+- Aesthetic: product-led, technical, visual; high-quality product screenshots,
+  workflow diagrams, code-style documentation blocks. **[PRD §2]**
+- Subtle Afrocentric geometric patterns for Cuesoft ecosystem alignment. **[PRD §2]**
+- Terminology: "AI-assisted body modeling" in marketing copy; "SMPL pipeline"
+  reserved for developer docs. **[PRD §6]**
+- CTAs: "Try Apparule Cloud", "View on GitHub", "Book a Demo". **[PRD §6]**
+- Case studies: retail, fashion SMEs, measurement management. **[PRD §6]**
+
+## 6. Compliance & safety requirements
+
+| Concern | Requirement |
+| --- | --- |
+| Data classification | Measurements + body images are **high-sensitivity personal data**; handling rules in data-model.md §4. **[PRD §7]** |
+| Privacy disclosure | Site links to the Apparule-specific clause in `privacy.cuesoft.io` (APP-005). |
+| Terms gate | Cloud users must accept product-specific ToS covering data retention and measurement-accuracy disclaimers *before* access. Consent must be recorded (data-model.md `ConsentRecord`). |
+| Accuracy disclaimer | Measurements are estimates; garment production decisions are the user's responsibility. Surface wherever measurements render. **[Proposed]** |
+
+## 7. Success metrics
+
+| Metric | Source | Requirement |
+| --- | --- | --- |
+| Demo Starts | Upstat event from walkthrough/demo CTA | ECO-ANALYTICS **[PRD]** |
+| GitHub Clicks | Upstat event from APP-001 gateway | ECO-ANALYTICS **[PRD]** |
+| Cloud instance requests | api/common (APP-002 flow) | **[Proposed]** |
+| Measurement sessions created / stored records | api/common | **[Proposed]** — the core-value metric |
+
+## 8. Open questions
+
+1. **`account.cuesoft.io` contract** — protocol (OIDC? opaque token introspection?),
+   token audience/claims, and timeline. Blocks APP-002 and PLAT-003's final shape
+   (roadmap D1). Interim: local JWT auth hardened enough for records **[Proposed]**.
+2. **Cloud instance model** — "request a cloud instance" reads as
+   instance-per-customer provisioning rather than one multi-tenant app. v1 treats
+   it as a *request queue + manual provisioning* (helm chart already exists per
+   instance) **[Proposed]** — confirm.
+3. **SMPL licensing** — SMPL model weights are free for research; commercial use
+   requires a license from Meshcapade/MPI. The hosted commercial cloud likely
+   needs SMPL commercial licensing or an alternative body model. Must be resolved
+   before PLAT-005 ships in cloud (roadmap risk R1).
+4. **Where records live** — README names both Firestore and Aiven Postgres.
+   data-model.md proposes Postgres as the system of record; confirm.
+5. **Figma designs** — Home canvas is empty; landing implementation (roadmap P0)
+   needs the design pass, or we proceed with a standards-based layout and
+   retrofit.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -126,3 +126,25 @@ capabilities beyond the web property. Made explicit so they can be scheduled:
 5. **Figma designs** — Home canvas is empty; landing implementation (roadmap P0)
    needs the design pass, or we proceed with a standards-based layout and
    retrofit.
+
+---
+
+## 9. Scope expansion — social commerce (2026-07-16) **[Directive]**
+
+Apparule is a **social network**: users add/take measurements; designers post
+outfits; users like, save, share, and **commission** outfits — a request
+carries the user's measurement snapshot; the designer produces the garment and
+**gets paid**. Look and feel: **instagram.com** (design.md). Platform
+structure: public home page + web dashboard + mobile app (mobile is the
+primary social surface; all products converge on this three-surface parity).
+
+- New requirement register: SOC-001…010 in [pages.md](pages.md) (feature
+  delta table). PLAT-001/002 (records) become the **measurement vault**
+  feeding SOC-004.
+- Page/screen inventory: [pages.md](pages.md). Design system +
+  microinteractions: [design.md](design.md).
+- New open questions: payment provider + escrow model + platform fee
+  (SOC-006); UGC trust & safety baseline (SOC-009) required before public
+  launch; designer verification (KYC for payouts).
+- Docs platform **[Directive]**: product docs on GitBook (Git-synced from
+  this `docs/` folder); API reference via Scalar from OpenAPI.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,86 @@
+# Apparule — Roadmap
+
+> Phases turn the PRD/current-state gap (api.md §3) into an ordered plan. Each
+> phase is shippable on its own. No code is implied to exist yet — this is the
+> agreed sequence for when implementation starts.
+
+## Phase 0 — Web property foundation
+
+**Goal:** apparule.cuesoft.io stops being a template and becomes the product's
+home. Everything here is achievable without new backend capabilities.
+
+| Item | Requirement | Notes |
+| --- | --- | --- |
+| Landing page: hero, problem statement, cloud-vs-OSS comparison, CTAs | APP-001, PRD §3/§6 | Figma Home canvas is currently empty — either the design pass happens first or we ship a standards-based layout and retrofit (prd.md §8.5) |
+| Interactive walkthrough (static/scripted, no live pipeline) | PRD §3 | Multi-step visualization of measurement entry → report |
+| Docs hub `/docs` with deploy guides + SMPL explainer | APP-003 (explainer), APP-004 (seed) | Content sources: repo docs, README |
+| API reference `/docs/api` rendering api/measure OpenAPI + hand-written api/common spec | APP-004 | Search can be client-side (flexsearch) at this scale |
+| Privacy disclosure page | APP-005, D3 | Links to Apparule clause on privacy.cuesoft.io |
+| Analytics events: Demo Starts, GitHub Clicks | ECO-ANALYTICS | **Blocked by D2** (Upstat event API) — ship with a no-op/queued client wrapper so events flow the day D2 lands |
+
+**Exit criteria:** PRD §3 sitemap fully served; APP-001/005 acceptance met;
+Lighthouse mobile score ≥ 90 (PRD's mobile-first bias).
+
+## Phase 1 — Trustworthy auth + cloud access flow
+
+**Goal:** APP-002 end-to-end, on real identity.
+
+| Item | Requirement | Notes |
+| --- | --- | --- |
+| Replace auth stubs: verify Google ID tokens properly; implement email link/OTP or drop the endpoint | PLAT-003 | Independent of D1; removes the `TODO(security-prd)` debt |
+| `account.cuesoft.io` integration once contract exists | ECO-AUTH, D1 | Until then the hardened local auth carries the flow |
+| Consent gate (ToS + retention + accuracy disclaimer) | PRD §7 | `CONSENT_RECORD` model |
+| Instance request flow + minimal dashboard page | APP-002 | Queue + manual ops provisioning via existing helm chart (prd.md §8.2) |
+
+**Exit criteria:** a signed-in user can accept terms and file an instance
+request; requests visible with status; zero unauthenticated access to any
+record endpoint.
+
+## Phase 2 — Measurement platform (the core product)
+
+**Goal:** PLAT-001/002/004 — records exist server-side and survive the phone.
+
+| Item | Requirement |
+| --- | --- |
+| Postgres provisioning + repository layer | data-model.md |
+| Customers CRUD + workspace scoping | PLAT-002 |
+| Measurement sessions: upload → internal api/measure call → persisted results | PLAT-001 |
+| Manual corrections (append-only) | data-model.md §2 |
+| Exports (PDF/CSV, signed URLs) | PLAT-004 |
+| Flutter: wire capture flow to sessions API; dashboard: records UI | PLAT-001/002 |
+| Retention automation for capture assets | PRD §7 |
+
+**Exit criteria:** capture on phone → stored session → visible in dashboard →
+exported PDF, with images auto-purged at `retention_until`.
+
+## Phase 3 — SMPL pipeline
+
+**Goal:** APP-003 (demo) fully honest, PLAT-005 delivering girth measurements.
+
+| Item | Notes |
+| --- | --- |
+| **Licensing decision first** (risk R1) | SMPL commercial license vs alternative body model — gates everything below for cloud use |
+| Research spike: single-image SMPL fitting (HMR-family) accuracy on target demographics | Includes accuracy benchmark harness vs tape measurements |
+| Pipeline v2: QC gate → fitting → mesh girths → confidence (architecture.md §5) | `method: smpl_v1`, additive response schema |
+| Demo media for landing | APP-003 — can precede production pipeline |
+| GPU inference deployment (cloud node pool) | Self-hosted default remains CPU 2-D method |
+
+**Exit criteria:** side-by-side accuracy report published in docs; cloud
+sessions can select `smpl_v1`; landing demo reflects the real pipeline.
+
+## Dependencies
+
+| ID | Dependency | Owner | Blocks |
+| --- | --- | --- | --- |
+| D1 | `account.cuesoft.io` auth contract | Cuesoft ecosystem | Phase 1 (final shape), APP-002 |
+| D2 | Upstat generic event-ingestion API | upstat repo (its PRD names it the ecosystem tracker) | ECO-ANALYTICS in Phase 0 |
+| D3 | Apparule clause on privacy.cuesoft.io | Cuesoft legal/content | APP-005 copy |
+| R1 | SMPL commercial licensing | Product decision | Phase 3 in cloud |
+
+## Sequencing rationale
+
+Phase 0 needs no one's permission and creates the public face; Phase 1 makes
+identity real (a hard precondition for storing body data); Phase 2 is the
+value core and the biggest engineering slice; Phase 3 is the differentiator
+but carries research + licensing risk, so it rides last with a demo shipped
+early (Phase 0 explainer, Phase 3 media upgrade).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -84,3 +84,26 @@ identity real (a hard precondition for storing body data); Phase 2 is the
 value core and the biggest engineering slice; Phase 3 is the differentiator
 but carries research + licensing risk, so it rides last with a demo shipped
 early (Phase 0 explainer, Phase 3 media upgrade).
+
+---
+
+## Revision — social commerce expansion (2026-07-16)
+
+The 2026-07-16 directive (instagram-feel social commerce: posts, likes,
+requests with measurement snapshots, designer payments) re-shapes the phases.
+Phases 0–1 stand (home page per pages.md Part A; real auth). The build order
+after them becomes:
+
+- **Phase 2 — Vault + capture** (unchanged core, reframed): measurement vault
+  = the social profile's data spine (pages.md B4/C6-C7).
+- **Phase 3 — Social graph & feed**: designer profiles, posts, follows,
+  likes/saves/comments, explore (SOC-001…003, 007).
+- **Phase 4 — Commerce**: requests + snapshots + order lifecycle + threads +
+  payments/escrow/payouts (SOC-004…006) — payment provider + KYC decisions
+  gate this phase.
+- **Phase 5 — SMPL pipeline** (was Phase 3): unchanged content; now also
+  feeds richer snapshots into requests.
+
+Trust & safety (SOC-009: report/block/moderation) ships **with** Phase 3 —
+UGC without moderation doesn't go public. Platform parity note: web dashboard
+and mobile ship each phase together (shared component naming, design.md §6).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -42,7 +42,7 @@ record endpoint.
 
 | Item | Requirement |
 | --- | --- |
-| Postgres provisioning + repository layer | data-model.md |
+| Firestore data layer (X-5) + repository layer | data-model.md |
 | Customers CRUD + workspace scoping | PLAT-002 |
 | Measurement sessions: upload → internal api/measure call → persisted results | PLAT-001 |
 | Manual corrections (append-only) | data-model.md §2 |


### PR DESCRIPTION
First pass of the PRD documentation phase for apparule. Docs only — no code.

- **[prd.md](../blob/docs/prd-breakdown/docs/prd.md)** — requirements broken down (APP-001…005 + ecosystem + implied platform requirements), compliance, success metrics, open questions (account.cuesoft.io contract, SMPL licensing, instance model).
- **[architecture.md](../blob/docs/prd-breakdown/docs/architecture.md)** — current vs target context (mermaid), per-service breakdown, core sequence diagrams, SMPL pipeline design + limitations of the current 2-D method.
- **[data-model.md](../blob/docs/prd-breakdown/docs/data-model.md)** — target ER model (workspaces/customers/sessions/measurements/consent), storage mapping, data classification + retention.
- **[api.md](../blob/docs/prd-breakdown/docs/api.md)** — exact current surface (incl. the auth stubs) vs proposed /api/v1, full requirement→gap table.
- **[roadmap.md](../blob/docs/prd-breakdown/docs/roadmap.md)** — 4 phases with exit criteria + dependency register (D1 account contract, D2 Upstat events API, R1 SMPL licensing).

Grounded against code: every [Current] claim was verified in-repo (e.g. `POST /measure` is stateless; both auth endpoints are `TODO(security-prd)` stubs; web is the create-next-app template; Figma Home canvas is empty).

Intended for iteration — comment inline and I'll revise on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)