### PR TITLE
docs: FAANG-review fixes — all 68 findings addressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ flowchart LR
 | Measurement    | Python, FastAPI, MediaPipe, OpenCV (`api/measure`)  |
 | Web            | Next.js, React, TypeScript                          |
 | Mobile         | Flutter (primary), native Android/iOS               |
-| Auth & data    | Firebase / Google auth, Firestore & Storage, Postgres, Redis |
+| Auth & data    | Firebase Google-only auth; Firestore (system of record, X-5) & Cloud Storage; shared Aiven Redis |
 | Infrastructure | Docker, Helm, Terraform, GCP Cloud Run              |
 
 ## Repository structure

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -27,3 +27,4 @@
 - [Authentication](flows/auth.md)
 - [Measurement Vault](flows/vault.md)
 - [Commission Request](flows/request.md)
+- [Designer Side](flows/designer.md)

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,8 +32,10 @@ FastAPI serves `/openapi.json` + `/docs` out of the box — the seed of APP-004.
 
 ## 2. Target surface **[Proposed]** — `/api/v1`, all on api/common unless noted
 
-Authentication: bearer token from `account.cuesoft.io` (D1) — or the hardened
-local JWT until D1 lands. All routes below require auth unless marked public.
+Authentication: **Firebase ID-token bearer, Google-only (X-1 hardened)** —
+verified server-side (audience `sandbox-e306a`, `sign_in_provider ==
+google.com`); the future `account.cuesoft.io` facade fronts the same tokens.
+All routes below require auth unless marked public.
 Authorization scope: every resource is workspace-scoped; membership checked per
 request.
 
@@ -41,7 +43,8 @@ request.
 
 | Method & path | Purpose | Maps to |
 | --- | --- | --- |
-| `POST /api/v1/auth/exchange` | Exchange an `account.cuesoft.io` token for an Apparule session (until/unless the gateway validates directly) | APP-002, D1 |
+| `GET /api/v1/me` | Resolve the caller's account (idempotent upsert on first login, flows/auth.md §3); returns username + consent + designer state | X-1 |
+| `PATCH /api/v1/me` | Update profile fields incl. `username` claim/rename (unique, 1×/30d) → `409 name_taken` | pages.md B6 |
 | `GET /api/v1/consent` | Current user's accepted document versions | PRD §7 |
 | `POST /api/v1/consent` | Record acceptance `{document, version}` | PRD §7 |
 
@@ -97,10 +100,12 @@ server-side by api/common to the same API.
 - Versioned base path `/api/v1`; additive changes only within a version.
 - Errors: `{"error": {"code": "...", "message": "..."}}` with stable codes —
   the current ad-hoc `{"error": "text"}` shape migrates at v1.
-- All list endpoints paginate (`?cursor=` + `limit`, default 50).
-- Idempotency keys accepted on session creation and instance requests
-  (`Idempotency-Key` header) — measurement capture retries must not duplicate
-  records on flaky mobile networks.
+- All list endpoints paginate (`?cursor=` + `limit`, default 50, max 100).
+- Idempotency keys (`Idempotency-Key` header, UUID) on session creation,
+  request submission, payments, and instance requests. Semantics **[Decided]**:
+  scope = account + endpoint; dedupe window **24h**; same key + identical
+  payload → replay the original response; same key + different payload →
+  `409 idempotency_conflict`; keys for failed (5xx) executions are released.
 
 ---
 
@@ -110,13 +115,17 @@ All under `/api/v1`, workspace/account auth as §2. Deltas only:
 
 | Group | Endpoints |
 | --- | --- |
-| Posts | `POST /posts` (designer) · `GET /posts/{id}` · `GET /feed` (followed + ranked) · `GET /explore?q&tags&price_band` · `DELETE /posts/{id}` |
-| Social graph | `POST/DELETE /follows/{designer}` · `POST/DELETE /posts/{id}/like` · `POST/DELETE /posts/{id}/save` · `POST /posts/{id}/comments` · `GET /posts/{id}/comments` |
-| Requests | `POST /posts/{id}/requests` (body: vault snapshot selector, notes, budget) · `GET /requests?role=customer\|designer` · `GET /requests/{id}` · `POST /requests/{id}/quote` · `POST /requests/{id}/decline` · `POST /requests/{id}/status` (in_progress/shipped/delivered) · `POST /requests/{id}/messages` |
-| Payments | `POST /requests/{id}/pay` (provider session) · webhook `/webhooks/payments` · `POST /requests/{id}/confirm-delivery` (releases escrow) · `POST /requests/{id}/dispute` |
+| Posts | `POST /posts` (designer) · `GET /posts/{id}` · `GET /feed` (followed + ranked) · `GET /explore?q&tags&price_band` (bands: `budget` <25k, `mid` 25–100k, `premium` >100k NGN **[Decided defaults]**) · `DELETE /posts/{id}` |
+| Social graph | `POST/DELETE /follows/{designer}` · `POST/DELETE /posts/{id}/like` · `POST/DELETE /posts/{id}/save` · `POST /posts/{id}/comments` (body ≤500 chars) · `GET /posts/{id}/comments` |
+| Trust & safety | `POST /reports` `{subject_kind, subject_id, reason}` · `POST/DELETE /blocks/{account}` · moderator: `GET /moderation/queue` · `POST /moderation/reports/{id}/action` `{action: hide_post\|suspend_account\|dismiss}` (A-6; semantics in data-model §6.2) |
+| Requests | `POST /posts/{id}/requests` (body: vault snapshot selector, notes, budget) · `GET /requests?role=customer\|designer` · `GET /requests/{id}` · `POST /requests/{id}/quote` · `POST /requests/{id}/decline` · `POST /requests/{id}/status` (in_progress/shipped — `delivered` is customer-confirm or system auto-confirm only, order-lifecycle §2) · `POST /requests/{id}/messages` |
+| Payments | `POST /requests/{id}/pay` (provider session) · `POST /webhooks/payments` (unversioned by design; **auth = provider signature only**, never bearer; unauthenticated-but-verified, engineering §2) · `POST /requests/{id}/confirm-delivery` (releases escrow) · `POST /requests/{id}/dispute` |
 | Designer | `POST /designer-profile` (enable + KYC start) · `GET /designer/earnings` · `POST /designer/payout-account` |
 | Notifications | `GET /notifications` · `POST /notifications/read` |
 
 Feed/explore are the only ranked endpoints (recency + follow affinity v1; no
-ML ranking until data exists). Likes/saves/follows are idempotent PUT-style
+ML ranking until data exists). Ranked pagination **[Decided]**: cursors encode
+a stable snapshot ordinal (rank computed at first page, frozen for the cursor's
+24h lifetime), so pages never duplicate or skip posts within one scroll
+session; new posts appear on refresh, not mid-scroll. Likes/saves/follows are idempotent PUT-style
 toggles with optimistic-client semantics (design.md MI-18).

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,43 +1,238 @@
 openapi: 3.1.0
 info:
   title: Apparule API
-  version: 0.1.0-draft
+  version: 0.2.0-draft
   description: >-
-    Draft contract for /api/v1 (docs/api.md is the narrative source). Rendered
-    by Scalar. Auth: Firebase ID tokens (Google-only, flows/auth.md). Errors
-    use the ecosystem envelope (engineering.md §1).
+    Contract for /api/v1 (docs/api.md is the narrative source; this file is the
+    Scalar-rendered reference). Auth: Firebase ID-token bearer, Google-only
+    (X-1 hardened) — backends reject sign_in_provider != google.com. Errors use
+    the ecosystem envelope (engineering.md §1); codes are snake_case and stable.
 servers:
   - url: https://api.apparule.cuesoft.io
+    description: sandbox (the only environment, X-6)
   - url: http://localhost:8080
 security: [{ firebase: [] }]
 tags:
-  - { name: auth }
-  - { name: vault }
-  - { name: social }
-  - { name: requests }
-  - { name: cloud }
+  - { name: auth, description: Account resolution + consent (flows/auth.md) }
+  - { name: vault, description: Measurement vault + customer records (flows/vault.md) }
+  - { name: social, description: Posts, feed, engagement (pages.md B1-B6) }
+  - { name: requests, description: Commission lifecycle (order-lifecycle.md) }
+  - { name: designer, description: Designer profile, earnings (flows/designer.md) }
+  - { name: safety, description: Trust & safety (data-model §6.2) }
+  - { name: notifications }
+  - { name: cloud, description: Instance requests (APP-002) }
+  - { name: webhooks }
+
 paths:
