### PR TITLE
docs: GitBook-safe README link

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -40,7 +40,7 @@ flowchart LR
 - **Data** — Firestore (system of record, X-5) & Cloud Storage; shared Aiven Redis (REDIS_DB tenancy).
 
 See [setup.md](setup.md) to run the stack locally, and the
-[repository structure](../README.md#repository-structure) in the README.
+[repository structure](https://github.com/cuesoftinc/apparule#repository-structure) in the README.
 
 ## Product & design documentation
 > Published site: **https://cuesoft.gitbook.io/apparule** (Git-synced from this folder on every merge to main).


### PR DESCRIPTION
Out-of-docs-root relative link → absolute GitHub URL (renders on the published site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)