### PR TITLE
docs: X-10 identity tiers — profile location for proximity recs, authz matrix fix, address-book posture

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -40,6 +40,7 @@ erDiagram
         string firebase_uid "identity key (X-1); the future facade fronts the same uid"
         string email
         string username "unique (case-insensitive), 3-30 chars [a-z0-9._]; claimable on demand, required to enable a designer profile; rename max 1x/30d"
+        json profile_location "optional, self-attested {city, state, country} — X-10 tier 1; powers near-me designer ranking + delivery pre-fill; sensitive PII (see section 4)"
         string deletion_state "active | deletion_pending"
         datetime created_at
     }
@@ -126,6 +127,13 @@ Modeling notes:
 - **`CAPTURE_ASSET.retention_until`** operationalizes the retention disclosure:
   source images are the most sensitive artifact and get the shortest default
   retention (e.g. 30 days **[Proposed]**), while derived measurements persist.
+- **`ACCOUNT.profile_location` is self-attested tier-1 profile data (X-10)** —
+  optional `{city, state, country}`, edited in settings (pages.md B7). It
+  powers proximity-ranked designer recommendations ("near me", pages.md B2)
+  and pre-fills the request stepper's delivery address (the delivery address
+  itself stays frozen per order, §6.3). Designers must set it to be eligible
+  for proximity ranking; without it they simply don't rank in "near me"
+  results — no hard gate. Classification: sensitive PII (§4), never logged.
 
 ## 3. Storage mapping **[Proposed]**
 
@@ -140,7 +148,7 @@ Modeling notes:
 | Class | Data | Rules |
 | --- | --- | --- |
 | High-sensitivity | Capture images, measurements, customer identity | Encrypted at rest; never logged (no image bytes, no measurement values in logs); shortest retention for images; deletion honours `retention_until`; export/delete rights surfaced in dashboard. |
-| Sensitive | Account email, consent records | Standard PII handling; consent rows immutable. |
+| Sensitive | Account email, consent records, `profile_location` (self-attested city/state/country — X-10 tier 1) | Standard PII handling; consent rows immutable; profile location never in logs or events. |
 | Operational | Session status, pipeline metadata, event counters | No special handling; safe for logs/metrics. |
 
 Deletion semantics: deleting a `CUSTOMER` soft-deletes then hard-purges
@@ -207,7 +215,9 @@ mutate an order); vault data is never public — a snapshot exists only inside
 a request the customer initiated (privacy story for APP-005); social counters
 (likes/saves) are denormalized on POST with periodic reconciliation; payments
 follow escrow: `held` at pay, `released` on delivery confirmation (dispute
-pauses release).
+pauses release); proximity ranking ("near me", pages.md B2) reads the
+designer's `ACCOUNT.profile_location` (§2, X-10 tier 1) — designers without
+one don't appear in proximity-ranked results (no hard gate).
 
 ---
 