-  /api/v1/me: { get: { tags: [auth], summary: Resolve account (upsert on first login), responses: { "200": { description: Account } } } }
+  /api/v1/me:
+    get:
+      tags: [auth]
+      summary: Resolve caller's account (idempotent upsert on first login)
+      responses:
+        "200": { description: Account, content: { application/json: { schema: { $ref: "#/components/schemas/Account" } } } }
+        "401": { $ref: "#/components/responses/Unauthenticated" }
+    patch:
+      tags: [auth]
+      summary: Update profile incl. username claim/rename (1x/30d)
+      requestBody: { content: { application/json: { schema: { type: object, properties: { username: { type: string, pattern: "^[a-z0-9._]{3,30}$" } } } } } }
+      responses:
+        "200": { description: Account }
+        "409": { description: name_taken, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
   /api/v1/consent:
     get: { tags: [auth], summary: Accepted document versions, responses: { "200": { description: Consent list } } }
-    post: { tags: [auth], summary: Record acceptance, responses: { "201": { description: Recorded } } }
+    post:
+      tags: [auth]
+      summary: Record acceptance (emits consent_recorded event)
+      requestBody: { content: { application/json: { schema: { type: object, required: [document, version], properties: { document: { enum: [tos, privacy] }, version: { type: string } } } } } }
+      responses: { "201": { description: Recorded } }
+
+  /api/v1/me/sessions:
+    post:
+      tags: [vault]
+      summary: Create own measurement session (self-customer alias, data-model §6.1)
+      parameters: [{ $ref: "#/components/parameters/IdempotencyKey" }]
+      requestBody:
+        content:
+          multipart/form-data:
+            schema: { type: object, required: [image], properties: { image: { type: string, format: binary, description: "<=10MB JPEG/PNG/HEIC" }, input_height_cm: { type: number, minimum: 100, maximum: 230 } } }
+      responses:
+        "201": { description: Session with measurements, content: { application/json: { schema: { $ref: "#/components/schemas/MeasurementSession" } } } }
+        "422": { description: "QC failure — capture-qc.md codes (no_body, multiple_bodies, partial_body, undecodable_image, low_resolution, poor_lighting, blurry, not_frontal, camera_tilt, arms_position, too_far)", content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+        "403": { description: consent_required }
+    get: { tags: [vault], summary: Own measurement history, parameters: [{ $ref: "#/components/parameters/Cursor" }, { $ref: "#/components/parameters/Limit" }], responses: { "200": { description: Sessions page } } }
   /api/v1/customers:
-    get: { tags: [vault], summary: List workspace customers, responses: { "200": { description: Page } } }
-    post: { tags: [vault], summary: Create customer, responses: { "201": { description: Customer } } }
+    get: { tags: [vault], summary: List workspace customers, parameters: [{ $ref: "#/components/parameters/Cursor" }, { $ref: "#/components/parameters/Limit" }], responses: { "200": { description: Page } } }
+    post: { tags: [vault], summary: Create customer (kind=client), responses: { "201": { description: Customer } } }
+  /api/v1/customers/{id}:
+    get: { tags: [vault], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Customer detail, responses: { "200": { description: Customer }, "404": { $ref: "#/components/responses/NotFound" } } }
+    patch: { tags: [vault], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Update, responses: { "200": { description: Customer } } }
+    delete: { tags: [vault], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Soft delete (purge per retention), responses: { "204": { description: Deleted } } }
   /api/v1/customers/{id}/sessions:
-    post: { tags: [vault], summary: "Create measurement session (multipart: image, input_height_cm; Idempotency-Key)", responses: { "201": { description: Session }, "422": { description: QC failure (capture-qc.md codes) } } }
-    get: { tags: [vault], summary: Measurement history, responses: { "200": { description: Sessions } } }
-  /api/v1/sessions/{id}/measurements: { patch: { tags: [vault], summary: Append manual corrections, responses: { "200": { description: Session } } } }
-  /api/v1/sessions/{id}/exports: { post: { tags: [vault], summary: Generate PDF/CSV export, responses: { "201": { description: Signed URL } } } }
-  /api/v1/feed: { get: { tags: [social], summary: Ranked home feed, responses: { "200": { description: Posts page } } } }
-  /api/v1/explore: { get: { tags: [social], summary: Search/discover posts, responses: { "200": { description: Posts page } } } }
-  /api/v1/posts: { post: { tags: [social], summary: Create outfit post (designer, KYC-gated), responses: { "201": { description: Post } } } }
-  /api/v1/posts/{id}/like: { post: { tags: [social], summary: Like (idempotent), responses: { "204": { description: OK } } }, delete: { tags: [social], summary: Unlike, responses: { "204": { description: OK } } } }
-  /api/v1/posts/{id}/requests: { post: { tags: [requests], summary: "Commission request (snapshot frozen server-side; Idempotency-Key)", responses: { "201": { description: Request }, "409": { description: duplicate_request | post_unavailable } } } }
-  /api/v1/requests/{id}/quote: { post: { tags: [requests], summary: Designer quote, responses: { "200": { description: Request } } } }
-  /api/v1/requests/{id}/pay: { post: { tags: [requests], summary: Init payment (escrow hold), responses: { "200": { description: Provider session } } } }
-  /api/v1/requests/{id}/confirm-delivery: { post: { tags: [requests], summary: Confirm delivery (releases payout), responses: { "200": { description: Request } } } }
-  /api/v1/instance-requests: { post: { tags: [cloud], summary: Request a cloud instance (consent-gated), responses: { "202": { description: Queued } } } }
+    post: { tags: [vault], parameters: [{ $ref: "#/components/parameters/Id" }, { $ref: "#/components/parameters/IdempotencyKey" }], summary: Create session for a client customer (same contract as /me/sessions), responses: { "201": { description: Session }, "422": { description: QC failure } } }
+    get: { tags: [vault], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Customer measurement history, responses: { "200": { description: Sessions } } }
+  /api/v1/sessions/{id}/measurements:
+    patch: { tags: [vault], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Append manual corrections (append-only, source=manual_correction), responses: { "200": { description: Session } } }
+  /api/v1/sessions/{id}/exports:
+    post: { tags: [vault], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Generate PDF/CSV export, requestBody: { content: { application/json: { schema: { type: object, properties: { format: { enum: [pdf, csv] } } } } } }, responses: { "201": { description: Signed URL (TTL) } } }
+
+  /api/v1/feed:
+    get: { tags: [social], summary: "Ranked home feed (rank frozen per cursor, 24h lifetime — api.md §5)", parameters: [{ $ref: "#/components/parameters/Cursor" }, { $ref: "#/components/parameters/Limit" }], responses: { "200": { description: Posts page } } }
+  /api/v1/explore:
+    get:
+      tags: [social]
+      summary: Search/discover
+      parameters:
+        - { name: q, in: query, schema: { type: string } }
+        - { name: tags, in: query, schema: { type: string } }
+        - { name: price_band, in: query, schema: { enum: [budget, mid, premium] } }
+        - { $ref: "#/components/parameters/Cursor" }
+      responses: { "200": { description: Posts page } }
+  /api/v1/posts:
+    post: { tags: [social], summary: "Create outfit post (designer, KYC-gated; <=10 images <=10MB each, JPEG/PNG/WebP; alt text)", responses: { "201": { description: Post }, "403": { description: kyc_incomplete } } }
+  /api/v1/posts/{id}:
+    get: { tags: [social], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Post detail (public permalink /p/{id}), security: [], responses: { "200": { description: Post } } }
+    delete: { tags: [social], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Delete own post, responses: { "204": { description: Deleted } } }
+  /api/v1/posts/{id}/like:
+    post: { tags: [social], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Like (idempotent toggle), responses: { "204": { description: OK } } }
+    delete: { tags: [social], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Unlike, responses: { "204": { description: OK } } }
+  /api/v1/posts/{id}/save:
+    post: { tags: [social], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Save (idempotent), responses: { "204": { description: OK } } }
+    delete: { tags: [social], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Unsave, responses: { "204": { description: OK } } }
+  /api/v1/posts/{id}/comments:
+    post: { tags: [social], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Comment (<=500 chars), responses: { "201": { description: Comment } } }
+    get: { tags: [social], parameters: [{ $ref: "#/components/parameters/Id" }, { $ref: "#/components/parameters/Cursor" }], summary: List comments, responses: { "200": { description: Page } } }
+  /api/v1/follows/{designer}:
+    post: { tags: [social], parameters: [{ name: designer, in: path, required: true, schema: { type: string } }], summary: Follow (idempotent), responses: { "204": { description: OK } } }
+    delete: { tags: [social], parameters: [{ name: designer, in: path, required: true, schema: { type: string } }], summary: Unfollow, responses: { "204": { description: OK } } }
+
+  /api/v1/posts/{id}/requests:
+    post:
+      tags: [requests]
+      summary: Commission request — measurement snapshot frozen server-side
+      parameters: [{ $ref: "#/components/parameters/Id" }, { $ref: "#/components/parameters/IdempotencyKey" }]
+      requestBody: { content: { application/json: { schema: { $ref: "#/components/schemas/RequestCreate" } } } }
+      responses:
+        "201": { description: Request }
+        "409": { description: duplicate_request | post_unavailable }
+        "422": { description: snapshot_invalid }
+        "429": { description: "rate_limited (>10 open requests)" }
+  /api/v1/requests:
+    get: { tags: [requests], summary: List by role, parameters: [{ name: role, in: query, schema: { enum: [customer, designer] } }, { $ref: "#/components/parameters/Cursor" }], responses: { "200": { description: Page } } }
+  /api/v1/requests/{id}:
+    get: { tags: [requests], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Order detail (party-only; others get 404), responses: { "200": { description: Request }, "404": { $ref: "#/components/responses/NotFound" } } }
+  /api/v1/requests/{id}/quote:
+    post: { tags: [requests], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Designer quote (7d expiry), requestBody: { content: { application/json: { schema: { type: object, required: [quote_cents, due_at], properties: { quote_cents: { type: integer }, currency: { type: string, default: NGN }, due_at: { type: string, format: date } } } } } }, responses: { "200": { description: Request } } }
+  /api/v1/requests/{id}/decline:
+    post: { tags: [requests], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Designer decline (reason required), responses: { "200": { description: Request } } }
+  /api/v1/requests/{id}/status:
+    post: { tags: [requests], parameters: [{ $ref: "#/components/parameters/Id" }], summary: "Designer progress: in_progress | shipped only (delivered is customer/system-only)", requestBody: { content: { application/json: { schema: { type: object, required: [status], properties: { status: { enum: [in_progress, shipped] }, tracking: { type: string } } } } } }, responses: { "200": { description: Request } } }
+  /api/v1/requests/{id}/pay:
+    post: { tags: [requests], parameters: [{ $ref: "#/components/parameters/Id" }, { $ref: "#/components/parameters/IdempotencyKey" }], summary: Init Paystack payment (escrow hold lands on charge.success webhook), responses: { "200": { description: Provider checkout session } } }
+  /api/v1/requests/{id}/confirm-delivery:
+    post: { tags: [requests], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Customer confirms delivery — releases payout (quote − 10% fee, A-1), responses: { "200": { description: Request } } }
+  /api/v1/requests/{id}/dispute:
+    post: { tags: [requests], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Open dispute (freezes payout), requestBody: { content: { application/json: { schema: { type: object, required: [reason], properties: { reason: { enum: [not_received, not_as_described, size_wrong, other] }, detail: { type: string } } } } } }, responses: { "200": { description: Request } } }
+  /api/v1/requests/{id}/messages:
+    post: { tags: [requests], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Thread message (<=1000 chars, optional image), responses: { "201": { description: Message } } }
+    get: { tags: [requests], parameters: [{ $ref: "#/components/parameters/Id" }, { $ref: "#/components/parameters/Cursor" }], summary: Thread, responses: { "200": { description: Page } } }
+
+  /api/v1/designer-profile:
+    post: { tags: [designer], summary: Enable designer profile (username required; starts Paystack KYC), responses: { "201": { description: Profile } } }
+  /api/v1/designer/payout-account:
+    post: { tags: [designer], summary: Attach payout account (bank resolution via Paystack), responses: { "200": { description: KYC state } } }
+  /api/v1/designer/earnings:
+    get: { tags: [designer], summary: Balance + payout history, responses: { "200": { description: Earnings } } }
+
+  /api/v1/reports:
+    post: { tags: [safety], summary: Report content/account, requestBody: { content: { application/json: { schema: { type: object, required: [subject_kind, subject_id, reason], properties: { subject_kind: { enum: [post, comment, account] }, subject_id: { type: string }, reason: { enum: [spam, inappropriate, counterfeit, harassment, other] }, detail: { type: string } } } } } }, responses: { "201": { description: Filed } } }
+  /api/v1/blocks/{account}:
+    post: { tags: [safety], parameters: [{ name: account, in: path, required: true, schema: { type: string } }], summary: Block (silent; semantics data-model §6.2), responses: { "204": { description: OK } } }
+    delete: { tags: [safety], parameters: [{ name: account, in: path, required: true, schema: { type: string } }], summary: Unblock, responses: { "204": { description: OK } } }
+  /api/v1/moderation/queue:
+    get: { tags: [safety], summary: Open reports (moderator only), responses: { "200": { description: Queue }, "403": { description: forbidden } } }
+  /api/v1/moderation/reports/{id}/action:
+    post: { tags: [safety], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Act on a report, requestBody: { content: { application/json: { schema: { type: object, required: [action], properties: { action: { enum: [hide_post, suspend_account, dismiss] } } } } } }, responses: { "200": { description: Actioned } } }
+
+  /api/v1/notifications:
+    get: { tags: [notifications], summary: Activity list (90d retention), parameters: [{ $ref: "#/components/parameters/Cursor" }], responses: { "200": { description: Page } } }
+  /api/v1/notifications/read:
+    post: { tags: [notifications], summary: Mark read (clears badges), responses: { "204": { description: OK } } }
+
+  /api/v1/instance-requests:
+    post: { tags: [cloud], parameters: [{ $ref: "#/components/parameters/IdempotencyKey" }], summary: Request a cloud instance (consent-gated), responses: { "202": { description: Queued } } }
+    get: { tags: [cloud], summary: Own requests + status (queued|provisioning|active|rejected|cancelled|deprovisioned), responses: { "200": { description: List } } }
+
+  /webhooks/payments:
+    post:
+      tags: [webhooks]
+      summary: Paystack webhook — signature-auth only (never bearer); unverified => 401 + ops alert
+      security: []
+      responses: { "200": { description: Processed (idempotent by provider reference) }, "401": { description: Invalid signature } }
+
 components:
   securitySchemes:
     firebase: { type: http, scheme: bearer, bearerFormat: "Firebase ID token (google.com provider only)" }
+  parameters:
+    Id: { name: id, in: path, required: true, schema: { type: string } }
+    Cursor: { name: cursor, in: query, schema: { type: string } }
+    Limit: { name: limit, in: query, schema: { type: integer, default: 50, maximum: 100 } }
+    IdempotencyKey:
+      name: Idempotency-Key
+      in: header
+      required: true
+      schema: { type: string, format: uuid }
+      description: "Scope account+endpoint, 24h window; same key + same payload replays the response; different payload => 409 idempotency_conflict (api.md §4)"
+  responses:
+    Unauthenticated: { description: "unauthenticated | token_expired (client refreshes and retries once)", content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+    NotFound: { description: "not_found (also returned for cross-tenant access — never 403)", content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+  schemas:
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code: { type: string, description: snake_case stable code (engineering.md §1) }
+            message: { type: string }
+            details: { type: object }
+    Account:
+      type: object
+      properties:
+        id: { type: string }
+        username: { type: string }
+        email: { type: string }
+        designer: { type: object, properties: { enabled: { type: boolean }, kyc_complete: { type: boolean } } }
+        consent: { type: array, items: { type: object, properties: { document: { type: string }, version: { type: string } } } }
+    MeasurementSession:
+      type: object
+      properties:
+        id: { type: string }
+        method: { enum: [mediapipe_2d, mediapipe_2d_v2, smpl_v1, manual] }
+        status: { enum: [pending_save, complete, failed] }
+        input_height_cm: { type: number }
+        measurements:
+          type: array
+          items: { type: object, properties: { name: { type: string }, value_cm: { type: number }, source: { enum: [pipeline, manual_correction] }, confidence: { type: number } } }
+        pipeline_meta: { type: object }
+    RequestCreate:
+      type: object
+      required: [session_id, delivery]
+      properties:
+        session_id: { type: string, description: vault session snapshotted server-side }
+        notes: { type: string, maxLength: 500 }
+        budget_cents: { type: integer }
+        currency: { type: string, default: NGN }
+        target_date: { type: string, format: date }
+        delivery:
+          type: object
+          required: [recipient_name, phone, line1, city, state, country]
+          properties:
+            recipient_name: { type: string }
+            phone: { type: string }
+            line1: { type: string }
+            line2: { type: string }
+            city: { type: string }
+            state: { type: string }
+            country: { type: string, default: NG }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,7 +65,7 @@ flowchart LR
     end
 
     subgraph Cuesoft ecosystem — external
-        ACC[account.cuesoft.io<br/>identity & session]
+        ACC[Firebase Auth sandbox-e306a<br/>account.cuesoft.io facade later]
         UP[Upstat<br/>events & uptime]
         CL[clients.cuesoft.io<br/>support]
         PRIV[privacy.cuesoft.io<br/>privacy hub]
@@ -77,9 +77,8 @@ flowchart LR
     LAND --> PRIV
     T --> DASH
     T -->|Flutter app| AC
-    DASH -->|sign in| ACC
-    DASH --> AC
-    AC -->|verify session/token| ACC
+    DASH -->|Google sign-in in-app (X-1)| AC
+    AC -.->|Firebase ID-token verify| ACC
     AC --> DB
     AC --> OBJ
     AC -->|internal call| AM
@@ -155,7 +154,9 @@ architecture:
 /privacy              Measurement-data handling disclosure (APP-005)
 /cloud                Cloud access: Google sign-in (Firebase, X-1),
                       ToS consent gate, instance request (APP-002)
-/dashboard            Post-auth: customers, measurement records (PLAT-001/2)
+/dashboard            Post-auth app (single canonical location [Decided]:
+                      path-based /dashboard on apparule.cuesoft.io — no
+                      app. subdomain; pages.md "B" sections map here)
 ```
 
 ### 3.4 mobile/flutter — capture client
@@ -193,11 +194,11 @@ sequenceDiagram
 sequenceDiagram
     actor T as Tailor
     participant W as apparule.cuesoft.io
-    participant A as account.cuesoft.io
+    participant A as Firebase Auth (Google-only, X-1)
     participant C as api/common
 
     T->>W: "Try Apparule Cloud"
-    W->>A: redirect to sign-in
+    W->>A: in-app Google sign-in (popup/redirect)
     A-->>W: session/token for T
     W->>C: GET /api/v1/consent (has T accepted Apparule ToS?)
     alt no consent on file
@@ -283,6 +284,31 @@ GPU-capable node pool for SMPL inference (cloud only). **[Proposed]**
 
 | Dependency | Needed by | Status |
 | --- | --- | --- |
-| D1 `account.cuesoft.io` contract | APP-002, PLAT-003 | External; not in any repo. Blocks final auth shape; interim hardened local JWT proposed. |
+| D1 `account.cuesoft.io` facade | future identity facade only | **Not blocking** (X-1): Firebase Auth on `sandbox-e306a` is the ratified interim and the facade fronts the same tokens. |
 | D2 Upstat event-ingestion API | ECO-ANALYTICS | Upstat has no generic event endpoint today — tracked in upstat's roadmap (its PRD names it the ecosystem tracking service). |
 | D3 `privacy.cuesoft.io` Apparule clause | APP-005 | Content dependency; page links out. |
+
+## 8. Social-commerce runtime additions (2026-07-16 expansion) **[Decided]**
+
+```mermaid
+flowchart LR
+    PS[Paystack] -->|signed webhooks| WH["/webhooks/payments (api/common)"]
+    SCHED[Cloud Scheduler] --> J1[job: quote expiry — hourly]
+    SCHED --> J2[job: auto-confirm + reminders — daily]
+    SCHED --> J3[job: retention purge — daily]
+    SCHED --> J4[job: payment reconciliation — hourly]
+    SCHED --> J5[job: counter reconciliation — hourly]
+    J1 & J2 & J3 & J4 & J5 --> AC[api/common job entrypoints<br/>Cloud Run jobs, same image]
+    AC -->|FCM Admin SDK| PUSH[push notifications]
+    AC -->|events| UP[Upstat]
+```
+
+- **Webhooks**: `/webhooks/payments` verifies the Paystack signature before
+  any processing; unverified → 401 + ops alert (flows/request.md §3).
+- **Scheduled jobs** run as **Cloud Run jobs** (same container image,
+  dedicated entrypoints) triggered by **Cloud Scheduler**; self-host runs
+  them via cron in compose. All jobs are idempotent — safe to re-run.
+- **Push** is FCM via the Firebase Admin SDK; in-app `NOTIFICATION` rows are
+  the source of truth, push is best-effort (data-model §6.4).
+- **Service-to-service**: api/common → api/measure uses Cloud Run IAM ID
+  tokens; api/measure has no public ingress in cloud (deployment.md §4).

--- a/docs/capture-qc.md
+++ b/docs/capture-qc.md
@@ -40,9 +40,9 @@ one actionable instruction beats a list.
 
 `scale = user_height_cm / body_height_px` uses the nose→ankle-midpoint
 distance, which is ~93% of true stature (nose≠crown, ankle≠sole). Corrected:
-`scale = (user_height_cm × 0.93) / body_height_px` **[Decided: apply the
-anthropometric correction that the current code omits — flagged as a v-next
-pipeline change since it shifts all outputs ~7%]**. Plausibility band: if the
+`scale = (user_height_cm × 0.93) / body_height_px` **[Decided: ships as
+`method: mediapipe_2d_v2` — the correction shifts all outputs ~7%, so it is a
+new method identifier, never a silent change to v1 sessions]**. Plausibility band: if the
 implied crown-to-sole pixel height maps outside 0.75–1.33× of the claimed
 height when cross-checked against torso proportions (shoulder-to-hip ÷
 stature expected ≈ 0.25±0.08), flag `pipeline_meta.qc.height_suspect = true`

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -37,8 +37,10 @@ erDiagram
 
     ACCOUNT {
         uuid id PK
-        string subject "account.cuesoft.io subject id"
+        string firebase_uid "identity key (X-1); the future facade fronts the same uid"
         string email
+        string username "unique (case-insensitive), 3-30 chars [a-z0-9._]; claimable on demand, required to enable a designer profile; rename max 1x/30d"
+        string deletion_state "active | deletion_pending"
         datetime created_at
     }
     WORKSPACE {
@@ -55,6 +57,7 @@ erDiagram
     CUSTOMER {
         uuid id PK
         uuid workspace_id FK
+        string kind "self | client — exactly one self per account"
         string display_name
         string contact "optional email/phone"
         string notes
@@ -66,7 +69,7 @@ erDiagram
         uuid customer_id FK
         string method "mediapipe_2d | smpl_v1 | manual"
         float input_height_cm
-        string status "pending | complete | failed"
+        string status "pending_save | complete | failed" // pending_save = results returned, not yet saved (24h TTL, flows/vault.md)
         json pipeline_meta "model version, confidence, QC flags"
         datetime created_at
     }
@@ -131,7 +134,6 @@ Modeling notes:
 | System of record | **Firestore** (default DB, `sandbox-e306a`) — **[Decided X-5]**, revising the earlier Postgres proposal | Firebase-native stack; real-time listeners for feed/threads/notifications; the relational entities in §2 map to collections with the workspace/customer/session hierarchy as document paths. Payments-ledger Postgres escape hatch per X-5. |
 | Capture images + exports | Object storage (Firebase Storage today, S3-compatible acceptable) | Large binaries out of the DB; signed URLs for downloads. |
 | Cache/queues (later) | Valkey/Redis (declared stack) | Instance-request queue, export jobs — not needed for P0. |
-| Firestore | Only if `account.cuesoft.io` integration demands it | Avoid two systems of record. |
 
 ## 4. Data classification & handling **[PRD §7]**
 
@@ -183,8 +185,9 @@ erDiagram
     REQUEST { uuid id PK
         uuid post_id FK
         uuid customer_id FK
-        string status "requested|quoted|paid|in_progress|shipped|delivered|declined|disputed|cancelled"
+        string status "requested|quoted|paid|in_progress|shipped|delivered|refunded|declined|disputed|cancelled"
         int quote_cents
+        string currency "ISO 4217; NGN-only v1 (A-1) — international arrives with Stripe"
         datetime due_at }
     MEASUREMENT_SNAPSHOT { uuid id PK
         uuid request_id FK
@@ -193,7 +196,8 @@ erDiagram
     PAYMENT { uuid id PK
         uuid request_id FK
         string provider "paystack|stripe — to ratify"
-        string state "authorized|held|released|refunded"
+        string state "held|released|refunded" // charge.success lands directly in held; no separate authorized step (Paystack capture model)
+        string currency "ISO 4217, matches REQUEST"
         int amount_cents
         int platform_fee_cents }
 ```
@@ -204,3 +208,85 @@ a request the customer initiated (privacy story for APP-005); social counters
 (likes/saves) are denormalized on POST with periodic reconciliation; payments
 follow escrow: `held` at pay, `released` on delivery confirmation (dispute
 pauses release).
+
+---
+
+## 6. Completeness additions (2026-07-16 review)
+
+### 6.1 The personal vault mapping (self-customer) **[Decided]**
+
+Every `ACCOUNT` owns exactly one `CUSTOMER` with `kind: self`, auto-created in
+its personal workspace on first session. **The vault IS the self-customer's
+sessions** — `/api/v1/me/sessions` routes alias `customers/{self-id}/sessions`.
+SME mode manages additional `kind: client` customers; the entity path is
+identical, so vault and client-record code share one implementation.
+
+### 6.2 Trust & safety entities (A-6)
+
+```mermaid
+erDiagram
+    ACCOUNT ||--o{ REPORT : files
+    ACCOUNT ||--o{ BLOCK : places
+    REPORT {
+        uuid id PK
+        uuid reporter_id FK
+        string subject_kind "post | comment | account"
+        uuid subject_id
+        string reason "spam | inappropriate | counterfeit | harassment | other(+text)"
+        string status "open | actioned | dismissed"
+        uuid actioned_by "moderator"
+        datetime created_at
+    }
+    BLOCK {
+        uuid blocker_id FK
+        uuid blocked_id FK
+        datetime created_at
+    }
+```
+
+**Block semantics** (engineering.md §2): blocked accounts cannot follow,
+comment, request, or message the blocker; their posts/comments disappear from
+the blocker's feed/explore/search (soft filter, not deletion). **Existing
+orders survive a block** — money outranks social — but their threads lock to
+order-essential messages only. Blocks are silent (no notification).
+
+### 6.3 Delivery address **[Decided]**
+
+`REQUEST.delivery` embeds `{recipient_name, phone, line1, line2?, city,
+state, country}` frozen at submit (like the snapshot — later address-book
+edits never mutate an order). Classification: **sensitive PII** — same
+handling row as customer identity (§4); never in logs or events.
+
+### 6.4 Notifications
+
+`NOTIFICATION { id, account_id, kind, payload_ref (order/post id), read_at,
+created_at }` — retention 90 days; unread badge counts derive from
+`read_at IS NULL`; push delivery via FCM is fire-and-forget (the in-app row
+is the source of truth).
+
+### 6.5 Attribute completions
+
+- `POST_MEDIA { id, post_id, object_key, position 0-9, alt_text (required at
+  publish; default "Outfit by {designer}" per design.md §5), width, height }`
+- `COMMENT { id, post_id, author_id, body ≤ 500 chars, created_at,
+  hidden_by_moderation bool }`
+- `LIKE / SAVE { post_id, account_id, created_at }` (composite PK)
+- `FOLLOW { follower_id, designer_id, created_at }` (composite PK)
+- `ORDER_EVENT { id, request_id, kind (state transitions + reminders), actor
+  (customer|designer|system|moderator), created_at }`
+- `THREAD_MESSAGE { id, request_id, author_id, body ≤ 1000 chars,
+  image_object_key?, created_at }`
+- `PAYOUT { id, designer_id, request_id, amount_cents, currency,
+  provider_transfer_ref, state (pending|paid|failed), created_at }`
+- `INSTANCE_REQUEST.status` gains terminal states: `queued | provisioning |
+  active | rejected | cancelled | deprovisioned`; every transition notifies
+  the requester (in-app + email) per APP-002 "acknowledged".
+
+### 6.6 Operational notes
+
+- Firestore reliability: PITR enabled (7-day window) + daily exports to the
+  Cloud Storage bucket (`apparule/backups/…`); recovery runbook lands with
+  F2-1. Denormalized social counters reconcile **hourly** (job R4, architecture
+  §8).
+- Draft captures on device use the platform keystore
+  (Keychain / Android Keystore via `flutter_secure_storage`).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -96,8 +96,9 @@ before public launch. Alternative: commission the brand pass first.
   is **Firebase Authentication on GCP project `sandbox-e306a`** ("sandbox") —
   Google sign-in + email flows come from Firebase; services verify Firebase ID
   tokens (OIDC-compatible). `account.cuesoft.io` **is not built yet** — each app replicates the
-  sign-in/sign-up screens **in-app** (own UI per its design system,
-  Firebase Auth underneath: Google sign-in + email/password flows). The
+  sign-in screens **in-app** (own UI per its design system,
+  Firebase Auth underneath — Google sign-in only; the email/password wording
+  that stood here pre-hardening is void). The
   central facade fronts the same Firebase project later without contract
   changes; in-app screens then become optional, not obsolete. **HARDENED
   2026-07-16: Google sign-in is the ONLY method — no username/password

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -49,10 +49,27 @@ Two hard-won rules inherited from cueprise, non-negotiable:
 2. **WIF only** (`google-github-actions/auth@v3` with
    `workload_identity_provider` + `service_account`) — no JSON keys.
 
-GitHub environments (`Staging <Project>`, `Production`) gate the deploy
-jobs and carry the URLs.
+The single protected GitHub environment is **`Sandbox`** (X-6) — it gates the
+deploy job, requires reviewers, and carries the sandbox URLs. No other deploy
+environments exist.
 
-## 4. Not in this phase
+## 4. Runtime contract (Cloud Run) **[Decided defaults]**
+
+| Service | CPU / mem | Concurrency | Min–max instances | Timeout |
+| --- | --- | --- | --- | --- |
+| api/common | 1 vCPU / 512 MiB | 80 | 0–5 | 60 s |
+| api/measure | 2 vCPU / 2 GiB (CPU inference) | 4 | 0–3 | 120 s |
+
+- Domains: `api.apparule.cuesoft.io` → api/common; api/measure is
+  **internal-only** (no public ingress; api/common calls it with a Cloud Run
+  IAM ID token — the service-to-service auth mechanism).
+- Rollback: redeploy the previous image digest (recorded in the release run) —
+  `gcloud run services update-traffic` to the prior revision is the fast path;
+  a broken release is rolled back before any forward fix.
+- Web env: `NEXT_PUBLIC_*` values flow Doppler → `apphosting.yaml` env
+  section at rollout time.
+
+## 5. Not in this phase
 
 Writing these workflows + the Pulumi stack is **implementation work**, out of
 scope for the docs phase — this document is the contract they'll be built

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -19,10 +19,10 @@
 | --- | --- |
 | 400 | `invalid_*` (malformed input) |
 | 401 | `unauthenticated`, `token_expired` |
-| 403 | `provider_not_allowed`, `email_unverified`, `consent_required`, `forbidden`, `account_disabled`, `kyc_incomplete` |
+| 403 | `provider_not_allowed`, `consent_required`, `forbidden`, `account_disabled`, `kyc_incomplete` |
 | 404 | `not_found` (never distinguishes "exists but not yours") |
-| 409 | `duplicate_request`, `post_unavailable`, `already_linked`, `name_taken` |
-| 422 | QC codes (capture-qc.md §1–2), `snapshot_invalid`, `ts_out_of_range` |
+| 409 | `duplicate_request`, `post_unavailable`, `name_taken` (username claim, api.md `/me`), `idempotency_conflict`, `account_has_active_orders` (deletion, flows/auth.md §4) |
+| 422 | QC codes (capture-qc.md §1–2), `snapshot_invalid` |
 | 429 | `rate_limited` (+ `Retry-After`) |
 | 5xx | `internal`, `pipeline_busy`, `provider_unavailable` |
 
@@ -38,7 +38,7 @@ membership for vault-of-customers use (SME mode).
 | Resource / action | visitor | user | designer | moderator |
 | --- | --- | --- | --- | --- |
 | Feed/explore read, post detail | ✓ (public posts) | ✓ | ✓ | ✓ |
-| Like/save/comment/follow | — | ✓ (verified email for comment) | ✓ | ✓ |
+| Like/save/comment/follow | — | ✓ | ✓ | ✓ |
 | Create post | — | — | ✓ (KYC complete) | — |
 | Own vault (read/write) | — | ✓ self only — **no role ever reads another's vault** | ✓ self | — |
 | Workspace customers/sessions | — | workspace members | — | — |
@@ -47,7 +47,7 @@ membership for vault-of-customers use (SME mode).
 | Quote/decline/status | — | — | ✓ own requests | dispute resolution |
 | Pay / confirm delivery / dispute | — | ✓ own orders | — | resolve |
 | Earnings/payout account | — | — | ✓ self | — |
-| Reports/blocks | — | ✓ | ✓ | queue + actions |
+| Reports/blocks | — | ✓ | ✓ | queue + actions (block semantics: data-model §6.2 — feed filtering, interaction bans, orders survive) |
 
 Enforcement: middleware resolves `{account, designer?, workspace?}` from the
 verified token once per request; handlers declare required capability —

--- a/docs/features.md
+++ b/docs/features.md
@@ -12,7 +12,7 @@
 | F0-1 | Design tokens package | tokens from `apparule/tokens` (Figma) as CSS vars + Tailwind config; light/dark | design.md §2, §7 | — |
 | F0-2 | Web app shell | Next.js layout, nav (A1), footer (A10), theme switch, Lucide setup | pages.md A1/A10 | F0-1 |
 | F0-3 | Hero + problem strip | A2 hero with device-frame loop, A3 stat cards | pages.md A2–A3 | F0-2 |
-| F0-4 | Walkthrough + SMPL explainer | A4 scroll panel, A5 constellation animation asset | pages.md A4–A5, capture-qc MI-12 asset | F0-2 |
+| F0-4 | Walkthrough + SMPL explainer | A4 scroll panel, A5 constellation animation asset | pages.md A4–A5, design.md MI-12 | F0-2 |
 | F0-5 | Designers/open-source/community/cloud-vs-oss sections | A6–A9 | pages.md | F0-2 |
 | F0-6 | Privacy page | APP-005 disclosure, retention copy from data-model §4 | pages.md A10, prd §6 | F0-2 |
 | F0-7 | Analytics client wrapper | queued no-op upstat client; events per master registry | upstat api.md §3.4 | F0-2 |
@@ -27,7 +27,7 @@
 | F1-3 | Web sign-in | single Google CTA screen, redirect fallback, session handling | flows/auth §2–4 | F1-1 |
 | F1-4 | Flutter sign-in rewire | google_sign_in + firebase_auth; retire password screens | flows/auth §5 | F1-1 |
 | F1-5 | Consent gate | consent sheet + GET/POST /consent + CONSENT_RECORD | prd §6, api.md | F1-2 |
-| F1-6 | Instance requests | POST/GET /instance-requests + dashboard status page | flows (prd APP-002), A-5 | F1-2 |
+| F1-6 | Instance requests | POST/GET /instance-requests + dashboard status page | architecture.md §4.2, prd APP-002, A-5 | F1-2 |
 | F1-7 | Stub removal | delete legacy /api/auth/*, TODO(security-prd) retired | flows/auth §6 checklist | F1-2..4 |
 
 ## Phase 2 — Vault + capture
@@ -73,10 +73,13 @@
 
 ## Phase 5 — SMPL (gated on A-3 licensing outcome)
 
-F5-1 licensing decision execution · F5-2 accuracy benchmark harness (tape-vs-
-pipeline) · F5-3 pipeline v2 (fitting→mesh→girths→confidence) · F5-4 GPU
-deploy (cloud) · F5-5 landing demo media upgrade. Refs: architecture §5,
-capture-qc §4.
+| ID | Unit | Delivers | Refs | Deps |
+| --- | --- | --- | --- | --- |
+| F5-1 | Licensing decision execution | Meshcapade quote → go/no-go | A-3 | — |
+| F5-2 | Accuracy benchmark harness | tape-vs-pipeline comparison suite | capture-qc §6 | — |
+| F5-3 | Pipeline v2 | QC → fitting → mesh girths → confidence (`method: smpl_v1`) | architecture §5, capture-qc §4 | F5-1, F5-2 |
+| F5-4 | GPU deploy (cloud) | inference node pool / GPU Cloud Run | deployment.md | F5-3 |
+| F5-5 | Landing demo media upgrade | real-pipeline demo replaces preview | pages.md A5 | F5-3 |
 
 ## Cross-phase engineering units
 

--- a/docs/flows/auth.md
+++ b/docs/flows/auth.md
@@ -51,12 +51,12 @@ sequenceDiagram
 | Case | Behaviour |
 | --- | --- |
 | Popup/sheet dismissed | silent return, screen unchanged |
-| `network-request-failed` | offline toast + retry |
-| `user-disabled` | "This account has been disabled" + support link |
+| `network-request-failed` *(Firebase SDK constant, not our catalog)* | offline toast + retry |
+| `user-disabled` *(Firebase SDK constant)* | "This account has been disabled" + support link |
 | Token with wrong provider (crafted email/password token from another tool) | `403 provider_not_allowed`; log server-side |
 | Google account without Play Services (Android edge) | `google_sign_in` fallback to web flow |
 | In-app browsers blocking popups (IG/Twitter webviews — likely for a social app!) | `signInWithRedirect` fallback; tested explicitly |
-| Account deletion | in-app: deletes ACCOUNT + vault per retention rules, then Firebase user; Google access revoked via SDK |
+| Account deletion | blocked while money is in flight: any non-terminal order (either role) or unsettled payout → `409 account_has_active_orders`; otherwise account enters `deletion_pending` (no new social/commerce actions) and hard-deletes ACCOUNT + vault per retention rules, then the Firebase user, once the last order is terminal and payouts settle; Google access revoked via SDK |
 
 ## 5. Screen inventory impact **[flags removals]**
 
@@ -68,7 +68,7 @@ return later for designer KYC, which Paystack owns anyway (A-2).
 
 ## 6. Instrumentation & acceptance
 
-Events: `auth_signin_completed`, `auth_signin_failed` — counters only.
+Events: `auth_signin_completed`, `auth_signin_failed`, `consent_recorded{document}` (emitted by the consent endpoints, F1-5) — counters only, per the master registry.
 
 - [ ] Email/Password provider disabled in Firebase console (verified)
 - [ ] Backend rejects non-Google-provider tokens (test with crafted token)

--- a/docs/flows/designer.md
+++ b/docs/flows/designer.md
@@ -1,0 +1,72 @@
+# Flow: Designer Side (onboarding, quoting, fulfilment)
+
+> The designer's half of the commerce loop — request.md is explicitly the
+> customer side. State machine + permissions: [order-lifecycle.md](../order-lifecycle.md).
+> Preconditions vary per section.
+
+## 1. Becoming a designer (F3-1 / F4-2)
+
+```mermaid
+flowchart TD
+    U[User taps "Become a designer"] --> UN{username claimed?}
+    UN -->|no| CLAIM[claim username — PATCH /me, 409 name_taken retry]
+    UN -->|yes| PROF[create profile: display name, bio]
+    CLAIM --> PROF
+    PROF --> POSTOK[can publish posts]
+    POSTOK --> KYC[attach payout account — Paystack bank resolution BVN]
+    KYC -->|verified| ACCEPT[posts can accept requests]
+    KYC -->|failed| RETRY[error surface + retry; support link after 3 fails]
+```
+
+- Posting is allowed pre-KYC; **accepting requests is not** (A-2 gate:
+  `post_unavailable` served to customers of non-KYC designers). This lets
+  designers build a portfolio before banking details.
+- KYC lapse (provider invalidates account): posts stop accepting requests
+  (same `post_unavailable`), open orders continue, payouts queue until
+  re-verification; designer sees a persistent banner.
+
+## 2. Quoting
+
+| Rule | Value |
+| --- | --- |
+| Quote window | 7 days from `requested`, expiry cancels (A-7); T-2d reminder to designer |
+| Quote contents | `quote_cents` (NGN v1) + `due_at` (≥ today + 1) |
+| Requote | allowed while `quoted` (replaces quote, resets the customer's view, does NOT reset expiry) |
+| Decline | reason required (enum + text); snapshot purged on the 30-day terminal schedule |
+| Concurrent requests | no cap on designer side; the pipeline view (§4) is the workload UI |
+
+## 3. Fulfilment obligations (the escrow clock)
+
+From order-lifecycle.md §1, designer-relevant deadlines:
+
+| State | Deadline | Consequence |
+| --- | --- | --- |
+| `paid`, not started | **T+14d** | system auto-refund + `refunded`; strike recorded |
+| past `due_at`, not shipped | due_at, due_at+7 reminders | customer gets one-click refund-dispute at due_at+14 |
+| `shipped` | — | auto-confirm pays out at T+14 if customer silent |
+
+Strikes **[Decided]**: 3 auto-refund strikes in 90 days pauses the profile
+(posts stop accepting requests) pending support review — protects customers
+from serial ghosting without permanent bans.
+
+## 4. Designer workspace (pages.md B3 "As designer" tab)
+
+- Pipeline list grouped by state with deadline chips (quote expiry, due dates,
+  auto-refund countdowns — the escrow clock made visible).
+- Order detail: snapshot values (this order only), thread, status actions
+  (`in_progress`, `shipped` + optional tracking), decline/quote forms.
+- Earnings (pages.md B6): balance = released payouts; pending = held escrow on
+  own orders; payout history with provider refs; fee line (10%) itemized per
+  order.
+
+## 5. Instrumentation & acceptance
+
+Events: `request_quoted`, `request_declined{reason}`, `payout_released` —
+**must be added to the master registry (upstat api.md §3.4) before
+implementation** (registry-first rule).
+
+- [ ] Non-KYC designer's posts serve `post_unavailable` to request attempts
+- [ ] Quote expiry + requote semantics proven by fixture tests
+- [ ] Auto-refund at T+14 fires with strike recording; 3-strike pause works
+- [ ] Snapshot visible only within the order; purged post-terminal
+- [ ] Earnings math ties to the money invariant (engineering §4)

--- a/docs/flows/request.md
+++ b/docs/flows/request.md
@@ -3,14 +3,15 @@
 > UI + contract layer over the state machine in
 > [order-lifecycle.md](../order-lifecycle.md). Covers the request stepper
 > (pages.md C5/B3, MI-10), payment, and every edge case. Preconditions:
-> authed + email verified (auth §4.3) + non-empty vault + consent on file.
+> authed (Google-only ⇒ email always verified, flows/auth.md §1) + non-empty
+> vault + consent on file.
 
 ## 1. The stepper (3 steps, sheet/modal)
 
 | Step | Content | Validation | Errors |
 | --- | --- | --- | --- |
 | 1 · Measurements | vault snapshot picker: latest session preselected; freshness warning if >90d ("Measurements are 4 months old — retake?") — warning, not block; shows exactly which values will be shared | ≥1 measurement in selection; session must be `complete` | vault empty → redirect to vault flow with return-path |
-| 2 · Details | notes (0–500 chars), budget (optional, ≥ post base price if designer set one — soft warning below), delivery city/address ref, target date (≥ designer turnaround, soft warning) | notes length; date ≥ today+turnaround → else "Designer's typical turnaround is 14 days" warning | |
+| 2 · Details | notes (0–500 chars), budget (optional, ≥ post base price if designer set one — soft warning below), delivery address (recipient, phone, line1/2, city, state — frozen into `REQUEST.delivery` at submit, data-model §6.3), target date (≥ designer turnaround, soft warning) | notes length; date ≥ today+turnaround → else "Designer's typical turnaround is 14 days" warning | |
 | 3 · Review | outfit summary, snapshot values (expandable), notes, budget; legal line: accuracy disclaimer + "measurements shared only with this designer for this order" | — | post deleted/designer deactivated since step 1 → `409 post_unavailable` → "This outfit is no longer available" + close |
 
 Submit: `POST /api/v1/posts/{id}/requests` with `Idempotency-Key` (UUID per
@@ -21,7 +22,6 @@ Success: MI-10 confetti + "View order". Failure taxonomy:
 | --- | --- | --- |
 | `409 duplicate_request` | open request already exists for this customer+post | jump to existing order |
 | `409 post_unavailable` | deleted/paused/designer KYC-lapsed | copy above |
-| `403 email_unverified` | — | verify sheet |
 | `422 snapshot_invalid` | session deleted between steps | back to step 1, picker refreshed |
 | `429` | >10 open requests **[Decided default cap]** | "You have too many open requests" |
 
@@ -74,7 +74,7 @@ Edge cases:
 - `shipped` push → order shows "Confirm delivery" + "Something wrong?".
 - Confirm: type nothing, single tap + confirm dialog → `delivered`, payout
   releases, review prompt **[Later]**.
-- Auto-confirm T+14d with reminders at T+7 and T+12 (order-lifecycle.md).
+- Auto-confirm T+14d after `shipped`, reminders at T+7 and T+12 (order-lifecycle.md §1/§4 — the single schedule of record).
 - Dispute: reason picker (not received / not as described / size wrong /
   other + text) → freezes payout, opens support thread; size-wrong disputes
   attach the snapshot for arbitration (the immutability pays off here).

--- a/docs/flows/vault.md
+++ b/docs/flows/vault.md
@@ -32,7 +32,7 @@ flowchart TD
 | --- | --- |
 | Height input | 100–230 cm (39–91 in); stored per account, editable in vault; changing height NEVER retro-scales old sessions (they froze their `input_height_cm`) |
 | Upload | multipart image ≤ 10 MB, JPEG/PNG/HEIC; client compresses to ≤2048px long edge before upload; `Idempotency-Key` header (UUID per capture attempt) — retries on flaky mobile MUST NOT create duplicate sessions |
-| QC failures | always `422 {error:{code, message, guidance}}`; codes: `no_body`, `multiple_bodies`, `partial_body`, `undecodable_image`; each maps to specific retake copy — never a generic "failed" |
+| QC failures | always `422 {error:{code, message, guidance}}`; full code set from capture-qc.md §1–2 with retake copy: `no_body` "Make sure your whole body is visible" · `multiple_bodies` "Make sure you're alone in frame" · `partial_body` "Include head to ankles" · `undecodable_image` "That image couldn't be read — try another photo" · `low_resolution` "Move closer or use a higher-quality camera" · `poor_lighting` "Find better lighting — avoid strong backlight" · `blurry` "Hold steady and retake" · `not_frontal` "Face the camera straight on" · `camera_tilt` "Hold the phone upright" · `arms_position` "Keep arms slightly away from your body" · `too_far` "Move closer — fill more of the frame" |
 | Unsaved results | server session rows created with `status: pending_save`; auto-purged after 24h unsaved **[Decided default]**; "Retake" purges immediately |
 | Save | flips `status: complete`; capture image begins its 30-day `retention_until` clock; measurements persist indefinitely |
 
@@ -40,7 +40,7 @@ flowchart TD
 
 | Case | Behaviour |
 | --- | --- |
-| Network dies mid-upload | client retries ×3 w/ backoff (same idempotency key); then "Saved to drafts — retry from vault" (draft = local image + height, encrypted at rest on device) |
+| Network dies mid-upload | client retries ×3 w/ backoff (same idempotency key); then "Saved to drafts — retry from vault" (draft = local image + height, encrypted via the platform keystore — Keychain / Android Keystore through `flutter_secure_storage`) |
 | App killed after capture, before save | draft persists locally; vault shows "1 unsaved capture" chip on next open |
 | Pipeline timeout (>30s) | `503 pipeline_busy`; client offers retry; session row marked `failed` |
 | User with no vault opens request flow | redirected here with "You need measurements first" (flows/request.md §2) |

--- a/docs/order-lifecycle.md
+++ b/docs/order-lifecycle.md
@@ -2,8 +2,8 @@
 
 > The full state machine behind SOC-004/005/006 (pages.md B3/C5/C8,
 > data-model.md §5 `REQUEST`). **[Proposed]** — this is the contract the
-> commerce phase implements; payments/escrow specifics gated on the provider
-> decision.
+> commerce phase implements; payments/escrow are the ratified A-1 model
+> (Paystack + platform ledger, 10% fee).
 
 ## 1. State machine
 
@@ -16,6 +16,7 @@ stateDiagram-v2
     quoted --> paid : customer pays (escrow hold)
     quoted --> cancelled : customer rejects quote / quote expires (7d)
     paid --> in_progress : designer starts work
+    paid --> refunded : system, designer inactive T+14d (no start)
     in_progress --> shipped : designer ships (tracking optional)
     shipped --> delivered : customer confirms OR auto-confirm T+14d
     delivered --> [*] : payout released
@@ -34,12 +35,17 @@ Rules:
 - **Measurement snapshot freezes at `requested`** — later vault changes never
   mutate an order; a re-measure prompts a *new* request.
 - **Quotes expire** after 7 days un-actioned (state → `cancelled`, both
-  parties notified) **[default to ratify]**.
+  parties notified) **[Decided, A-7]**.
 - **Auto-confirm**: `shipped` → `delivered` at T+14 days without customer
   action, after two reminders — protects designer payout from ghosting
-  **[default to ratify]**.
+  **[Decided, A-7]**.
 - **Dispute window** ends at delivery confirmation; disputes freeze payout
   and open a support thread (routes to `clients.cuesoft.io` when live).
+- **Escrow never waits forever [Decided]**: `paid` with no `in_progress`
+  within **14 days** auto-refunds (system transition; designer notified +
+  strike recorded); an order past `due_at + 14 days` without `shipped`
+  surfaces a one-click "request refund" dispute path to the customer with
+  reminders to the designer at due_at and due_at+7.
 - Cancellation after `paid` is a refund path, not a `cancelled` transition —
   money movements only ever resolve through `delivered` (payout) or
   `refunded`.
@@ -67,11 +73,12 @@ and only that frozen copy.
 | --- | --- |
 | `paid` | full quote captured to platform escrow; `PAYMENT.state = held` |
 | `delivered` | payout = quote − platform fee → designer payout account; `released` |
-| `refunded` | escrow returns to customer (fee handling per provider rules) |
+| `refunded` | platform triggers the Paystack refund from the ledger within **1 business day** of the resolving event; full-amount refunds only in v1 (no partials); the platform absorbs provider refund fees **[Decided]** |
 
-Platform fee % and payout timing (instant vs T+2) are provider-dependent —
-decide with the provider (Paystack-first for NG rails, Stripe for
-international **[Proposed]**). Designer payouts require completed KYC
+Platform fee: **10% of quote** (A-1, ratified); payout timing: **on delivery
+confirmation** — no instant payout in v1 (A-1). Provider: Paystack for NG
+rails; Stripe arrives with international (A-1). All amounts carry `currency`
+(NGN-only v1, data-model §5). Designer payouts require completed KYC
 (`DESIGNER_PROFILE.payout_account` verified) *before* their posts can accept
 requests — not at payout time, when it's too late.
 
@@ -84,7 +91,7 @@ requests — not at payout time, when it's too late.
 | paid | payment receipt | **push: order funded — start work** |
 | in_progress | status update | — |
 | shipped | **push: shipped** (+tracking) | — |
-| delivered−2d (pending auto-confirm) | reminder ×2 | — |
+| auto-confirm reminders (T+7, T+12 after shipped) | reminder ×2 | — |
 | delivered | confirmation + review prompt **[Later]** | **push: payout released** |
 | declined / cancelled / disputed / refunded | push | push |
 

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -32,7 +32,7 @@ Docs: hosted on **GitBook** (Git-synced from this `docs/` folder) **[Directive]*
 API reference via **Scalar** rendering the OpenAPI specs (api.md) embedded at
 `/docs/api`. **[Proposed]**
 
-## Part B — Web dashboard (app.apparule.cuesoft.io or /app)
+## Part B — Web dashboard (`apparule.cuesoft.io/dashboard` — canonical [Decided]; "B" routes below are relative to it)
 
 Desktop adaptation of the mobile IA (design.md §2 layout). Left rail: Home,
 Explore, Create, Orders, Vault, Profile, Settings; bottom of rail: theme
@@ -53,12 +53,15 @@ toggle, support (`clients.cuesoft.io`).
   overlay fade-in 120ms; click → post modal (IG desktop pattern: media left,
   detail right).
 - Filter chips: style tags, price band, turnaround time, "near me" **[Proposed]**.
+- Post permalinks: every post has a public web route `/p/{post_id}` (share
+  target for MI-9; renders post detail, request CTA for signed-in users).
 
 ### B3 `/app/orders` — Requests & orders (both roles)
 - Tabs: **As customer** / **As designer** (designer tab only when creator
   profile enabled).
 - `RequestCard` list; status pills (MI-14): `requested → quoted → paid →
-  in_progress → shipped → delivered` (+ `declined`, `disputed`, `cancelled`).
+  in_progress → shipped → delivered` (+ `refunded`, `declined`, `disputed`,
+  `cancelled`).
 - Click → order detail: outfit summary · **measurement snapshot** (the exact
   values sent, immutable) · thread (MI-17) · timeline (MI-14) · payment box
   (MI-15: quote → pay → escrow-held → released on delivery confirm)
@@ -69,7 +72,7 @@ toggle, support (`clients.cuesoft.io`).
 
 ### B4 `/app/vault` — Measurement vault
 - Header: freshness ring avatar (MI-11) + "Retake" CTA → capture options
-  (webcam upload / phone hand-off QR **[Proposed]** / manual entry MI-13).
+  (webcam upload / manual entry MI-13; phone hand-off QR was CUT from scope — mobile capture covers it **[Decided]**).
 - `MeasurementCard` grid (shoulder, hip, +SMPL girths when available) with
   history sparklines; tap → history sheet (sessions list, method chips,
   delete session).
@@ -79,7 +82,9 @@ toggle, support (`clients.cuesoft.io`).
 ### B5 `/app/create` — Post an outfit (designer)
 - Dropzone (≤10 media, reorder by drag; MI-4 preview) → details form
   (caption, style tags, base price or "quote on request", turnaround days,
-  fabric notes) → publish.
+  fabric notes) → publish. Media limits **[Decided]**: images only in v1 (video
+  is a later decision), ≤10 items, ≤10 MB each, JPEG/PNG/WebP, client-resized
+  to ≤2048px long edge; alt text required (default "Outfit by {designer}").
 - Non-creator users see the creator-profile upsell here ("Become a designer").
 
 ### B6 `/app/{username}` — Profiles
@@ -89,6 +94,11 @@ toggle, support (`clients.cuesoft.io`).
 - Regular user: private vault indicator (measurements NEVER public), saved
   looks tab, order history link. Privacy default: vault visible to no one;
   a measurement snapshot is shared **only** inside a request (APP-005 story).
+
+### B7a `/dashboard/admin/moderation` (staff only)
+- Moderation queue (A-6): open reports with subject preview, reporter
+  context, actions hide_post / suspend_account / dismiss (api.md §5 T&S);
+  audit trail via `REPORT.actioned_by`.
 
 ### B7 `/app/settings`
 - Account (Google sign-in via Firebase per X-1; `account.cuesoft.io` facade later), creator profile toggle,
@@ -102,7 +112,7 @@ Existing screens (splash/welcome/auth/capture) remain the entry path.
 
 | # | Screen | Spec |
 | --- | --- | --- |
-| C1 | Onboarding | existing auth flow; post-signup interstitial: "Take your first measurement" (→C6) or "Explore outfits" — skippable |
+| C1 | Onboarding | Google-only sign-in (flows/auth.md §5 — one CTA screen; password/verification screens retired); post-signup interstitial: "Take your first measurement" (→C6) or "Explore outfits" — skippable |
 | C2 | Home feed | = B1 minus right column; story rail on top; MI-1/2/3/4/5/6/16/18/20 all active |
 | C3 | Explore | search + 3-col grid; long-press peek preview (scale 0.97 + dim, MI haptic light); pull-to-refresh MI-5 |
 | C4 | Post detail | full-bleed carousel; action row; caption; comments sheet (swipe-up); Request CTA pinned bottom (safe-area) |

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -45,7 +45,7 @@ measurement entry must be touch-friendly and responsive. **[PRD §5]**
 | ID | Requirement | Priority | Expanded acceptance criteria |
 | --- | --- | --- | --- |
 | APP-001 | Open-Source Gateway | Must | Prominent GitHub link + contribution guidelines from the landing page; repository README/CONTRIBUTING are the landing targets. |
-| APP-002 | Cloud Access Flow | Must | Sign-in via `account.cuesoft.io`; authenticated users can request a cloud instance; request is tracked and acknowledged. Users must accept product-specific ToS (data retention + accuracy disclaimer) before cloud access. **[PRD §7]** |
+| APP-002 | Cloud Access Flow | Must | Sign-in via `account.cuesoft.io` *(X-1: in-app Google/Firebase interim)*; authenticated users can request a cloud instance; request is tracked and acknowledged. Users must accept product-specific ToS (data retention + accuracy disclaimer) before cloud access. **[PRD §7]** |
 | APP-003 | SMPL Pipeline Demo | Should | Visual/video walkthrough of the SMPL-based measurement process embedded on the landing page. |
 | APP-004 | API Reference | Should | Searchable API documentation for third-party integration. |
 | APP-005 | Privacy Disclosure | Must | Explicit page/section describing how measurements and personal physical data are handled, linking to the Apparule clause in `privacy.cuesoft.io`. |
@@ -54,7 +54,7 @@ measurement entry must be touch-friendly and responsive. **[PRD §5]**
 
 | ID | Requirement | Notes |
 | --- | --- | --- |
-| ECO-AUTH | All login/session management via `account.cuesoft.io` | External service — does not exist in this repo; see roadmap dependency D1. **[PRD §4.2]** |
+| ECO-AUTH | All login/session management via `account.cuesoft.io` *(X-1 hardened: in-app Google-only over Firebase now; facade later)* | Not blocking (D1 demoted). **[PRD §4.2]** |
 | ECO-SUPPORT | Route active users needing help to `clients.cuesoft.io` | Link-out only in v1. |
 | ECO-ANALYTICS | Track "Demo Starts" and "GitHub Clicks" via Upstat | Depends on Upstat exposing a generic event-ingestion API (cross-repo dependency D2 — Upstat currently has none). |
 
@@ -113,11 +113,11 @@ capabilities beyond the web property. Made explicit so they can be scheduled:
 1. ~~**`account.cuesoft.io` contract**~~ **RESOLVED (X-1)**: in-app Google-only sign-in over Firebase Auth (`sandbox-e306a`); the facade comes later. Original question — protocol (OIDC? opaque token introspection?),
    token audience/claims, and timeline. Blocks APP-002 and PLAT-003's final shape
    (roadmap D1). Interim: local JWT auth hardened enough for records **[Proposed]**.
-2. **Cloud instance model** — "request a cloud instance" reads as
+2. ~~**Cloud instance model**~~ **RESOLVED (A-5)**: request queue + manual provisioning. Original — "request a cloud instance" reads as
    instance-per-customer provisioning rather than one multi-tenant app. v1 treats
    it as a *request queue + manual provisioning* (helm chart already exists per
    instance) **[Proposed]** — confirm.
-3. **SMPL licensing** — SMPL model weights are free for research; commercial use
+3. ~~**SMPL licensing**~~ **RESOLVED (A-3)**: launch on 2-D, licensing quote in parallel. Original — SMPL model weights are free for research; commercial use
    requires a license from Meshcapade/MPI. The hosted commercial cloud likely
    needs SMPL commercial licensing or an alternative body model. Must be resolved
    before PLAT-005 ships in cloud (roadmap risk R1).
@@ -126,6 +126,11 @@ capabilities beyond the web property. Made explicit so they can be scheduled:
 5. **Figma designs** — Home canvas is empty; landing implementation (roadmap P0)
    needs the design pass, or we proceed with a standards-based layout and
    retrofit.
+6. **OPEN (tracked)**: hero H1 copy (pages.md A2 — owner: brand pass) and the
+   Discord server URL (pages.md A8 — owner: community setup) are unresolved
+   content dependencies for Phase 0.
+7. **Metrics targets**: prd §7 metrics are baseline-gathering in v1 — numeric
+   targets set after 90 days of data **[Decided]**.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -27,7 +27,7 @@ Lighthouse mobile score ≥ 90 (PRD's mobile-first bias).
 
 | Item | Requirement | Notes |
 | --- | --- | --- |
-| Replace auth stubs: verify Google ID tokens properly; implement email link/OTP or drop the endpoint | PLAT-003 | Independent of D1; removes the `TODO(security-prd)` debt |
+| Replace auth stubs with Firebase Google-only verification (X-1 hardened); email endpoint deleted with no successor | PLAT-003 | flows/auth.md is the contract; removes the `TODO(security-prd)` debt |
 | `account.cuesoft.io` integration once contract exists | ECO-AUTH, D1 | Until then the hardened local auth carries the flow |
 | Consent gate (ToS + retention + accuracy disclaimer) | PRD §7 | `CONSENT_RECORD` model |
 | Instance request flow + minimal dashboard page | APP-002 | Queue + manual ops provisioning via existing helm chart (prd.md §8.2) |
@@ -72,7 +72,7 @@ sessions can select `smpl_v1`; landing demo reflects the real pipeline.
 
 | ID | Dependency | Owner | Blocks |
 | --- | --- | --- | --- |
-| D1 | `account.cuesoft.io` auth contract | Cuesoft ecosystem | Phase 1 (final shape), APP-002 |
+| D1 | `account.cuesoft.io` facade | Cuesoft ecosystem | Nothing (X-1: Firebase interim ratified; facade is cosmetic later) |
 | D2 | Upstat generic event-ingestion API | upstat repo (its PRD names it the ecosystem tracker) | ECO-ANALYTICS in Phase 0 |
 | D3 | Apparule clause on privacy.cuesoft.io | Cuesoft legal/content | APP-005 copy |
 | R1 | SMPL commercial licensing | Product decision | Phase 3 in cloud |
@@ -105,5 +105,12 @@ after them becomes:
   feeds richer snapshots into requests.
 
 Trust & safety (SOC-009: report/block/moderation) ships **with** Phase 3 —
-UGC without moderation doesn't go public. Platform parity note: web dashboard
+UGC without moderation doesn't go public.
+
+Exit criteria for the revised phases: **P2 (Vault)** capture→save→history on
+both surfaces with QC codes + retention job live; **P3 (Social)** post→follow
+→feed→like/save/comment E2E with T&S actions working and counters reconciling;
+**P4 (Commerce)** request→quote→pay→deliver→payout on Paystack sandbox with the
+money invariant green and disputes freezing payouts; **P5 (SMPL)** accuracy
+report published + cloud girth sessions selectable. Platform parity note: web dashboard
 and mobile ship each phase together (shared component naming, design.md §6).


### PR DESCRIPTION
Applies every finding from the deep documentation review (13 high / 33 med / 22 low). Key upgrades: vault self-customer model, escrow inactivity SLAs + designer strikes, complete T&S contract, usernames, currency/address/notification modeling, Firebase-only consistency sweep, runtime architecture for webhooks/jobs/push, Cloud Run sizing+rollback, full OpenAPI surface, and the new designer-side flow spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)