### PR TITLE
feat(F0-1): design-token package (CSS vars + Tailwind v4 mapping)

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1,26 +1,39 @@
 @import "tailwindcss";
+@import "../styles/tokens.css";
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
+/*
+ * Tailwind v4 theme mapping — utilities like bg-bg, bg-elev, text-text-2,
+ * border-border, text-like resolve to the design tokens (docs/design.md §2).
+ * Tailwind's default 4px spacing scale matches the ecosystem foundation grid.
+ */
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
+  --color-bg: var(--bg);
+  --color-elev: var(--bg-elev);
+  --color-border: var(--border);
+  --color-text: var(--text);
+  --color-text-2: var(--text-2);
+  --color-accent-start: var(--accent-start);
+  --color-accent-end: var(--accent-end);
+  --color-link: var(--link);
+  --color-like: var(--like);
+  --color-success: var(--success);
+  --color-warn: var(--warn);
+  --color-error: var(--error);
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  /* system stack on app surfaces (design.md §2 Type); display font TBD at brand pass */
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  --font-mono: var(--font-geist-mono);
+
+  --radius-card: 8px;
+
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --ease-exit: cubic-bezier(0.4, 0, 1, 1);
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
 }

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -1,0 +1,92 @@
+/*
+ * Apparule design tokens — source of truth: docs/design.md §2 + Figma
+ * `apparule/tokens` (Style Guide page). Light/dark via [data-theme] with a
+ * prefers-color-scheme fallback for first paint. F0-1.
+ */
+
+:root {
+  /* color — light */
+  --bg: #ffffff;
+  --bg-elev: #ffffff;
+  --border: #dbdbdb;
+  --text: #111111;
+  --text-2: #737373;
+  --accent-start: #e1306c;
+  --accent-end: #f77737;
+  --link: #00376b;
+  --like: #ed4956;
+  --success: #2e7d32;
+  --warn: #b26a00;
+  --error: #c62828;
+
+  /* shared foundations (design.md §2, ecosystem parity) */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  --duration-fast: 120ms;
+  --duration-base: 200ms;
+  --duration-entrance: 250ms;
+  --duration-slow: 300ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --ease-exit: cubic-bezier(0.4, 0, 1, 1);
+
+  --z-base: 0;
+  --z-sticky: 10;
+  --z-dropdown: 20;
+  --z-overlay: 30;
+  --z-sheet: 40;
+  --z-toast: 50;
+
+  --radius-card: 8px;
+  --radius-pill: 9999px;
+
+  --gradient-accent: linear-gradient(90deg, var(--accent-start), var(--accent-end));
+}
+
+[data-theme="dark"] {
+  --bg: #000000;
+  --bg-elev: #121212;
+  --border: #262626;
+  --text: #fafafa;
+  --text-2: #a8a8a8;
+  --link: #e0f1ff;
+  --success: #4ecb71;
+  --warn: #ffb020;
+  --error: #ff6b6e;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    --bg: #000000;
+    --bg-elev: #121212;
+    --border: #262626;
+    --text: #fafafa;
+    --text-2: #a8a8a8;
+    --link: #e0f1ff;
+    --success: #4ecb71;
+    --warn: #ffb020;
+    --error: #ff6b6e;
+  }
+}
+
+/* focus rule (ecosystem foundation): 2px accent ring, 2px offset */
+:focus-visible {
+  outline: 2px solid var(--accent-start);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
First implementation unit per [docs/features.md](../blob/main/docs/features.md) — F0-1.

- `web/src/styles/tokens.css`: complete token set from design.md §2 (mirrors Figma `apparule/tokens`): light/dark via `[data-theme]` with `prefers-color-scheme` first-paint fallback; shared ecosystem foundations (4px spacing scale, motion durations + easings, z-index layers, radii, 2px accent focus ring, reduced-motion guard); the Apparule gradient.
- `globals.css`: Tailwind v4 `@theme` mapping (utilities: `bg-bg`, `bg-elev`, `text-text-2`, `border-border`, `text-like`, …); system font stack per design.md.

Verified: `npm run build` clean.

Unblocks: F0-2 (web app shell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)