### PR TITLE
docs: link the published GitBook site

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Configuration is provided at runtime via environment variables — for example
 all targets. Never commit credentials or bake them into an image.
 
 ## Documentation
+- [Hosted docs](https://cuesoft.gitbook.io/apparule) — the full documentation site (auto-synced from `docs/`)
 
 - [Project overview](docs/overview.md) — architecture and components
 - [Local setup](docs/setup.md) — development environment and per-service run commands

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -28,6 +28,8 @@ See [setup.md](setup.md) to run the stack locally, and the
 [repository structure](../README.md#repository-structure) in the README.
 
 ## Product & design documentation
+> Published site: **https://cuesoft.gitbook.io/apparule** (Git-synced from this folder on every merge to main).
+
 
 - [prd.md](prd.md) — product requirements breakdown (personas, requirements, compliance, open questions)
 - [architecture.md](architecture.md) — current vs target system design, sequences, SMPL pipeline


### PR DESCRIPTION
Adds https://cuesoft.gitbook.io/apparule (live, Git-synced) to README + docs overview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)