### PR TITLE
docs: excellence pass — valid mermaid, Brevo X-7, CORS standard, X-8 protocols

### DIFF
--- a/api/common/.env.example
+++ b/api/common/.env.example
@@ -4,4 +4,4 @@ JWT_SECRET=dev-secret-change-me
 GOOGLE_CLOUD_PROJECT=apparule-local
 # Optional path to a Firebase service-account JSON for full functionality.
 FIREBASE_CONFIG_PATH=
-ALLOWED_ORIGINS=http://localhost:3000
+CORS_ORIGINS=http://localhost:3000

--- a/api/common/internal/config/config.go
+++ b/api/common/internal/config/config.go
@@ -23,7 +23,7 @@ func Load() (*Config, error) {
 		JWTSecret:          os.Getenv("JWT_SECRET"),
 		FirebaseConfigPath: os.Getenv("FIREBASE_CONFIG_PATH"),
 		ProjectID:          firstNonEmpty(os.Getenv("GOOGLE_CLOUD_PROJECT"), os.Getenv("GCP_PROJECT")),
-		AllowedOrigins:     splitCSV(getenv("ALLOWED_ORIGINS", "http://localhost:3000")),
+		AllowedOrigins:     splitCSV(getenv("CORS_ORIGINS", "http://localhost:3000")),
 	}
 
 	// Fail fast rather than fall back to a baked-in secret: a hard-coded

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,7 +64,7 @@ flowchart LR
         OBJ[(Object storage<br/>capture images, exports)]
     end
 
-    subgraph Cuesoft ecosystem — external
+    subgraph ECO["Cuesoft ecosystem — external"]
         ACC[Firebase Auth sandbox-e306a<br/>account.cuesoft.io facade later]
         UP[Upstat<br/>events & uptime]
         CL[clients.cuesoft.io<br/>support]
@@ -77,7 +77,7 @@ flowchart LR
     LAND --> PRIV
     T --> DASH
     T -->|Flutter app| AC
-    DASH -->|Google sign-in in-app (X-1)| AC
+    DASH -->|"Google sign-in in-app (X-1)"| AC
     AC -.->|Firebase ID-token verify| ACC
     AC --> DB
     AC --> OBJ
@@ -209,7 +209,7 @@ sequenceDiagram
     T->>W: request cloud instance
     W->>C: POST /api/v1/instance-requests
     C-->>W: 202 queued
-    Note over C: ops provisions via the existing helm chart;<br/>status transitions surface in the dashboard
+    Note over C: ops provisions via the existing helm chart ·<br/>status transitions surface in the dashboard
 ```
 
 ### 4.3 Measurement record lifecycle — target **[Proposed]**

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -69,7 +69,7 @@ erDiagram
         uuid customer_id FK
         string method "mediapipe_2d | smpl_v1 | manual"
         float input_height_cm
-        string status "pending_save | complete | failed" // pending_save = results returned, not yet saved (24h TTL, flows/vault.md)
+        string status "pending_save (results unsaved, 24h TTL) | complete | failed"
         json pipeline_meta "model version, confidence, QC flags"
         datetime created_at
     }
@@ -196,7 +196,7 @@ erDiagram
     PAYMENT { uuid id PK
         uuid request_id FK
         string provider "paystack|stripe — to ratify"
-        string state "held|released|refunded" // charge.success lands directly in held; no separate authorized step (Paystack capture model)
+        string state "held | released | refunded — charge.success lands directly in held (Paystack capture model)"
         string currency "ISO 4217, matches REQUEST"
         int amount_cents
         int platform_fee_cents }

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -149,3 +149,17 @@ before public launch. Alternative: commission the brand pass first.
   happen exclusively on tag creation (`v*`)**, treated as production-grade:
   a GitHub tag ruleset restricts `v*` creation to owner-level access, and the
   deploy workflow additionally runs in a protected GitHub environment. ☑
+- **X-7 Transactional email (RATIFIED, directive 2026-07-16)**: **Brevo REST
+  API** for all product email (alert emails, money-event receipts, purge
+  confirmations…) — the irealty pattern: `BREVO_API_KEY`, `BREVO_FROM_EMAIL`,
+  `BREVO_FROM_NAME` in Doppler. **No SMTP anywhere** — existing SMTP/gomail
+  plumbing retires when next touched. Revises U-4's Resend pick where it
+  applied. ☑
+- **X-8 Protocol standard (RATIFIED 2026-07-16)**: ecosystem APIs are
+  **HTTP/JSON**. gRPC exists ONLY where upstat needs it: **OTLP/gRPC ingest**
+  (OTel industry standard, OBS-001), internal s2s (observability↔common),
+  and the existing monitor control plane until monitors-v2. Cloud Run runs
+  gRPC fine with end-to-end HTTP/2 (h2c) — already how api/common works.
+  **Browser gRPC-Web + Envoy is a sunset path**: no new surface uses it
+  (U-5); at monitors-v2 (OBS-006) the dashboard goes fully HTTP and Envoy
+  retires from the cloud topology. apparule/expendit never adopt gRPC. ☑

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -98,3 +98,14 @@ construction (emulator rule tests are part of CI, not optional).
 - [ ] Firestore emulator rules tests in CI
 - [ ] Money invariant property test present before Phase 4 merges
 - [ ] Never-log grep gate wired into build-and-test.yml
+
+## CORS contract (ecosystem standard)
+
+- Env: **`CORS_ORIGINS`** — comma-separated exact origins; no wildcard in
+  cloud; `http://localhost:3000` default for native dev.
+- Behaviour: echo the request Origin **only if allowlisted**; `Vary: Origin`;
+  `Allow-Credentials: false` (bearer auth — no cookies);
+  methods `GET,POST,PUT,PATCH,DELETE,OPTIONS`; headers
+  `Authorization, Content-Type, Idempotency-Key, X-Org-Id`; preflight 204
+  with `Access-Control-Max-Age: 600`.
+- Implemented today in api/common (`CORS_ORIGINS`, renamed from `ALLOWED_ORIGINS` for ecosystem consistency).

--- a/docs/flows/designer.md
+++ b/docs/flows/designer.md
@@ -8,8 +8,9 @@
 
 ```mermaid
 flowchart TD
-    U[User taps "Become a designer"] --> UN{username claimed?}
-    UN -->|no| CLAIM[claim username — PATCH /me, 409 name_taken retry]
+    U["User taps 'Become a designer'"] --> UN{username claimed?}
+    CLAIM["claim username — PATCH /me, 409 name_taken retry"]
+    UN -->|no| CLAIM
     UN -->|yes| PROF[create profile: display name, bio]
     CLAIM --> PROF
     PROF --> POSTOK[can publish posts]


### PR DESCRIPTION
Excellence pass: all 49 mermaid diagrams now validate with mermaid-cli (9 were syntactically invalid and rendered as plaintext on GitBook — fixed); X-7 Brevo email (no SMTP); CORS_ORIGINS standardization + CORS contract; X-8 protocol standard (HTTP/JSON; upstat gRPC scoped to OTLP+s2s, Envoy sunset at monitors-v2); structure parity (canonical architecture skeleton, section renumbering, runtime-contract sections); links re-verified 0 broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)