@@ -256,6 +266,11 @@ order-essential messages only. Blocks are silent (no notification).
 state, country}` frozen at submit (like the snapshot — later address-book
 edits never mutate an order). Classification: **sensitive PII** — same
 handling row as customer identity (§4); never in logs or events.
+
+v1 posture **[Proposed]**: **no stored address book** — the request stepper
+pre-fills from the account's most recent `REQUEST.delivery` (first order:
+city/state/country seed from `ACCOUNT.profile_location`, §2); a saved
+`ADDRESS` entity is tier-1 (X-10) later scope.
 
 ### 6.4 Notifications
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -180,3 +180,29 @@ before public launch. Alternative: commission the brand pass first.
   /v1/events counters) — never mix the pipelines. Env names standard:
   OTEL_SERVICE_NAME, OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_HEADERS,
   OTEL_RESOURCE_ATTRIBUTES. ☑
+- **X-10 Identity, profile & KYC tiers (RATIFIED, directive 2026-07-16)**: layered on
+  X-1 — Google-only sign-in stays the sole credential; tiers add profile data and
+  verification, never alternative logins. **Tier 0 — Google identity** (all
+  products): firebase_uid + Google-verified email; grants all read/basic use.
+  **Tier 1 — self-attested profile & location** (captured in product
+  profile/settings; sensitive PII, never logged): apparule = bio + profile
+  location {city, state, country} powering proximity-ranked designer
+  recommendations ("near me") and delivery-address pre-fill (delivery address
+  itself stays frozen per order); expendit = tax-jurisdiction location —
+  state_of_residence for individuals, registered_address for company orgs —
+  which resolves the remittance authority (State IRS vs FIRS); upstat = org
+  timezone (IANA) only, for accurate report rendering and time-bucketing —
+  deliberately the entire upstat requirement. **Tier 2 — provider-verified
+  financial identity** (only where money moves or government filings
+  generate; store provider refs + verification state, never raw government
+  IDs): apparule designer payouts = Paystack bank resolution, BVN-backed
+  (already ratified A-2 — canonized as the ecosystem pattern); expendit
+  filing identity = TIN (+ RC number + registered address for companies)
+  required at filing-pack generation (422 tax_identity_incomplete); v1
+  verification is format validation + attestation, provider-verified arrives
+  with direct e-filing (post-v1); upstat = N/A until billing enters the PRD.
+  **Rules**: tiers gate capabilities, never sign-in; KYC state machines +
+  error codes live in flow docs (apparule kyc_incomplete/post_unavailable is
+  the template); tier-2 fields are high-sensitivity in every data-model §4
+  classification; verification is delegated to the money/filing provider —
+  no in-house document review. ☑

--- a/docs/design.md
+++ b/docs/design.md
@@ -167,7 +167,7 @@ component samples are the next Style Guide iteration.
 | --- | --- | --- |
 | 0 Foundations | type styles from §2 scale · Lucide icon set import · grid styles (630/935 columns) | everything |
 | 1 Atoms | Button, Input, Pill/Chip, Avatar, IconButton, Toast | all molecules |
-| 2 Molecules | StoryRail item, action row, MeasurementCard, StatusPill set, TabBar, Sheet chrome · **capture kit**: CaptureOverlay, CountdownRing, QCHintChip, ProcessingConstellation, CaptureResults chrome, ManualMeasureRow, CaptureOptionCard | cards |
+| 2 Molecules | StoryRail item, action row, MeasurementCard, StatusPill set, TabBar, Sheet chrome · **form kit**: FormRow, AddressFieldset (request-stepper delivery + profile location, X-10 tier 1) · **capture kit**: CaptureOverlay, CountdownRing, QCHintChip, ProcessingConstellation, CaptureResults chrome, ManualMeasureRow, CaptureOptionCard | cards |
 | 3 Cards | PostCard, RequestCard, NotificationRow, CommentRow, ThreadBubble, EmptyState set, Skeletons | screens |
 | 4 Screen templates | feed, post detail, request stepper (3 steps), vault, capture overlays, orders list+detail, profile ×2, moderation queue | mobile + dashboard designs |
 | 5 Home page | A1–A10 sections (pages.md Part A) | landing design |
@@ -195,6 +195,8 @@ component samples are the next Style Guide iteration.
 | CaptureResults chrome | header (confidence summary) + MeasurementCard stagger list slot + "Save to vault" gradient / "Retake" quiet (pages.md C6) |
 | ManualMeasureRow | tape-measure slider + numeric field + cm/in toggle · state: default / active / error (MI-13) |
 | CaptureOptionCard | mode: webcam-upload / manual-entry (vault "Retake" options, pages.md B: vault header) |
+| FormRow | label + control + helper/error · state: default/focus/error/disabled (profile & settings editors) |
+| AddressFieldset | context: delivery (request stepper — frozen per order) / profile location (city + state + country · "near me" explainer, X-10 tier 1) · NG-state select · prefill-from-last-order |
 
 ### 8.3 Design-prep needed from content
 

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -39,7 +39,8 @@ membership for vault-of-customers use (SME mode).
 | --- | --- | --- | --- | --- |
 | Feed/explore read, post detail | ✓ (public posts) | ✓ | ✓ | ✓ |
 | Like/save/comment/follow | — | ✓ | ✓ | ✓ |
-| Create post | — | — | ✓ (KYC complete) | — |
+| Create post | — | — | ✓ (designer profile) | — |
+| Post accepts requests | — | — | ✓ (KYC complete, A-2 — `post_unavailable` otherwise; flows/designer.md §1) | — |
 | Own vault (read/write) | — | ✓ self only — **no role ever reads another's vault** | ✓ self | — |
 | Workspace customers/sessions | — | workspace members | — | — |
 | Create request | — | ✓ (verified, vault non-empty, consent) | ✓ as customer | — |

--- a/docs/features.md
+++ b/docs/features.md
@@ -51,7 +51,7 @@
 | F3-1 | Designer profiles | role enable, profile docs, KYC state (gate only, provider in F4-2) | data-model §5 | F2-1 |
 | F3-2 | Posts | create (media ≤10, tags, price), post docs + Cloud Storage | pages.md B5, api.md §5 | F3-1 |
 | F3-3 | Follow graph + feed | follows, home feed (recency+affinity), caught-up divider | pages.md B1/C2, api.md §5 | F3-2 |
-| F3-4 | Explore + search | grid, filters, search | pages.md B2/C3 | F3-2 |
+| F3-4 | Explore + search | grid, filters (incl. "near me" ranked by designer `profile_location`, captured in settings B7 — X-10 tier 1; locationless designers don't rank), search | pages.md B2/C3/B7, data-model.md §2 | F3-2 |
 | F3-5 | Engagement | likes/saves/comments (optimistic, idempotent toggles) + counters | MI-1..3, MI-18, engineering §3 | F3-2 |
 | F3-6 | PostCard component set | web + Flutter parity components (design.md §3 anatomy) | design.md, F0-1 | F3-2 |
 | F3-7 | Trust & safety baseline | report/block, moderation queue, hide/suspend | A-6, engineering §2 | F3-2 |

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -52,7 +52,10 @@ toggle, support (`clients.cuesoft.io`).
 - Masonry grid of outfit posts (1:1 crops); hover: like/comment counts
   overlay fade-in 120ms; click → post modal (IG desktop pattern: media left,
   detail right).
-- Filter chips: style tags, price band, turnaround time, "near me" **[Proposed]**.
+- Filter chips: style tags, price band, turnaround time, "near me" **[Proposed]**
+  — proximity ranking by designer `profile_location` (data-model.md §2,
+  X-10 tier 1); designers without a location simply don't rank in proximity
+  results (no hard gate).
 - Post permalinks: every post has a public web route `/p/{post_id}` (share
   target for MI-9; renders post detail, request CTA for signed-in users).
 
@@ -102,7 +105,9 @@ toggle, support (`clients.cuesoft.io`).
 
 ### B7 `/app/settings`
 - Account (Google sign-in via Firebase per X-1; `account.cuesoft.io` facade later), creator profile toggle,
-  payout account (designer), notifications, privacy & data (export/delete,
+  payout account (designer), **profile location** (city/state/country,
+  optional — explainer: "used to recommend nearby designers"; X-10 tier 1,
+  data-model.md §2), notifications, privacy & data (export/delete,
   consent history), language, theme.
 
 ## Part C — Mobile app (Flutter) — primary surface
@@ -116,7 +121,7 @@ Existing screens (splash/welcome/auth/capture) remain the entry path.
 | C2 | Home feed | = B1 minus right column; story rail on top; MI-1/2/3/4/5/6/16/18/20 all active |
 | C3 | Explore | search + 3-col grid; long-press peek preview (scale 0.97 + dim, MI haptic light); pull-to-refresh MI-5 |
 | C4 | Post detail | full-bleed carousel; action row; caption; comments sheet (swipe-up); Request CTA pinned bottom (safe-area) |
-| C5 | Request stepper | MI-10 sheet: Step 1 pick measurement set (vault snapshot picker, freshness warnings); Step 2 notes + budget + delivery; Step 3 review → submit; success: confetti + "view order" |
+| C5 | Request stepper | MI-10 sheet: Step 1 pick measurement set (vault snapshot picker, freshness warnings); Step 2 notes + budget + delivery (pre-fills from most recent order — no saved address book in v1, data-model.md §6.3); Step 3 review → submit; success: confetti + "view order" |
 | C6 | Capture | existing guide screens restyled: silhouette overlay + countdown (MI-12); processing constellation; results screen: measurement cards stagger-in, "Save to vault" primary, "Retake" quiet; manual-entry fallback (MI-13) |
 | C7 | Vault | = B4 adapted; entry from Profile tab header ring |
 | C8 | Orders | = B3 list + detail; push notifications drive re-entry (badge MI-16) |


### PR DESCRIPTION
## What

Applies the KYC-audit gaps assigned to apparule ([kyc-2], [kyc-6]) plus the ratified cross-cutting X-10 decision and the 2026-07-16 profile-location directive.

### decisions.md — X-10 (Cross-cutting, after X-9)
New ratified decision **X-10 Identity, profile & KYC tiers**: tier 0 Google identity (X-1), tier 1 self-attested profile & location (apparule = bio + profile location powering "near me" designer recommendations and delivery pre-fill), tier 2 provider-verified financial identity (A-2 Paystack/BVN canonized as the ecosystem pattern). Rules: tiers gate capabilities, never sign-in; KYC state machines live in flow docs; tier-2 fields are high-sensitivity; verification is delegated to the provider.

### engineering.md — authz matrix fix [kyc-2]
`Create post` was gated on "KYC complete", contradicting A-2 and flows/designer.md §1 (posting is allowed pre-KYC so designers can build a portfolio). Now: `Create post → ✓ (designer profile)` + new row `Post accepts requests → ✓ (KYC complete, A-2 — post_unavailable otherwise)`.

### data-model.md — profile location + address-book posture [kyc-6]
- §2 `ACCOUNT` gains optional self-attested `profile_location {city, state, country}` (X-10 tier 1) + modeling note: powers proximity-ranked designer recommendations and delivery pre-fill; designers without it simply don't rank (no hard gate).
- §4 classification: profile_location added to the Sensitive row, never in logs or events.
- §5 rules: proximity ranking reads the designer's `ACCOUNT.profile_location`.
- §6.3: explicit v1 posture — **no stored address book**; the stepper pre-fills from the most recent `REQUEST.delivery`; a saved `ADDRESS` entity is X-10 tier-1 later scope.

### pages.md / features.md / design.md
- B2 "near me" filter chip gains its data-source cross-ref; B7 settings gains a **Profile location** item ("used to recommend nearby designers"); C5 stepper notes the pre-fill/no-address-book posture.
- F3-4 (Explore + search) carries the near-me proximity-ranking scope.
- design.md §8.2 gains **FormRow** and **AddressFieldset** component contracts, mentioned in the §8.1 stage-2 molecules row (form kit).

## Validation

- data-model.md §2 erDiagram (the only mermaid block touched) re-validated with `@mermaid-js/mermaid-cli` — renders clean.
- No code changes; docs only. openapi.yaml untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)