### PR TITLE
docs: QA-loop alignment — prototype standard, state coverage, star-badge rewording, as-built notes

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -226,7 +226,10 @@ iconography rule (§2).
 **Stage 4 screen-state rule [Directive 2026-07-18].** Every data-driven
 screen template ships **three frames**: default, empty (EmptyState + its
 first-run copy; demo-data toggle where a flow specs one), and loading
-(Skeleton). A template isn't done until all three exist.
+(Skeleton). A template isn't done until all three exist. **As built
+(2026-07-18 QA loop):** the rule is met on the core data-driven templates —
+default / empty / loading frames exist across feed, explore, vault, orders,
+and notifications, and their dashboard equivalents.
 
 **Naming standards (canonical across the three products) [Decided
 2026-07-17].** Component sets are PascalCase; variant property names are
@@ -344,6 +347,12 @@ an iteration addition once the build report confirms it. **Confirmed
 (2026-07-18):** the build added it — the `FAQItem` row above is the as-built
 contract.
 
+*As-built fixes (2026-07-18 QA loop):* three master corrections from the QA
+pass — `Sheet`: the master's slot strokes are removed (slots render clean in
+instances); `Input` textarea kind: inner text-area height fixed;
+`RequestCard`: the title truncates to 1 line (ellipsis) so the price is
+always visible.
+
 ### 8.3 Design-prep needed from content
 
 Outfit photography for realistic feed mocks is now **sourced** (2026-07-16):
@@ -354,3 +363,40 @@ for inappropriate provenance — a conflict-related archive image — and
 replaced from the curated pool; the attribution grid on the Assets page is
 maintained (every image keeps its caption). Still needed: hero H1 copy
 (prd §8.6); the Afrocentric pattern asset (§2) at 3 opacities.
+
+### 8.4 Prototype (built 2026-07-18)
+
+> The click-through layer wired over the Stage-4/5 frames, and the standard
+> it follows **[Decided 2026-07-18]**. Prototype wiring is part of "done"
+> for a flow the same way the §8.1 three-frame rule is for a screen.
+
+**Named flows (starting points per page).** Every prototype flow has a named
+starting point on its Figma page:
+
+- **Mobile** — "Onboarding → first order" starting at C1 (pages.md Part C),
+  plus separate state starts for the designer onboarding/KYC, payout,
+  dispute, and decline paths.
+- **Dashboard** — "Feed" (B1), plus starts for the moderation, decline,
+  creator-upsell, and payout states.
+- **Home** — "Marketing site" (Part A), whose CTA hands off cross-page into
+  the app flow.
+
+**Wiring conventions.**
+
+- Reactions are `ON_CLICK` → `NAVIGATE` between top-level frames.
+- Transitions: `DISSOLVE` ~150–200ms for nav/tab switches; `SMART_ANIMATE`
+  for pushes and backs; `AFTER_TIMEOUT` for async verification states
+  (e.g. processing → results), which advance on their own.
+- Empty, loading, QA, and index frames stay **out** of the flow by design —
+  they exist for the §8.1 screen-state rule and for QA, not for wiring; the
+  prototype walks real user paths only.
+
+**Reachability.** Verified by BFS over the reaction graph from each flow's
+starting point: every wired frame is reachable, and there are no dead ends
+besides intentional terminals.
+
+**Cross-page links (move-wire-restore).** The plugin API rejects creating a
+cross-page `NAVIGATE` reaction outright, but an existing reaction persists
+across page moves — so cross-page links (the Home CTA handoff) are wired by
+temporarily moving the source frame to the destination page, adding the
+wire there, and moving the frame back.

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -14,7 +14,7 @@ community links → preview → dual CTA **Try Cloud** / **Self Host**.
 
 | # | Section | Content & components | Interactions |
 | --- | --- | --- | --- |
-| A1 | Nav bar | logo · Product · Docs (GitBook) · Community · GitHub (star count badge) · Sign in · **Try Cloud** (gradient) | sticky, blurs on scroll; star count fetched client-side, animates count-up once |
+| A1 | Nav bar | logo · Product · Docs (GitBook) · Community · GitHub (star badge — the live count is populated at runtime; static designs render the badge with no number per the accuracy standard, design.md §8.2b) · Sign in · **Try Cloud** (gradient) | sticky, blurs on scroll; star count fetched client-side, animates count-up once |
 | A2 | Hero | H1 "Precision measurement meets social fashion" (copy pass pending); subcopy; dual CTA **Try Cloud** / **Self Host**; hero visual: phone frame auto-playing a silent feed→capture→request loop | CTA hover lifts 2px; visual loop pauses on hover/reduced-motion |
 | A3 | Problem strip | 3 stat cards (manual-measurement error, fragmented records, lost designer reach) | cards fade-up on scroll-into-view (once) |
 | A4 | Product walkthrough | 4-step horizontal scroll-jacked panel (Capture → Vault → Discover → Commission), each step = **real screen thumbnail** (exported from the Stage-4 Figma frames, not illustrative art **[Directive 2026-07-18]**) + 2 lines | step dots + keyboard arrows; scroll-jack disabled on mobile (vertical stack) |
