### PR TITLE
docs: Figma true Light/Dark modes + foundations variables

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -148,7 +148,7 @@ so design tokens and specs translate 1:1. **[Proposed]**
 ## 7. Figma Style Guide (source of truth for tokens)
 
 The design system lives in the product's Figma file on a dedicated **Style
-Guide** page, backed by a variable collection **`apparule/tokens`**. The file's plan allows a single variable mode, so themes are expressed as **`light/` and `dark/` variable groups** (same token names in each) rather than modes — migrate to true modes if the plan changes. Every color token in §2 exists as a Figma
+Guide** page, backed by a variable collection **`apparule/tokens`** with **true Light and Dark modes** (migrated 2026-07-16 after the pro upgrade; the earlier light/dark-group workaround is retired — components bind one token and switch by mode). The collection also carries the foundations as variables: spacing scale, radii, durations, z-index. Every color token in §2 exists as a Figma
 variable (scopes: frame/shape/text fills + strokes) so designs bind to tokens,
 never raw hexes; the Style Guide page renders swatches (both modes), the type
 scale, and status/accent samples. Token changes happen in Figma first, then


### PR DESCRIPTION
Style-guide alignment: tokens verified hex-for-hex vs §2; foundations variables (+ upstat series palette) added; collections migrated to true Light/Dark modes (pro); boards extended and screenshot-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)