@@ -22,7 +22,7 @@ community links → preview → dual CTA **Try Cloud** / **Self Host**.
 | A5 | SMPL/AI section (APP-003) | short explainer "AI-assisted body modeling", looping landmark-constellation animation (same asset as MI-12), link → GitBook deep-dive | |
 | A6 | For designers | split panel: "Post outfits, get commissioned, get paid" + earnings screenshot | |
 | A7 | Open source section | `docker compose up` snippet with copy button · architecture mini-diagram · GitHub + CONTRIBUTING links | copy button ✓ morph |
-| A7b | For developers — Contribute **[Directive 2026-07-18]** | stack line (Flutter · Go/Gin `api/common` · Python/FastAPI `api/measure`, architecture.md) · "interesting problems" list (on-device capture QC, escrow ledger, single-image SMPL fitting) · links: good-first-issues filter, CONTRIBUTING.md, Discord · GitHub star-count badge (reuses A1 fetch) | link cards lift 2px on hover; `github_click` fires here too |
+| A7b | For developers — Contribute **[Directive 2026-07-18]** | stack line (Flutter · Go/Gin `api/common` · Python/FastAPI `api/measure`, architecture.md) · "interesting problems" list (on-device capture QC, escrow ledger, single-image SMPL fitting) · links: good-first-issues filter, CONTRIBUTING.md, Discord · GitHub star badge (live count populated at runtime, reusing the A1 fetch; renders with no number in static designs, as A1) | link cards lift 2px on hover; `github_click` fires here too |
 | A7c | Self-host **[Directive 2026-07-18]** | data-ownership pitch (your measurements on your own metal — nothing leaves your server) · `docker compose up -d` one-liner (same snippet asset as A7) · "what ships" list (`api-common` · `api-measure` · `web`, per docker-compose.yml) · link → docs quickstart (GitBook) | copy button ✓ morph (shared with A7); `self_host_click` fires here too |
 | A8 | Community | Discord card (member count), roadmap link, CueLABS note | |
 | A9 | Cloud vs Self-host table (PRD §3) | feature comparison; Cloud column ends in Try Cloud CTA, OSS column in Self Host (→ docs quickstart) | |
@@ -154,7 +154,8 @@ Existing screens (splash/welcome/auth/capture) remain the entry path.
 
 | # | Screen | Spec |
 | --- | --- | --- |
-| C1 | Onboarding | Google-only sign-in (flows/auth.md §5 — one CTA screen; password/verification screens retired); post-signup interstitial: "Take your first measurement" (→C6) or "Explore outfits" — skippable |
+| C1 | Onboarding | Google-only sign-in (flows/auth.md §5 — one CTA screen; password/verification screens retired); first sign-in hands off to C1b |
+| C1b | Post-signup interstitial | "Take your first measurement" (→C6) or "Explore outfits" (→C3) — skippable; split out of the C1 row 2026-07-18 (the QA loop built it as its own screen) |
 | C2 | Home feed | = B1 minus right column; story rail on top; MI-1/2/3/4/5/6/16/18/20 all active |
 | C3 | Explore | search + 3-col grid; long-press peek preview (scale 0.97 + dim, MI haptic light); pull-to-refresh MI-5; search-results state = B2 **[Directive 2026-07-18]** |
 | C4 | Post detail | full-bleed carousel; action row; caption; comments sheet (swipe-up); Request CTA pinned bottom (safe-area) |


### PR DESCRIPTION
Aligns pages.md and design.md with the 2026-07-18 Figma QA loop.

## pages.md
- **A1 / A7b star badge reworded**: the live star count is populated at runtime; static designs render the badge with no number per the design-accuracy standard (design.md §8.2b) — kills the recurring audit conflict.
- **C-register verified against the loop's build**: C5 success state, C6 processing/countdown/manual-entry states, C9 other-user profile, caught-up feed states, B2 search-results state, B5 'Become a designer' upsell, B8 designer onboarding + payout states, and B9 /app/earnings were all already registered. One addition: **C1b post-signup interstitial** split out of the C1 row into its own register row (the loop built it as its own screen).

## design.md
- **§8.1**: as-built note on the Stage-4 screen-state rule — default/empty/loading frames exist across feed/explore/vault/orders/notifications and their dashboard equivalents.
- **§8.2b**: as-built fixes note [2026-07-18 QA loop] — Sheet master slot-strokes removed; textarea inner-height fix; RequestCard title truncation (1-line ellipsis, price always visible).
- **§8.4 Prototype (new)**: the prototype standard — named flow starting points per page (Mobile 'Onboarding → first order' + designer/payout/dispute/decline starts; Dashboard 'Feed' + moderation/decline/upsell/payout-state starts; Home 'Marketing site' with cross-page CTA handoff); wiring conventions (ON_CLICK NAVIGATE, DISSOLVE ~150–200ms nav/tab, SMART_ANIMATE pushes/backs, AFTER_TIMEOUT async verification); empty/loading/QA/index frames out of the flow by design; BFS reachability over the reaction graph; move-wire-restore technique for cross-page links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)