### PR TITLE
fix(web): W1 Figma-match QA — component fidelity pass

### DIFF
--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -392,12 +392,14 @@ export function ComponentGallery() {
             source="scan"
             confidence={0.92}
             history={[41.8, 42.0, 42.5]}
+            updatedAt={daysAgo(12)}
           />
           <MeasurementCard
             name="hip_width"
             valueCm={36.8}
             source="manual"
             confidence={0.62}
+            updatedAt={daysAgo(12)}
           />
         </div>
       </Section>
@@ -441,7 +443,7 @@ export function ComponentGallery() {
 
       <Section title="EmptyState">
         <div className="grid gap-4 md:grid-cols-2">
-          {(["feed", "vault", "orders", "explore", "notifications"] as EmptyStateContext[]).map((ctx) => (
+          {(["feed", "vault", "orders", "explore", "notifications", "camera-permission"] as EmptyStateContext[]).map((ctx) => (
             <EmptyState key={ctx} context={ctx} />
           ))}
         </div>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -230,28 +230,48 @@ body {
   }
 }
 
-/* MI-13 tape-measure slider (ManualMeasureRow) — gradient track fill */
+/* MI-13 tape-measure slider (ManualMeasureRow) — Figma master 66:695:
+   transparent track over the ruler ticks; accent dot thumb (ring when the
+   row is active). */
 .tape-slider {
   appearance: none;
-  height: 8px;
-  border-radius: var(--ap-radius-pill);
-  background: var(--ap-border);
+  height: 100%;
+  background: transparent;
   outline-offset: 4px;
+}
+.tape-slider::-webkit-slider-runnable-track {
+  background: transparent;
+}
+.tape-slider::-moz-range-track {
+  background: transparent;
 }
 .tape-slider::-webkit-slider-thumb {
   appearance: none;
-  width: 20px;
-  height: 20px;
+  width: 16px;
+  height: 16px;
   border-radius: var(--ap-radius-pill);
   background: var(--ap-accent-gradient);
-  border: 2px solid var(--ap-bg);
   cursor: pointer;
 }
 .tape-slider::-moz-range-thumb {
-  width: 20px;
-  height: 20px;
+  width: 16px;
+  height: 16px;
   border-radius: var(--ap-radius-pill);
   background: var(--ap-accent-gradient);
-  border: 2px solid var(--ap-bg);
+  border: none;
   cursor: pointer;
+}
+[data-state="active"] .tape-slider::-webkit-slider-thumb {
+  box-shadow:
+    0 0 0 3px var(--ap-bg),
+    0 0 0 5px var(--ap-accent-start);
+}
+[data-state="active"] .tape-slider::-moz-range-thumb {
+  box-shadow:
+    0 0 0 3px var(--ap-bg),
+    0 0 0 5px var(--ap-accent-start);
+}
+/* active row: the numeric value reads in the accent (MI-13 master) */
+[data-state="active"] input[inputmode="decimal"] {
+  color: var(--ap-accent-start);
 }

--- a/web/src/components/ui/AddressFieldset.test.tsx
+++ b/web/src/components/ui/AddressFieldset.test.tsx
@@ -17,7 +17,11 @@ describe("AddressFieldset (§8.2)", () => {
     render(
       <AddressFieldset context="profile-location" value={{}} onChange={() => {}} />,
     );
-    expect(screen.getByText(/recommend nearby designers/i)).toBeInTheDocument();
+    // Figma master copy (74:801)
+    expect(
+      screen.getByText(/recommend designers near you/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/pre-fills from your last order/i)).toBeInTheDocument();
     expect(screen.queryByText("Recipient name")).not.toBeInTheDocument();
   });
 

--- a/web/src/components/ui/AddressFieldset.tsx
+++ b/web/src/components/ui/AddressFieldset.tsx
@@ -47,6 +47,8 @@ export function AddressFieldset({
       disabled={disabled}
       className={clsx("flex flex-col gap-4", className)}
     >
+      {/* Figma master (74:801): address → city → state → country → phone,
+          stacked full-width; recipient/line-2 are web data-model additions */}
       {context === "delivery" ? (
         <>
           <FormRow label="Recipient name" required error={errors.recipient_name}>
@@ -57,19 +59,11 @@ export function AddressFieldset({
               error={errors.recipient_name}
             />
           </FormRow>
-          <FormRow label="Phone" required error={errors.phone}>
-            <Input
-              value={value.phone ?? ""}
-              onChange={(e) => set({ phone: e.target.value })}
-              placeholder="+234…"
-              error={errors.phone}
-            />
-          </FormRow>
           <FormRow label="Address line 1" required error={errors.line1}>
             <Input
               value={value.line1 ?? ""}
               onChange={(e) => set({ line1: e.target.value })}
-              placeholder="Street address"
+              placeholder="14 Adeola Odeku St"
               error={errors.line1}
             />
           </FormRow>
@@ -81,40 +75,60 @@ export function AddressFieldset({
             />
           </FormRow>
         </>
-      ) : (
-        <p className="text-caption text-text-2">
-          Used to recommend nearby designers — optional, and never shown
-          publicly.
-        </p>
-      )}
-      <div className="grid grid-cols-2 gap-4">
-        <FormRow label="City" required={context === "delivery"} error={errors.city}>
-          <Input
-            value={value.city ?? ""}
-            onChange={(e) => set({ city: e.target.value })}
-            placeholder="City"
-            error={errors.city}
-          />
-        </FormRow>
-        <FormRow label="State" required={context === "delivery"} error={errors.state}>
-          <Select
-            aria-label="State"
-            options={STATE_OPTIONS}
-            value={value.state || undefined}
-            onValueChange={(state) => set({ state })}
-            placeholder="Select state"
-            error={errors.state}
-            disabled={disabled}
-          />
-        </FormRow>
-      </div>
-      <FormRow label="Country" required={context === "delivery"} error={errors.country}>
+      ) : null}
+      <FormRow label="City" required={context === "delivery"} error={errors.city}>
         <Input
-          value={value.country ?? "NG"}
-          onChange={(e) => set({ country: e.target.value })}
-          error={errors.country}
+          value={value.city ?? ""}
+          onChange={(e) => set({ city: e.target.value })}
+          placeholder="Ikeja"
+          error={errors.city}
         />
       </FormRow>
+      <FormRow label="State" required={context === "delivery"} error={errors.state}>
+        <Select
+          aria-label="State"
+          options={STATE_OPTIONS}
+          value={value.state || undefined}
+          onValueChange={(state) => set({ state })}
+          placeholder="Lagos"
+          error={errors.state}
+          disabled={disabled}
+        />
+      </FormRow>
+      <FormRow label="Country" required={context === "delivery"} error={errors.country}>
+        <Select
+          aria-label="Country"
+          options={[{ value: "NG", label: "Nigeria" }]}
+          value={value.country ?? "NG"}
+          onValueChange={(country) => set({ country })}
+          error={errors.country}
+          disabled={disabled}
+        />
+      </FormRow>
+      {context === "delivery" ? (
+        <>
+          <FormRow label="Phone" required error={errors.phone}>
+            <Input
+              value={value.phone ?? ""}
+              onChange={(e) => set({ phone: e.target.value })}
+              placeholder="+234 801 234 5678"
+              error={errors.phone}
+            />
+          </FormRow>
+          <p className="text-caption text-text-2">
+            Saved with this order — address changes never affect placed orders
+          </p>
+        </>
+      ) : (
+        <div className="flex flex-col gap-1">
+          <p className="text-caption text-text-2">
+            Used to recommend designers near you
+          </p>
+          <p className="text-caption text-text-2">
+            Pre-fills from your last order
+          </p>
+        </div>
+      )}
     </fieldset>
   );
 }

--- a/web/src/components/ui/AppBar.tsx
+++ b/web/src/components/ui/AppBar.tsx
@@ -54,8 +54,12 @@ export function AppBar({
       ) : null}
       <div
         className={clsx(
-          "min-w-0 flex-1 truncate font-bold",
-          kind === "root" ? "text-title" : "text-body-lg",
+          "min-w-0 flex-1 truncate font-semibold",
+          // Figma master (85:994): root paints the gradient wordmark;
+          // sub/over-media center a 16px title between the actions.
+          kind === "root"
+            ? "bg-accent-gradient bg-clip-text text-title text-transparent"
+            : "text-center text-body-lg",
         )}
       >
         {title}

--- a/web/src/components/ui/Avatar.tsx
+++ b/web/src/components/ui/Avatar.tsx
@@ -6,7 +6,7 @@
 // Initials render when no image URL is provided.
 import clsx from "clsx";
 import Image from "next/image";
-import { BadgeCheck } from "lucide-react";
+import { Check } from "lucide-react";
 
 export type AvatarSize = 32 | 44 | 56 | 96;
 export type AvatarRing = "none" | "gradient" | "amber" | "gray";
@@ -71,13 +71,17 @@ export function Avatar({
             aria-label={name}
             style={dimension}
             className={clsx(
-              "grid select-none place-items-center rounded-pill bg-border/60 font-semibold text-text",
+              // Figma master (42:189): solid border-token fill, text-2
+              // initials (12px at 32 → 28px at 96).
+              "grid select-none place-items-center rounded-pill bg-border font-semibold text-text-2",
               ring !== "none" && "border-2 border-bg",
               size >= 96
-                ? "text-title"
+                ? "text-[28px]"
                 : size >= 56
                   ? "text-body-lg"
-                  : "text-caption",
+                  : size >= 44
+                    ? "text-body"
+                    : "text-micro",
             )}
           >
             {initials(name)}
@@ -85,14 +89,19 @@ export function Avatar({
         )}
       </span>
       {verified ? (
+        // Figma master: accent-gradient disc, 2px bg keyline, white check,
+        // flush to the bottom-right corner (14px at 32/44 → 28px at 96).
         <span
           data-testid="verified-badge"
           title="Verified designer"
-          className="absolute -bottom-0.5 -right-0.5 grid place-items-center rounded-pill bg-bg"
+          className={clsx(
+            "absolute bottom-0 right-0 grid place-items-center rounded-pill border-2 border-bg bg-accent-gradient text-on-accent",
+            size >= 96 ? "size-7" : size >= 56 ? "size-5" : "size-3.5",
+          )}
         >
-          <BadgeCheck
-            size={size >= 56 ? 18 : 14}
-            className="fill-link text-bg"
+          <Check
+            size={size >= 96 ? 17 : size >= 56 ? 12 : 8}
+            strokeWidth={3}
             aria-label="Verified designer"
           />
         </span>

--- a/web/src/components/ui/Banner.tsx
+++ b/web/src/components/ui/Banner.tsx
@@ -5,7 +5,7 @@
 // explainer). Used for KYC-lapse, offline retry, consent notices.
 import { useState } from "react";
 import clsx from "clsx";
-import { AlertTriangle, CheckCircle2, Info, X, XCircle } from "lucide-react";
+import { AlertTriangle, CheckCircle2, Info, X } from "lucide-react";
 
 export type BannerTone = "info" | "warn" | "error" | "success";
 
@@ -21,11 +21,20 @@ export interface BannerProps {
   className?: string;
 }
 
+// Figma master (95:1220): info=circled-i, warn/error=triangle, success=check.
 const TONE_ICON: Record<BannerTone, typeof Info> = {
   info: Info,
   warn: AlertTriangle,
-  error: XCircle,
+  error: AlertTriangle,
   success: CheckCircle2,
+};
+
+// Action links bind to the tone token (Learn more=link, Re-verify=warn…).
+const TONE_ACTION: Record<BannerTone, string> = {
+  info: "text-link",
+  warn: "text-warn",
+  error: "text-error",
+  success: "text-success",
 };
 
 export function Banner({
@@ -46,7 +55,7 @@ export function Banner({
       data-tone={tone}
       className={clsx(
         "flex items-start gap-3 rounded-card border px-4 py-3 text-body",
-        tone === "info" && "border-border bg-bg-elev text-text",
+        tone === "info" && "border-link/40 bg-link/10 text-text",
         tone === "warn" && "border-warn/40 bg-warn/10 text-text",
         tone === "error" && "border-error/40 bg-error/10 text-text",
         tone === "success" && "border-success/40 bg-success/10 text-text",
@@ -57,7 +66,7 @@ export function Banner({
         size={20}
         className={clsx(
           "mt-0.5 shrink-0",
-          tone === "info" && "text-text-2",
+          tone === "info" && "text-link",
           tone === "warn" && "text-warn",
           tone === "error" && "text-error",
           tone === "success" && "text-success",
@@ -68,7 +77,10 @@ export function Banner({
         <button
           type="button"
           onClick={onAction}
-          className="shrink-0 font-semibold text-link underline-offset-2 hover:underline"
+          className={clsx(
+            "shrink-0 font-semibold underline-offset-2 hover:underline",
+            TONE_ACTION[tone],
+          )}
         >
           {actionLabel}
         </button>

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -2,7 +2,9 @@
 
 // Button — design.md §8.2: kind gradient-primary / quiet / destructive /
 // link · size md 44 / sm 36 · state default / pressed / disabled / loading.
-// Pressed = active scale (fast/standard, reduced-motion safe).
+// Figma master (39:66): radius/card corners, px 16/12, label 14/13 semibold,
+// disabled 40%, loading = spinner-only. Pressed = Figma overlay tint +
+// active scale (fast/standard, reduced-motion safe).
 import { forwardRef, type ButtonHTMLAttributes } from "react";
 import clsx from "clsx";
 import { Spinner } from "./Spinner";
@@ -39,33 +41,35 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         data-kind={kind}
         data-size={size}
         className={clsx(
-          "inline-flex items-center justify-center gap-2 font-semibold",
+          "inline-flex items-center justify-center gap-2 rounded-card font-semibold",
           "transition-transform duration-120 ease-standard enabled:active:scale-[0.98]",
           "motion-reduce:transition-none motion-reduce:active:scale-100",
-          "disabled:opacity-50 disabled:cursor-not-allowed",
-          size === "md" ? "h-11 px-6 text-body-lg" : "h-9 px-4 text-body",
-          kind !== "link" && "rounded-pill",
-          kind === "gradient-primary" && "bg-accent-gradient text-on-accent",
-          kind === "quiet" && "border border-border bg-bg-elev text-text",
-          kind === "destructive" && "bg-error text-on-accent",
+          "disabled:opacity-40 disabled:cursor-not-allowed",
+          size === "md" ? "h-11 px-4 text-body" : "h-9 px-3 text-caption",
+          kind === "gradient-primary" &&
+            "bg-accent-gradient text-on-accent enabled:active:shadow-[inset_0_0_0_999px_rgba(0,0,0,0.16)]",
+          kind === "quiet" &&
+            "border border-border bg-bg-elev text-text enabled:active:bg-[rgba(128,128,128,0.18)]",
+          kind === "destructive" &&
+            "bg-error text-on-accent enabled:active:shadow-[inset_0_0_0_999px_rgba(0,0,0,0.16)]",
           kind === "link" &&
-            "h-auto px-0 text-link underline-offset-2 hover:underline",
+            "text-link underline-offset-2 hover:underline enabled:active:bg-[rgba(128,128,128,0.18)]",
           className,
         )}
         {...rest}
       >
         {loading ? (
+          // Figma master: loading swaps the label for a spinner at fixed
+          // width (spinner 18 md / 16 sm, on-accent on filled kinds).
           <Spinner
-            size={20}
-            kind={kind === "quiet" || kind === "link" ? "neutral" : "gradient"}
-            className={
-              kind === "gradient-primary" || kind === "destructive"
-                ? "text-on-accent"
-                : undefined
+            size={size === "md" ? 18 : 16}
+            kind={
+              kind === "quiet" || kind === "link" ? "neutral" : "on-accent"
             }
           />
-        ) : null}
-        {children}
+        ) : (
+          children
+        )}
       </button>
     );
   },

--- a/web/src/components/ui/CaptureOptionCard.test.tsx
+++ b/web/src/components/ui/CaptureOptionCard.test.tsx
@@ -7,16 +7,17 @@ describe("CaptureOptionCard (§8.2b)", () => {
   it("mode=webcam-upload renders its copy", () => {
     render(<CaptureOptionCard mode="webcam-upload" />);
     const card = screen.getByRole("button");
+    // Figma master (66:696) carries the canonical copy
     expect(card).toHaveAttribute("data-mode", "webcam-upload");
-    expect(card).toHaveTextContent("Webcam upload");
-    expect(card).toHaveTextContent("Two photos and your height");
+    expect(card).toHaveTextContent("Use your camera");
+    expect(card).toHaveTextContent("Full-body photo, we measure automatically");
   });
 
   it("mode=manual-entry renders its copy", () => {
     render(<CaptureOptionCard mode="manual-entry" />);
     const card = screen.getByRole("button");
     expect(card).toHaveAttribute("data-mode", "manual-entry");
-    expect(card).toHaveTextContent("Manual entry");
+    expect(card).toHaveTextContent("Enter manually");
   });
 
   it("fires onClick", async () => {

--- a/web/src/components/ui/CaptureOptionCard.tsx
+++ b/web/src/components/ui/CaptureOptionCard.tsx
@@ -4,7 +4,7 @@
 // the vault "Retake" options (pages.md B4 header; phone hand-off QR was cut
 // from scope).
 import clsx from "clsx";
-import { Camera, PencilRuler } from "lucide-react";
+import { Camera, ChevronRight, PencilRuler } from "lucide-react";
 
 export type CaptureOptionMode = "webcam-upload" | "manual-entry";
 
@@ -14,17 +14,18 @@ export interface CaptureOptionCardProps {
   className?: string;
 }
 
+// Figma masters (66:721) carry the canonical copy.
 const OPTION_COPY: Record<
   CaptureOptionMode,
   { title: string; body: string }
 > = {
   "webcam-upload": {
-    title: "Webcam upload",
-    body: "Two photos and your height — the AI does the rest.",
+    title: "Use your camera",
+    body: "Full-body photo, we measure automatically",
   },
   "manual-entry": {
-    title: "Manual entry",
-    body: "Tape-measure sliders and numeric input, cm or in.",
+    title: "Enter manually",
+    body: "Tape-measure your key metrics",
   },
 };
 
@@ -43,13 +44,15 @@ export function CaptureOptionCard({ mode, onClick, className }: CaptureOptionCar
         className,
       )}
     >
-      <span className="grid size-11 shrink-0 place-items-center rounded-pill bg-accent-gradient text-on-accent">
-        <Icon size={24} aria-hidden="true" />
+      {/* Figma master: soft accent-tint disc with an accent glyph */}
+      <span className="grid size-10 shrink-0 place-items-center rounded-pill bg-accent-start/12 text-accent-start">
+        <Icon size={20} aria-hidden="true" />
       </span>
-      <span className="flex min-w-0 flex-col gap-0.5">
-        <span className="text-body-lg font-semibold text-text">{copy.title}</span>
-        <span className="text-body text-text-2">{copy.body}</span>
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="text-body font-semibold text-text">{copy.title}</span>
+        <span className="text-caption text-text-2">{copy.body}</span>
       </span>
+      <ChevronRight size={16} className="shrink-0 text-text-2" aria-hidden />
     </button>
   );
 }

--- a/web/src/components/ui/CaptureOverlay.tsx
+++ b/web/src/components/ui/CaptureOverlay.tsx
@@ -34,20 +34,42 @@ export function CaptureOverlay({
     <div
       data-guide={guide}
       className={clsx(
-        "relative aspect-[3/4] w-full overflow-hidden rounded-card bg-black",
+        // Figma master (63:701): 9:16 viewport, 40% scrim, corner marks,
+        // top instruction line.
+        "relative aspect-[9/16] w-full overflow-hidden rounded-card bg-black",
         className,
       )}
     >
       <div className="absolute inset-0">{children}</div>
+      <div className="absolute inset-0 bg-black/40" aria-hidden />
 
-      {/* Dashed standing-silhouette guide (head → shoulders → arms-out →
-          ankles), centered over the viewport. */}
+      {/* viewfinder corner marks */}
+      <svg
+        data-testid="corner-marks"
+        viewBox="0 0 360 640"
+        aria-hidden="true"
+        className="absolute inset-0 size-full"
+        preserveAspectRatio="none"
+      >
+        <g fill="none" stroke="white" strokeWidth={3} strokeLinecap="round">
+          <path d="M24 56 V32 H48 M312 32 H336 V56 M336 584 V608 H312 M48 608 H24 V584" />
+        </g>
+      </svg>
+
+      {/* instruction line — 16px semibold white, top-centered */}
+      <p className="absolute inset-x-4 top-[9%] text-center text-body-lg font-semibold text-white">
+        {guide === "aligned" ? "Perfect — hold still" : "Stand inside the outline"}
+      </p>
+
+      {/* Standing-silhouette guide (head → shoulders → arms-out → ankles),
+          centered over the viewport; dashed while searching, solid success
+          stroke when aligned (MI-12). */}
       <svg
         data-testid="silhouette"
         viewBox="0 0 200 300"
         aria-hidden="true"
         className={clsx(
-          "absolute inset-0 m-auto h-[85%]",
+          "absolute inset-0 m-auto h-[70%]",
           guide === "searching" &&
             "animate-[silhouette-pulse_2s_ease-in-out_infinite] motion-reduce:animate-none motion-reduce:opacity-70",
           guide !== "searching" && "opacity-80",
@@ -57,7 +79,7 @@ export function CaptureOverlay({
           fill="none"
           stroke={guide === "aligned" ? "var(--ap-success)" : "white"}
           strokeWidth={2.5}
-          strokeDasharray="6 6"
+          strokeDasharray={guide === "aligned" ? undefined : "6 6"}
           strokeLinecap="round"
           strokeLinejoin="round"
         >

--- a/web/src/components/ui/CaptureResults.test.tsx
+++ b/web/src/components/ui/CaptureResults.test.tsx
@@ -22,19 +22,23 @@ function renderResults(overrides: Partial<Parameters<typeof CaptureResults>[0]> 
 }
 
 describe("CaptureResults (§8.2b)", () => {
+  // Figma master (65:612): the header carries a confidence pill; the full
+  // count/mean summary lives in its title attribute.
   it("header summarizes count, mean confidence, and low-confidence flags", () => {
     renderResults();
-    expect(screen.getByTestId("confidence-summary")).toHaveTextContent(
-      "2 measurements · 77% average confidence · 1 low — consider retaking",
+    const pill = screen.getByTestId("confidence-summary");
+    expect(pill).toHaveTextContent("1 low confidence");
+    expect(pill).toHaveAttribute(
+      "title",
+      "2 measurements · 77% average confidence",
     );
   });
 
   it("omits the low flag when everything clears 0.7", () => {
     renderResults({ confidences: [0.92, 0.88] });
-    expect(screen.getByTestId("confidence-summary")).toHaveTextContent(
-      "2 measurements · 90% average confidence",
-    );
-    expect(screen.getByTestId("confidence-summary")).not.toHaveTextContent("low");
+    const pill = screen.getByTestId("confidence-summary");
+    expect(pill).toHaveTextContent("High confidence");
+    expect(pill).not.toHaveTextContent("low");
   });
 
   it("staggers the card list 60ms apart (MI-12), reduced-motion safe", () => {
@@ -58,7 +62,10 @@ describe("CaptureResults (§8.2b)", () => {
 
   it("saving: save shows loading, retake disabled", () => {
     renderResults({ saving: true });
-    expect(screen.getByRole("button", { name: /Save to vault/ })).toBeDisabled();
+    // Figma Button master: loading swaps the label for a spinner
+    const saving = document.querySelector('button[aria-busy="true"]');
+    expect(saving).not.toBeNull();
+    expect(saving).toBeDisabled();
     expect(screen.getByRole("button", { name: "Retake" })).toBeDisabled();
   });
 });

--- a/web/src/components/ui/CaptureResults.tsx
+++ b/web/src/components/ui/CaptureResults.tsx
@@ -34,19 +34,27 @@ export function CaptureResults({
 
   return (
     <div className={clsx("flex flex-col gap-4", className)}>
-      <header className="flex flex-col gap-1">
-        <h2 className="text-title font-bold text-text">Your measurements</h2>
-        <p data-testid="confidence-summary" className="text-body text-text-2">
-          {count} measurement{count === 1 ? "" : "s"} ·{" "}
-          <span className="tnum">{Math.round(mean * 100)}%</span> average
-          confidence
-          {lowCount > 0
-            ? ` · ${lowCount} low — consider retaking`
-            : ""}
-        </p>
+      {/* Figma master (65:612): title + confidence pill header, stacked
+          cards, Save (gradient, wide) beside Retake (quiet). */}
+      <header className="flex items-center justify-between gap-3">
+        <h2 className="text-body-lg font-semibold text-text">
+          Your measurements
+        </h2>
+        <span
+          data-testid="confidence-summary"
+          title={`${count} measurement${count === 1 ? "" : "s"} · ${Math.round(mean * 100)}% average confidence`}
+          className={clsx(
+            "inline-flex h-6 items-center rounded-pill px-2 text-micro font-semibold",
+            lowCount > 0
+              ? "bg-warn/14 text-warn"
+              : "bg-success/14 text-success",
+          )}
+        >
+          {lowCount > 0 ? `${lowCount} low confidence` : "High confidence"}
+        </span>
       </header>
 
-      <div className="grid grid-cols-2 gap-3">
+      <div className="flex flex-col gap-3">
         {Children.map(children, (child, i) => (
           <div
             style={{ animationDelay: `${i * 60}ms` }}
@@ -57,8 +65,13 @@ export function CaptureResults({
         ))}
       </div>
 
-      <div className="flex flex-col gap-2">
-        <Button kind="gradient-primary" loading={saving} onClick={onSave}>
+      <div className="flex gap-2">
+        <Button
+          kind="gradient-primary"
+          loading={saving}
+          onClick={onSave}
+          className="flex-1"
+        >
           Save to vault
         </Button>
         <Button kind="quiet" disabled={saving} onClick={onRetake}>

--- a/web/src/components/ui/CaughtUpDivider.tsx
+++ b/web/src/components/ui/CaughtUpDivider.tsx
@@ -9,9 +9,10 @@ export function CaughtUpDivider({ className }: { className?: string }) {
       data-testid="caught-up"
       className={clsx("flex items-center gap-4 py-6", className)}
     >
+      {/* Figma master (96:1214): accent-ringed check + text-token label */}
       <span className="h-px flex-1 bg-border" />
-      <span className="flex items-center gap-2 text-body text-text-2">
-        <CheckCircle2 size={20} className="text-success" />
+      <span className="flex items-center gap-2 text-body font-semibold text-text">
+        <CheckCircle2 size={20} className="text-accent-start" />
         You&apos;re all caught up
       </span>
       <span className="h-px flex-1 bg-border" />

--- a/web/src/components/ui/Chip.tsx
+++ b/web/src/components/ui/Chip.tsx
@@ -29,10 +29,12 @@ export function Chip({
       data-kind={kind}
       aria-pressed={kind === "selected" || undefined}
       className={clsx(
-        "inline-flex h-8 items-center gap-1 rounded-pill border px-3 text-body",
+        // Figma master (41:19): 13px semibold label; selected = solid
+        // text-token fill (reads as active filter, not an action).
+        "inline-flex h-8 items-center gap-1.5 rounded-pill border px-3 text-caption font-semibold",
         "transition-colors duration-120 ease-standard motion-reduce:transition-none",
         kind === "selected"
-          ? "border-transparent bg-accent-gradient font-semibold text-on-accent"
+          ? "border-transparent bg-text text-bg"
           : "border-border bg-bg-elev text-text",
         className,
       )}
@@ -50,7 +52,7 @@ export function Chip({
           }}
           className="-mr-1 grid size-4 place-items-center rounded-pill text-text-2 hover:text-text"
         >
-          <X size={12} strokeWidth={2.5} />
+          <X size={14} strokeWidth={2.5} />
         </span>
       ) : null}
     </button>

--- a/web/src/components/ui/CodeSnippetBlock.tsx
+++ b/web/src/components/ui/CodeSnippetBlock.tsx
@@ -38,20 +38,25 @@ export function CodeSnippetBlock({
         <span className="select-none text-bg/50">$ </span>
         {code}
       </code>
+      {/* Figma master (Stage 5): labeled Copy pill; ✓ Copied turns success */}
       <button
         type="button"
         aria-label={copied ? "Copied" : "Copy command"}
         onClick={copy}
         className={clsx(
-          "grid size-8 shrink-0 place-items-center rounded-card text-bg/70 hover:bg-bg/10 hover:text-bg",
-          "transition-transform duration-120 ease-standard motion-reduce:transition-none",
+          "flex h-7 shrink-0 items-center gap-1.5 rounded-pill border px-3 text-micro font-semibold",
+          "transition-colors duration-120 ease-standard motion-reduce:transition-none",
+          copied
+            ? "border-success text-success"
+            : "border-bg/30 text-bg hover:bg-bg/10",
         )}
       >
         {copied ? (
-          <Check size={16} data-testid="copied-check" className="text-success" />
+          <Check size={14} data-testid="copied-check" className="text-success" />
         ) : (
-          <Copy size={16} />
+          <Copy size={14} />
         )}
+        {copied ? "Copied" : "Copy"}
       </button>
     </div>
   );

--- a/web/src/components/ui/CommentRow.tsx
+++ b/web/src/components/ui/CommentRow.tsx
@@ -40,20 +40,30 @@ export function CommentRow({
     >
       <Avatar size={32} name={comment.author.username} src={comment.author.avatar_url} />
       <div className="min-w-0 flex-1">
+        {/* Figma master (92:1077): the comment text stays visible while
+            posting; the meta line reads "Posting…" */}
         <p className="text-body text-text">
           <span className="font-semibold">{comment.author.username}</span>{" "}
           {comment.body}
         </p>
         <div className="mt-1 flex items-center gap-4 text-micro text-text-2">
-          <time dateTime={comment.created_at}>{formatAgo(comment.created_at)}</time>
-          {comment.like_count > 0 ? (
-            <span className="tnum">{comment.like_count} likes</span>
-          ) : null}
-          {onReply ? (
-            <button type="button" onClick={onReply} className="font-semibold">
-              Reply
-            </button>
-          ) : null}
+          {posting ? (
+            <span>Posting…</span>
+          ) : (
+            <>
+              <time dateTime={comment.created_at}>
+                {formatAgo(comment.created_at)}
+              </time>
+              {comment.like_count > 0 ? (
+                <span className="tnum">{comment.like_count} likes</span>
+              ) : null}
+              {onReply ? (
+                <button type="button" onClick={onReply} className="font-semibold">
+                  Reply
+                </button>
+              ) : null}
+            </>
+          )}
         </div>
       </div>
       <button

--- a/web/src/components/ui/CommunityCard.tsx
+++ b/web/src/components/ui/CommunityCard.tsx
@@ -50,7 +50,12 @@ export function CommunityCard({
         Builders, designers, and tailors shaping open-source fashion tech —
         roadmap talk, capture-QC debugging, and show-and-tell.
       </p>
-      <Button kind="quiet" size="sm" onClick={() => window.open(discordHref, "_blank")}>
+      {/* Figma master (Stage 5): the Join CTA paints the gradient */}
+      <Button
+        kind="gradient-primary"
+        size="sm"
+        onClick={() => window.open(discordHref, "_blank")}
+      >
         Join Discord
       </Button>
     </div>

--- a/web/src/components/ui/ComparisonTable.test.tsx
+++ b/web/src/components/ui/ComparisonTable.test.tsx
@@ -10,14 +10,14 @@ describe("ComparisonTable (§8.2b marketing, pages.md A9)", () => {
     expect(screen.getByRole("columnheader", { name: "Self-host" })).toBeInTheDocument();
   });
 
-  it("CTA row: Cloud → Try Cloud, OSS → Self Host", async () => {
+  it("CTA row: Cloud → Start on Cloud, OSS → Self-host it (Stage 5 master)", async () => {
     const onTryCloud = vi.fn();
     const onSelfHost = vi.fn();
     render(<ComparisonTable onTryCloud={onTryCloud} onSelfHost={onSelfHost} />);
     const ctaRow = screen.getByTestId("cta-row");
     expect(ctaRow).toBeInTheDocument();
-    await userEvent.click(screen.getByRole("button", { name: "Try Cloud" }));
-    await userEvent.click(screen.getByRole("button", { name: "Self Host" }));
+    await userEvent.click(screen.getByRole("button", { name: "Start on Cloud" }));
+    await userEvent.click(screen.getByRole("button", { name: "Self-host it" }));
     expect(onTryCloud).toHaveBeenCalledOnce();
     expect(onSelfHost).toHaveBeenCalledOnce();
   });

--- a/web/src/components/ui/ComparisonTable.tsx
+++ b/web/src/components/ui/ComparisonTable.tsx
@@ -40,40 +40,54 @@ export function ComparisonTable({
   className,
 }: ComparisonTableProps) {
   return (
-    <table className={clsx("w-full max-w-2xl border-collapse text-body", className)}>
-      <thead>
-        <tr className="border-b border-border text-left">
-          <th className="py-3 pr-4 font-semibold text-text">Feature</th>
-          <th className="w-36 py-3 text-center font-semibold text-text">Cloud</th>
-          <th className="w-36 py-3 text-center font-semibold text-text">Self-host</th>
-        </tr>
-      </thead>
-      <tbody>
-        {rows.map((row) => (
-          <tr key={row.feature} className="border-b border-border">
-            <td className="py-3 pr-4 text-text">{row.feature}</td>
-            <td className="py-3 text-center">
-              <Cell value={row.cloud} />
+    // Figma master (Stage 5): the table sits in a bordered card; the
+    // Feature header reads as a caption, CTAs are "Start on Cloud" /
+    // "Self-host it".
+    <div
+      className={clsx(
+        "w-full max-w-2xl overflow-hidden rounded-card border border-border bg-bg-elev",
+        className,
+      )}
+    >
+      <table className="w-full border-collapse text-body">
+        <thead>
+          <tr className="border-b border-border text-left">
+            <th className="px-4 py-3 text-caption font-normal text-text-2">
+              Feature
+            </th>
+            <th className="w-36 py-3 text-center font-semibold text-text">Cloud</th>
+            <th className="w-36 px-4 py-3 text-center font-semibold text-text">
+              Self-host
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.feature} className="border-b border-border">
+              <td className="px-4 py-3 text-text">{row.feature}</td>
+              <td className="py-3 text-center">
+                <Cell value={row.cloud} />
+              </td>
+              <td className="px-4 py-3 text-center">
+                <Cell value={row.oss} />
+              </td>
+            </tr>
+          ))}
+          <tr data-testid="cta-row">
+            <td className="py-4" />
+            <td className="py-4 text-center">
+              <Button kind="gradient-primary" size="sm" onClick={onTryCloud}>
+                Start on Cloud
+              </Button>
             </td>
-            <td className="py-3 text-center">
-              <Cell value={row.oss} />
+            <td className="px-4 py-4 text-center">
+              <Button kind="quiet" size="sm" onClick={onSelfHost}>
+                Self-host it
+              </Button>
             </td>
           </tr>
-        ))}
-        <tr data-testid="cta-row">
-          <td className="py-4" />
-          <td className="py-4 text-center">
-            <Button kind="gradient-primary" size="sm" onClick={onTryCloud}>
-              Try Cloud
-            </Button>
-          </td>
-          <td className="py-4 text-center">
-            <Button kind="quiet" size="sm" onClick={onSelfHost}>
-              Self Host
-            </Button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/web/src/components/ui/DateInput.tsx
+++ b/web/src/components/ui/DateInput.tsx
@@ -63,10 +63,14 @@ export function DateInput({
           disabled={disabled}
           aria-invalid={error ? true : undefined}
           className={clsx(
-            "flex h-11 items-center justify-between gap-2 rounded-card border bg-bg-elev px-3 text-body-lg",
+            // Figma form-kit frame (74:801): 14px value, 1.5px error border,
+            // 2px accent focus, 40% disabled.
+            "flex h-11 items-center justify-between gap-2 rounded-card bg-bg-elev px-3 text-body",
             "transition-colors duration-120 ease-standard motion-reduce:transition-none",
-            "disabled:opacity-50",
-            error ? "border-error" : "border-border focus:border-accent-start",
+            "disabled:opacity-40",
+            error
+              ? "border-[1.5px] border-error"
+              : "border border-border focus:border-2 focus:border-accent-start",
             value ? "text-text" : "text-text-2",
           )}
           {...rest}

--- a/web/src/components/ui/EarningsSummary.tsx
+++ b/web/src/components/ui/EarningsSummary.tsx
@@ -4,7 +4,7 @@
 // pending (held escrow) cards · TransactionRow kind payout / escrow-held /
 // fee-line (10%) · amount tabular + provider ref.
 import clsx from "clsx";
-import { ArrowDownToLine, Lock, Percent } from "lucide-react";
+import { CreditCard, Info, ShieldCheck } from "lucide-react";
 import type { Earnings, EarningsEntry } from "@/models";
 import { formatAgo, formatNaira } from "@/lib/format";
 
@@ -20,8 +20,9 @@ export function EarningsSummary({ earnings, className }: EarningsSummaryProps) {
         data-testid="balance-card"
         className="flex flex-col gap-1 rounded-card border border-border bg-bg-elev p-4"
       >
-        <span className="text-caption text-text-2">Balance (released)</span>
-        <span className="tnum text-title-lg font-bold text-text">
+        {/* Figma master (97:1249): "Available" / "In escrow", green value */}
+        <span className="text-caption text-text-2">Available</span>
+        <span className="tnum text-title-lg font-bold text-success">
           {formatNaira(earnings.balance_cents, earnings.currency)}
         </span>
       </div>
@@ -29,7 +30,7 @@ export function EarningsSummary({ earnings, className }: EarningsSummaryProps) {
         data-testid="pending-card"
         className="flex flex-col gap-1 rounded-card border border-border bg-bg-elev p-4"
       >
-        <span className="text-caption text-text-2">Pending (escrow)</span>
+        <span className="text-caption text-text-2">In escrow</span>
         <span className="tnum text-title-lg font-bold text-warn">
           {formatNaira(earnings.pending_cents, earnings.currency)}
         </span>
@@ -38,10 +39,12 @@ export function EarningsSummary({ earnings, className }: EarningsSummaryProps) {
   );
 }
 
+// Figma masters (97:1281): card glyph for payouts, shield for escrow,
+// info for the fee line.
 const KIND_META = {
-  payout: { icon: ArrowDownToLine, label: "Payout" },
-  escrow_held: { icon: Lock, label: "Escrow held" },
-  fee_line: { icon: Percent, label: "Platform fee (10%)" },
+  payout: { icon: CreditCard, label: "Payout" },
+  escrow_held: { icon: ShieldCheck, label: "Escrow held" },
+  fee_line: { icon: Info, label: "Platform fee (10%)" },
 } as const;
 
 export interface TransactionRowProps {
@@ -61,14 +64,7 @@ export function TransactionRow({ entry, className }: TransactionRowProps) {
         className,
       )}
     >
-      <span
-        className={clsx(
-          "grid size-9 shrink-0 place-items-center rounded-pill border border-border",
-          entry.kind === "payout" && "text-success",
-          entry.kind === "escrow_held" && "text-warn",
-          entry.kind === "fee_line" && "text-text-2",
-        )}
-      >
+      <span className="grid size-9 shrink-0 place-items-center rounded-pill border border-border text-text-2">
         <Icon size={16} />
       </span>
       <div className="min-w-0 flex-1">
@@ -80,14 +76,11 @@ export function TransactionRow({ entry, className }: TransactionRowProps) {
           {entry.provider_ref ? ` · ${entry.provider_ref}` : ""}
         </p>
       </div>
+      {/* Figma master: debits read in the text tokens, credits in success */}
       <span
         className={clsx(
           "tnum shrink-0 text-body font-semibold",
-          negative
-            ? "text-text-2"
-            : entry.kind === "escrow_held"
-              ? "text-warn"
-              : "text-success",
+          negative ? "text-text" : "text-success",
         )}
       >
         {negative ? "" : "+"}

--- a/web/src/components/ui/EmptyState.tsx
+++ b/web/src/components/ui/EmptyState.tsx
@@ -5,10 +5,11 @@
 import clsx from "clsx";
 import {
   Bell,
-  Compass,
+  Camera,
+  Home,
   Package,
   Ruler,
-  Users,
+  Search,
   type LucideIcon,
 } from "lucide-react";
 import { Button } from "./Button";
@@ -18,33 +19,57 @@ export type EmptyStateContext =
   | "vault"
   | "orders"
   | "explore"
-  | "notifications";
+  | "notifications"
+  | "camera-permission";
 
-const CONTEXT: Record<EmptyStateContext, { icon: LucideIcon; line: string; cta: string }> = {
+// Figma masters (54:459): icon, copy and CTA kind per context; primary CTAs
+// paint the gradient, recovery/secondary ones stay quiet.
+const CONTEXT: Record<
+  EmptyStateContext,
+  {
+    icon: LucideIcon;
+    line: string;
+    cta: string;
+    ctaKind: "gradient-primary" | "quiet";
+    cta2?: string;
+  }
+> = {
   feed: {
-    icon: Users,
+    icon: Home,
     line: "Follow designers to fill your feed",
-    cta: "Explore designers",
+    cta: "Explore outfits",
+    ctaKind: "gradient-primary",
   },
   vault: {
     icon: Ruler,
-    line: "No measurements yet — take your first capture",
-    cta: "Measure now",
+    line: "No measurements yet — take your first scan",
+    cta: "Take measurement",
+    ctaKind: "gradient-primary",
   },
   orders: {
     icon: Package,
-    line: "No orders yet — request an outfit you love",
-    cta: "Explore outfits",
+    line: "No orders yet",
+    cta: "Discover designers",
+    ctaKind: "quiet",
   },
   explore: {
-    icon: Compass,
+    icon: Search,
     line: "Nothing matches that search",
-    cta: "Clear filters",
+    cta: "Clear search",
+    ctaKind: "quiet",
   },
   notifications: {
     icon: Bell,
-    line: "You're all caught up — nothing new",
+    line: "You're all caught up",
     cta: "Back to feed",
+    ctaKind: "quiet",
+  },
+  "camera-permission": {
+    icon: Camera,
+    line: "Camera access is off — enable it in Settings to measure automatically",
+    cta: "Open Settings",
+    ctaKind: "gradient-primary",
+    cta2: "Enter manually instead",
   },
 };
 
@@ -54,6 +79,8 @@ export interface EmptyStateProps {
   line?: string;
   ctaLabel?: string;
   onCta?: () => void;
+  /** camera-permission carries a quiet secondary CTA (98:1274). */
+  onSecondaryCta?: () => void;
   className?: string;
 }
 
@@ -62,6 +89,7 @@ export function EmptyState({
   line,
   ctaLabel,
   onCta,
+  onSecondaryCta,
   className,
 }: EmptyStateProps) {
   const spec = CONTEXT[context];
@@ -86,13 +114,31 @@ export function EmptyState({
         </defs>
         <rect width="100%" height="100%" fill={`url(#es-${context})`} />
       </svg>
-      <span className="relative grid size-16 place-items-center rounded-pill border border-border bg-bg-elev">
-        <Icon size={28} className="text-text-2" />
+      {/* Figma master: 88px dashed ring, 32px text-2 glyph, 13px text-2 line */}
+      <span className="relative grid size-[88px] place-items-center rounded-pill border border-dashed border-border bg-bg-elev">
+        <Icon size={32} className="text-text-2" />
       </span>
-      <p className="relative text-body-lg text-text">{line ?? spec.line}</p>
-      <Button kind="gradient-primary" size="sm" onClick={onCta} className="relative">
+      <p className="relative max-w-80 text-caption text-text-2">
+        {line ?? spec.line}
+      </p>
+      <Button
+        kind={spec.ctaKind}
+        size="sm"
+        onClick={onCta}
+        className="relative"
+      >
         {ctaLabel ?? spec.cta}
       </Button>
+      {spec.cta2 ? (
+        <Button
+          kind="quiet"
+          size="sm"
+          onClick={onSecondaryCta}
+          className="relative"
+        >
+          {spec.cta2}
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/web/src/components/ui/FormRow.test.tsx
+++ b/web/src/components/ui/FormRow.test.tsx
@@ -24,12 +24,12 @@ describe("FormRow (§8.2)", () => {
     expect(screen.queryByText("3–30 chars")).not.toBeInTheDocument();
   });
 
-  it("marks required fields", () => {
+  it("marks required fields for assistive tech (no visual star — 74:801)", () => {
     render(
       <FormRow label="Phone" required>
         <Input aria-label="Phone" />
       </FormRow>,
     );
-    expect(screen.getByText("*")).toBeInTheDocument();
+    expect(screen.getByText("(required)")).toHaveClass("sr-only");
   });
 });

--- a/web/src/components/ui/FormRow.tsx
+++ b/web/src/components/ui/FormRow.tsx
@@ -25,16 +25,18 @@ export function FormRow({
   className,
 }: FormRowProps) {
   return (
-    <div className={clsx("flex flex-col gap-1.5", className)} data-error={!!error || undefined}>
+    <div className={clsx("flex flex-col gap-2", className)} data-error={!!error || undefined}>
       <label htmlFor={htmlFor} className="text-body font-semibold text-text">
         {label}
-        {required ? <span className="text-error"> *</span> : null}
+        {/* Figma master (74:801) draws no required marker — announce it
+            to assistive tech only. */}
+        {required ? <span className="sr-only"> (required)</span> : null}
       </label>
       {children}
       {error ? (
-        <p className="text-micro text-error">{error}</p>
+        <p className="text-caption text-error">{error}</p>
       ) : helper ? (
-        <p className="text-micro text-text-2">{helper}</p>
+        <p className="text-caption text-text-2">{helper}</p>
       ) : null}
     </div>
   );

--- a/web/src/components/ui/GoogleAuthButton.tsx
+++ b/web/src/components/ui/GoogleAuthButton.tsx
@@ -57,17 +57,23 @@ export function GoogleAuthButton({
         disabled={disabled || loading}
         aria-busy={loading}
         className={clsx(
-          // md button: 44px height, pill radius, hairline border on bg-elev
-          "flex h-11 items-center justify-center gap-3 rounded-pill border border-border bg-bg-elev px-6",
-          "text-body-lg font-semibold text-text",
+          // Figma master (83:887): 48px, radius/card, hairline border,
+          // 14px semibold; loading keeps the G and swaps the label for a
+          // spinner; pressed tints the surface.
+          "flex h-12 items-center justify-center gap-3 rounded-card border border-border bg-bg-elev px-6",
+          "text-body font-semibold text-text",
           "transition-transform duration-120 ease-standard",
-          "enabled:active:scale-[0.98]", // pressed
-          "disabled:opacity-50 disabled:cursor-not-allowed",
+          "enabled:active:scale-[0.98] enabled:active:bg-[rgba(128,128,128,0.18)]",
+          "disabled:opacity-40 disabled:cursor-not-allowed",
           "motion-reduce:transition-none motion-reduce:active:scale-100",
         )}
       >
-        {loading ? <Spinner size={20} kind="neutral" /> : <GoogleG size={18} />}
-        <span>Continue with Google</span>
+        <GoogleG size={18} />
+        {loading ? (
+          <Spinner size={20} kind="neutral" />
+        ) : (
+          <span>Continue with Google</span>
+        )}
       </button>
       {notice ? (
         <p role="status" className="text-center text-caption text-text-2">

--- a/web/src/components/ui/GridTile.tsx
+++ b/web/src/components/ui/GridTile.tsx
@@ -5,7 +5,7 @@
 // carousel. Explore masonry + profile grids.
 import clsx from "clsx";
 import Image from "next/image";
-import { Copy, Heart, MessageCircle } from "lucide-react";
+import { Camera, Copy, Heart, MessageCircle } from "lucide-react";
 import { Skeleton } from "./Skeleton";
 
 export interface GridTileProps {
@@ -29,7 +29,7 @@ export function GridTile({
   onClick,
   className,
 }: GridTileProps) {
-  if (skeleton || !src) {
+  if (skeleton) {
     return <Skeleton kind="media" className={clsx("rounded-none", className)} />;
   }
   return (
@@ -42,7 +42,14 @@ export function GridTile({
         className,
       )}
     >
-      <Image src={src} alt={alt} fill sizes="(max-width: 768px) 33vw, 300px" className="object-cover" />
+      {src ? (
+        <Image src={src} alt={alt} fill sizes="(max-width: 768px) 33vw, 300px" className="object-cover" />
+      ) : (
+        // Figma master (86:984): media-less default shows a camera glyph
+        <span className="absolute inset-0 grid place-items-center text-text-2">
+          <Camera size={24} aria-hidden />
+        </span>
+      )}
       {carousel ? (
         <span
           data-testid="carousel-badge"

--- a/web/src/components/ui/IconButton.tsx
+++ b/web/src/components/ui/IconButton.tsx
@@ -25,8 +25,8 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
           "inline-grid place-items-center rounded-pill text-text",
           "transition-transform duration-120 ease-standard enabled:active:scale-90",
           "motion-reduce:transition-none motion-reduce:active:scale-100",
-          "disabled:opacity-50 disabled:cursor-not-allowed",
-          "hover:bg-border/40",
+          "disabled:opacity-40 disabled:cursor-not-allowed",
+          "hover:bg-border/40 enabled:active:bg-[rgba(128,128,128,0.18)]",
           size === "md" ? "size-11" : "size-9",
           className,
         )}

--- a/web/src/components/ui/Input.tsx
+++ b/web/src/components/ui/Input.tsx
@@ -39,12 +39,15 @@ export interface TextareaProps
   maxLength?: number;
 }
 
-const frame = (error: boolean, disabled: boolean) =>
+// Figma master (40:76): focus = 2px accent border, error = 1.5px error
+// border, disabled = 40% opacity on the whole field.
+const frame = (error: boolean, disabled: boolean, multiline = false) =>
   clsx(
-    "flex items-center gap-2 rounded-card border bg-bg-elev px-3 transition-colors duration-120 ease-standard",
-    "focus-within:border-accent-start motion-reduce:transition-none",
-    error ? "border-error" : "border-border",
-    disabled && "opacity-50",
+    "flex rounded-card bg-bg-elev px-3 transition-colors duration-120 ease-standard",
+    multiline ? "flex-col items-start gap-2 py-3" : "h-11 items-center gap-2",
+    "focus-within:border-2 focus-within:border-accent-start motion-reduce:transition-none",
+    error ? "border-[1.5px] border-error" : "border border-border",
+    disabled && "opacity-40",
   );
 
 export function Input(props: InputProps | TextareaProps) {
@@ -58,28 +61,29 @@ export function Input(props: InputProps | TextareaProps) {
     const length = String(rest.value ?? "").length;
     return (
       <div className={clsx("flex flex-col gap-1", className)} data-kind="textarea">
-        <div className={clsx(frame(!!error, !!rest.disabled), "py-2")}>
+        <div className={frame(!!error, !!rest.disabled, true)}>
           <textarea
             rows={3}
             maxLength={maxLength}
             aria-invalid={error ? true : undefined}
             aria-describedby={error ? errorId : undefined}
-            className="min-h-20 w-full resize-y bg-transparent text-body text-text outline-none placeholder:text-text-2"
+            className="min-h-16 w-full resize-y bg-transparent text-body text-text outline-none placeholder:text-text-2"
             {...rest}
           />
-        </div>
-        <div className="flex justify-between text-micro text-text-2">
-          {error ? (
-            <span id={errorId} className="text-error">
-              {error}
+          {/* Figma master: counter sits inside the field, bottom-right. */}
+          <div className="flex w-full justify-end text-micro">
+            <span
+              className={clsx("tnum", error ? "text-error" : "text-text-2")}
+            >
+              {length}/{maxLength}
             </span>
-          ) : (
-            <span />
-          )}
-          <span className="tnum">
-            {length}/{maxLength}
-          </span>
+          </div>
         </div>
+        {error ? (
+          <span id={errorId} className="text-caption text-error">
+            {error}
+          </span>
+        ) : null}
       </div>
     );
   }
@@ -90,12 +94,14 @@ export function Input(props: InputProps | TextareaProps) {
 
   return (
     <div className={clsx("flex flex-col gap-1", className)} data-kind={kind}>
-      <div className={clsx(frame(!!error, !!disabled), "h-11")}>
+      <div className={frame(!!error, !!disabled)}>
         {kind === "search" ? (
           <Search size={18} className="shrink-0 text-text-2" aria-hidden />
         ) : null}
         {kind === "currency" ? (
-          <span className="shrink-0 text-body-lg text-text-2">₦</span>
+          <span className="shrink-0 text-body font-semibold text-text-2">
+            ₦
+          </span>
         ) : null}
         <input
           type={kind === "numeric" || kind === "currency" ? "text" : kind === "search" ? "search" : "text"}
@@ -104,17 +110,22 @@ export function Input(props: InputProps | TextareaProps) {
           aria-invalid={error ? true : undefined}
           aria-describedby={error ? errorId : undefined}
           className={clsx(
-            "w-full bg-transparent text-body-lg text-text outline-none placeholder:text-text-2",
+            "w-full bg-transparent text-body text-text outline-none placeholder:text-text-2",
             (kind === "numeric" || kind === "currency") && "tnum",
           )}
           {...rest}
         />
+        {kind === "currency" ? (
+          <span className="shrink-0 text-micro font-semibold text-text-2">
+            NGN
+          </span>
+        ) : null}
         {kind === "numeric" && unit && onUnitChange ? (
           <UnitToggle unit={unit} onUnitChange={onUnitChange} disabled={disabled} />
         ) : null}
       </div>
       {error ? (
-        <span id={errorId} className="text-micro text-error">
+        <span id={errorId} className="text-caption text-error">
           {error}
         </span>
       ) : null}
@@ -122,7 +133,9 @@ export function Input(props: InputProps | TextareaProps) {
   );
 }
 
-/** MI-13 cm/in toggle — flips with a 3D x-rotation, 200ms. */
+/** MI-13 cm/in toggle — flips with a 3D x-rotation, 200ms.
+ * Figma master (40:19): segmented pill on a border-token track; the active
+ * unit fills with the text token, the inactive one reads as text-2. */
 function UnitToggle({
   unit,
   onUnitChange,
@@ -144,13 +157,23 @@ function UnitToggle({
         setTimeout(() => setFlipping(false), 200);
       }}
       className={clsx(
-        "shrink-0 rounded-pill border border-border px-2 py-0.5 text-micro font-semibold text-text-2",
+        "flex shrink-0 items-center gap-[2px] rounded-pill bg-border p-[2px]",
         "transition-transform duration-200 ease-standard [transform-style:preserve-3d]",
         flipping && "[transform:rotateX(360deg)]",
         "motion-reduce:transition-none motion-reduce:[transform:none]",
       )}
     >
-      {unit}
+      {(["cm", "in"] as const).map((u) => (
+        <span
+          key={u}
+          className={clsx(
+            "rounded-pill px-2 py-[2px] text-micro font-semibold",
+            u === unit ? "bg-text text-bg" : "text-text-2",
+          )}
+        >
+          {u}
+        </span>
+      ))}
     </button>
   );
 }

--- a/web/src/components/ui/ManualMeasureRow.tsx
+++ b/web/src/components/ui/ManualMeasureRow.tsx
@@ -82,18 +82,19 @@ export function ManualMeasureRow({
           error={undefined}
         />
       </div>
-      {/* tape-measure themed slider: gradient fill + tick marks */}
-      <div className="relative">
+      {/* tape-measure ruler (Figma 66:695): visible tick marks under a
+          transparent track, accent-dot thumb */}
+      <div className="relative h-6">
         <div
           aria-hidden
-          className="pointer-events-none absolute inset-x-0 top-1/2 flex h-2 -translate-y-1/2 justify-between px-0.5"
+          className="pointer-events-none absolute inset-x-1 top-1/2 flex -translate-y-1/2 items-end justify-between"
         >
-          {Array.from({ length: 21 }).map((_, i) => (
+          {Array.from({ length: 41 }).map((_, i) => (
             <span
               key={i}
               className={clsx(
-                "w-px bg-border",
-                i % 5 === 0 ? "h-2" : "h-1 self-center",
+                "w-px bg-text-2/60",
+                i % 5 === 0 ? "h-3" : "h-1.5",
               )}
             />
           ))}
@@ -106,7 +107,7 @@ export function ManualMeasureRow({
           step={0.5}
           value={valueCm ?? min}
           onChange={(e) => onChange(Number(e.target.value))}
-          className="tape-slider relative w-full"
+          className="tape-slider absolute inset-0 w-full"
         />
       </div>
       {error ? <p className="text-micro text-error">{error}</p> : null}

--- a/web/src/components/ui/MeasurementCard.test.tsx
+++ b/web/src/components/ui/MeasurementCard.test.tsx
@@ -9,7 +9,8 @@ describe("MeasurementCard (§8.2)", () => {
     );
     expect(screen.getByText("Shoulder Width")).toBeInTheDocument();
     expect(screen.getByText("42.5 cm")).toBeInTheDocument();
-    expect(screen.getByText("scan")).toBeInTheDocument();
+    // Figma master (48:208): sentence-case source chip
+    expect(screen.getByText("Scan")).toBeInTheDocument();
   });
 
   it.each(["scan", "manual"] as const)("renders source=%s", (source) => {

--- a/web/src/components/ui/MeasurementCard.tsx
+++ b/web/src/components/ui/MeasurementCard.tsx
@@ -5,7 +5,8 @@
 // with/without history sparkline (bespoke SVG — no chart kits, reuse
 // policy). Tap → history sheet (wired by the vault view).
 import clsx from "clsx";
-import { formatCm } from "@/lib/format";
+import { Camera, Pencil } from "lucide-react";
+import { formatAgo, formatCm } from "@/lib/format";
 import { humanizeMeasureName } from "./ManualMeasureRow";
 import type { MeasureUnit } from "./Input";
 
@@ -17,6 +18,8 @@ export interface MeasurementCardProps {
   confidence?: number | null;
   /** Oldest → newest values for the sparkline (omit to hide). */
   history?: number[];
+  /** ISO timestamp for the "Updated 12d ago" meta line (Figma 48:208). */
+  updatedAt?: string | null;
   onClick?: () => void;
   className?: string;
 }
@@ -28,10 +31,12 @@ export function MeasurementCard({
   source,
   confidence = null,
   history,
+  updatedAt,
   onClick,
   className,
 }: MeasurementCardProps) {
   const lowConfidence = confidence !== null && confidence < 0.7;
+  const SourceIcon = source === "scan" ? Camera : Pencil;
   return (
     <button
       type="button"
@@ -43,43 +48,44 @@ export function MeasurementCard({
         className,
       )}
     >
+      {/* Figma master (48:208): 13px text-2 metric name; neutral outlined
+          source chip with a 12px icon + sentence-case label. */}
       <div className="flex w-full items-center justify-between gap-2">
-        <span className="text-body font-semibold text-text">
+        <span className="text-caption text-text-2">
           {humanizeMeasureName(name)}
         </span>
-        <span
-          className={clsx(
-            "rounded-pill border px-2 py-0.5 text-micro font-semibold",
-            source === "scan"
-              ? "border-link/40 text-link"
-              : "border-border text-text-2",
-          )}
-        >
-          {source}
+        <span className="flex h-5 items-center gap-1 rounded-pill border border-border px-2 text-micro font-semibold text-text-2">
+          <SourceIcon size={12} aria-hidden />
+          {source === "scan" ? "Scan" : "Manual"}
         </span>
       </div>
-      <span className="tnum text-title-lg font-bold text-text">
+      <span className="tnum text-title-lg font-semibold text-text">
         {formatCm(valueCm, unit)}
       </span>
       {lowConfidence ? (
         <span
           data-testid="low-confidence"
-          className="w-fit rounded-pill border border-warn/40 bg-warn/10 px-2 py-0.5 text-micro font-semibold text-warn"
+          className="flex h-5 w-fit items-center rounded-pill bg-warn/14 px-2 text-micro font-semibold text-warn"
         >
-          low confidence
+          Low confidence · {confidence!.toFixed(2)}
         </span>
       ) : null}
       {history && history.length > 1 ? (
         <Sparkline values={history} />
       ) : null}
+      {updatedAt ? (
+        <span className="text-micro text-text-2">
+          Updated {formatAgo(updatedAt)} ago
+        </span>
+      ) : null}
     </button>
   );
 }
 
-/** Bespoke sparkline — history trend, accent-gradient stroke. */
+/** Bespoke sparkline — history trend, accent-gradient stroke (168×32). */
 export function Sparkline({ values }: { values: number[] }) {
-  const width = 120;
-  const height = 28;
+  const width = 168;
+  const height = 32;
   const min = Math.min(...values);
   const max = Math.max(...values);
   const range = max - min || 1;

--- a/web/src/components/ui/MediaDropzone.test.tsx
+++ b/web/src/components/ui/MediaDropzone.test.tsx
@@ -20,8 +20,10 @@ describe("MediaDropzone (§8.2b)", () => {
   });
 
   it("error state announces the size/type message", () => {
+    // Figma master (94:1142): headline + type hint inside the dropzone
     render(<MediaDropzone state="error" onFiles={() => {}} />);
-    expect(screen.getByRole("alert")).toHaveTextContent(/JPEG\/PNG\/WebP/);
+    expect(screen.getByRole("alert")).toHaveTextContent(/File too large/);
+    expect(screen.getByText(/JPEG\/PNG\/WebP only/)).toBeInTheDocument();
   });
 
   it("file picks call onFiles", async () => {

--- a/web/src/components/ui/MediaDropzone.tsx
+++ b/web/src/components/ui/MediaDropzone.tsx
@@ -6,14 +6,18 @@
 // only, ≤10 items, ≤10MB each, JPEG/PNG/WebP.
 import { useRef } from "react";
 import clsx from "clsx";
-import { GripVertical, ImagePlus, Text, X } from "lucide-react";
-import { Spinner } from "./Spinner";
+import { AlertTriangle, GripVertical, ImagePlus, Text, X } from "lucide-react";
 
 export interface MediaDropzoneProps {
   state?: "empty" | "uploading" | "error";
   /** 0–1 while uploading. */
   progress?: number;
+  /** e.g. "Uploading 3 of 6…" (Figma 94:1137); falls back to percent. */
+  uploadingLabel?: string;
+  /** e.g. "outfit-04.jpg · 2.1 MB" under the progress bar. */
+  fileLabel?: string;
   errorMessage?: string;
+  errorHint?: string;
   onFiles: (files: File[]) => void;
   disabled?: boolean;
   className?: string;
@@ -22,7 +26,10 @@ export interface MediaDropzoneProps {
 export function MediaDropzone({
   state = "empty",
   progress = 0,
-  errorMessage = "That file is too large or not an image (JPEG/PNG/WebP, ≤10MB).",
+  uploadingLabel,
+  fileLabel,
+  errorMessage = "File too large — max 10 MB",
+  errorHint = "Try a smaller export, or JPEG/PNG/WebP only",
   onFiles,
   disabled,
   className,
@@ -47,11 +54,31 @@ export function MediaDropzone({
         )}
       >
         {state === "uploading" ? (
+          // Figma master (94:1137): bold count line, gradient progress bar,
+          // filename meta.
           <>
-            <Spinner size={28} kind="gradient" />
-            <span className="text-body text-text-2 tnum">
-              Uploading… {Math.round(progress * 100)}%
+            <span className="tnum text-body font-semibold text-text">
+              {uploadingLabel ?? `Uploading… ${Math.round(progress * 100)}%`}
             </span>
+            <span className="h-1 w-40 overflow-hidden rounded-pill bg-border">
+              <span
+                data-testid="upload-progress"
+                className="block h-full bg-accent-gradient transition-[width] duration-120 ease-standard motion-reduce:transition-none"
+                style={{ width: `${Math.round(progress * 100)}%` }}
+              />
+            </span>
+            {fileLabel ? (
+              <span className="text-micro text-text-2">{fileLabel}</span>
+            ) : null}
+          </>
+        ) : state === "error" ? (
+          // Figma master (94:1142): the error replaces the dropzone copy.
+          <>
+            <AlertTriangle size={24} className="text-error" />
+            <span role="alert" className="text-body font-semibold text-error">
+              {errorMessage}
+            </span>
+            <span className="text-micro text-text-2">{errorHint}</span>
           </>
         ) : (
           <>
@@ -60,16 +87,11 @@ export function MediaDropzone({
               Drag photos here or <span className="font-semibold text-link">browse</span>
             </span>
             <span className="text-micro text-text-2">
-              Up to 10 images · JPEG/PNG/WebP · 10 MB each
+              Up to 10 photos · JPEG/PNG/WebP · 10 MB each
             </span>
           </>
         )}
       </button>
-      {state === "error" ? (
-        <p role="alert" className="mt-1 text-micro text-error">
-          {errorMessage}
-        </p>
-      ) : null}
       <input
         ref={inputRef}
         type="file"

--- a/web/src/components/ui/ModerationQueueRow.test.tsx
+++ b/web/src/components/ui/ModerationQueueRow.test.tsx
@@ -7,10 +7,14 @@ import { fixtureReport } from "./fixtures";
 describe("ModerationQueueRow (§8.2b, A-6)", () => {
   it("open state renders preview, reporter context, reason, three actions", () => {
     render(<ModerationQueueRow report={fixtureReport} />);
+    // Figma master (93:1219): "Reported comment" headline + excerpt meta
+    expect(screen.getByText("Reported comment")).toBeInTheDocument();
     expect(screen.getByText(/Buy followers cheap/)).toBeInTheDocument();
-    expect(screen.getByText(/reported by tunde.o/)).toBeInTheDocument();
+    expect(screen.getByText(/Reported by tunde.o/)).toBeInTheDocument();
     expect(screen.getByText("spam")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Hide post" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Hide comment" }),
+    ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Suspend account" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Dismiss" })).toBeInTheDocument();
   });
@@ -18,7 +22,7 @@ describe("ModerationQueueRow (§8.2b, A-6)", () => {
   it("actions map to the api enum", async () => {
     const onAction = vi.fn();
     render(<ModerationQueueRow report={fixtureReport} onAction={onAction} />);
-    await userEvent.click(screen.getByRole("button", { name: "Hide post" }));
+    await userEvent.click(screen.getByRole("button", { name: "Hide comment" }));
     expect(onAction).toHaveBeenCalledWith("hide_post");
     await userEvent.click(screen.getByRole("button", { name: "Suspend account" }));
     expect(onAction).toHaveBeenCalledWith("suspend_account");

--- a/web/src/components/ui/ModerationQueueRow.tsx
+++ b/web/src/components/ui/ModerationQueueRow.tsx
@@ -42,25 +42,35 @@ export function ModerationQueueRow({
             />
           </span>
         ) : null}
+        {/* Figma master (93:1219): "Reported post/comment" headline, the
+            excerpt + reporter in the meta line, warn-tinted Spam pill. */}
         <div className="min-w-0 flex-1">
-          <p className="line-clamp-2 text-body text-text">
-            {report.subject_preview.text}
+          <p className="text-body font-semibold text-text">
+            Reported {report.subject_kind}
           </p>
-          <p className="mt-0.5 text-caption text-text-2">
-            {report.subject_kind} · reported by {report.reporter.username} ·{" "}
-            {formatAgo(report.created_at)}
+          <p className="mt-0.5 line-clamp-2 text-caption text-text-2">
+            “{report.subject_preview.text}” · Reported by{" "}
+            {report.reporter.username} · {formatAgo(report.created_at)} ago
           </p>
         </div>
-        <span className="shrink-0 rounded-pill border border-error/40 bg-error/10 px-2.5 py-0.5 text-micro font-semibold text-error">
+        <span className="shrink-0 rounded-pill bg-warn/14 px-2 py-0.5 text-micro font-semibold capitalize text-warn">
           {report.reason}
         </span>
       </div>
       {open ? (
         <div className="flex gap-2">
-          <Button kind="destructive" size="sm" onClick={() => onAction?.("hide_post")}>
-            Hide post
+          <Button
+            kind="quiet"
+            size="sm"
+            onClick={() => onAction?.("hide_post")}
+          >
+            {report.subject_kind === "comment" ? "Hide comment" : "Hide post"}
           </Button>
-          <Button kind="quiet" size="sm" onClick={() => onAction?.("suspend_account")}>
+          <Button
+            kind="destructive"
+            size="sm"
+            onClick={() => onAction?.("suspend_account")}
+          >
             Suspend account
           </Button>
           <Button kind="quiet" size="sm" onClick={() => onAction?.("dismiss")}>
@@ -69,7 +79,7 @@ export function ModerationQueueRow({
         </div>
       ) : (
         <p data-testid="audit-line" className="text-micro text-text-2">
-          {report.status} · by {report.actioned_by ?? "moderator"}
+          Actioned · by {report.actioned_by ?? "moderator"}
         </p>
       )}
     </div>

--- a/web/src/components/ui/NavRail.tsx
+++ b/web/src/components/ui/NavRail.tsx
@@ -7,13 +7,13 @@
 import clsx from "clsx";
 import Link from "next/link";
 import {
-  Compass,
   Home,
-  LifeBuoy,
+  Info,
   Moon,
   Package,
-  PlusSquare,
+  Plus,
   Ruler,
+  Search,
   Settings,
   Sun,
   User,
@@ -30,10 +30,11 @@ export interface NavRailItemSpec {
   badge?: number;
 }
 
+// Figma master (84:1046): explore = search glyph, create = plain plus.
 export const DEFAULT_NAV_ITEMS: NavRailItemSpec[] = [
   { key: "home", label: "Home", href: "/dashboard", icon: Home },
-  { key: "explore", label: "Explore", href: "/dashboard/explore", icon: Compass },
-  { key: "create", label: "Create", href: "/dashboard/create", icon: PlusSquare },
+  { key: "explore", label: "Explore", href: "/dashboard/explore", icon: Search },
+  { key: "create", label: "Create", href: "/dashboard/create", icon: Plus },
   { key: "orders", label: "Orders", href: "/dashboard/orders", icon: Package },
   { key: "vault", label: "Vault", href: "/dashboard/vault", icon: Ruler },
   { key: "profile", label: "Profile", href: "/dashboard/profile", icon: User },
@@ -68,6 +69,17 @@ export function NavRail({
         className,
       )}
     >
+      {/* Figma master (84:1046): gradient brandmark heads the rail */}
+      <div
+        className={clsx(
+          "flex h-12 items-center pb-2",
+          expanded ? "px-3" : "justify-center",
+        )}
+      >
+        <span className="bg-accent-gradient bg-clip-text text-title font-bold text-transparent">
+          {expanded ? "Apparule" : "A"}
+        </span>
+      </div>
       <ul className="flex flex-1 flex-col gap-1">
         {items.map((item) => (
           <li key={item.key}>
@@ -79,7 +91,7 @@ export function NavRail({
           </li>
         ))}
       </ul>
-      <div className="flex flex-col gap-1 border-t border-border pt-3">
+      <div className="flex flex-col gap-1 pt-3">
         <button
           type="button"
           onClick={() => setPreference(nextTheme)}
@@ -95,7 +107,7 @@ export function NavRail({
           rel="noopener noreferrer"
           className={itemClasses(false, expanded)}
         >
-          <LifeBuoy size={24} />
+          <Info size={24} />
           {expanded ? <span>Support</span> : null}
         </a>
       </div>
@@ -103,11 +115,13 @@ export function NavRail({
   );
 }
 
+// Figma master (84:902): 48px items, 14px labels; default reads text-2,
+// active binds to text with a semibold label + accent dot; hover tints.
 function itemClasses(active: boolean, expanded: boolean): string {
   return clsx(
-    "relative flex h-12 items-center gap-4 rounded-card px-3 text-body-lg text-text",
+    "relative flex h-12 items-center gap-3 rounded-card px-3 text-body",
     "transition-colors duration-120 ease-standard hover:bg-border/30 motion-reduce:transition-none",
-    active && "font-bold",
+    active ? "font-semibold text-text" : "text-text-2 hover:text-text",
     !expanded && "justify-center px-0",
   );
 }
@@ -130,11 +144,17 @@ export function NavRailItem({
       className={itemClasses(active, expanded)}
     >
       <span className="relative">
-        <Icon size={24} strokeWidth={active ? 2.5 : 2} />
+        {active ? (
+          <span
+            data-testid="nav-active-dot"
+            className="absolute -left-2 top-1/2 size-1 -translate-y-1/2 rounded-pill bg-accent-gradient"
+          />
+        ) : null}
+        <Icon size={24} />
         {item.badge ? (
           <span
             data-testid="nav-badge"
-            className="tnum absolute -right-2 -top-1.5 grid min-w-4 place-items-center rounded-pill bg-like px-1 text-[10px] font-bold leading-4 text-on-accent"
+            className="tnum absolute -right-2 -top-1.5 grid min-w-4 place-items-center rounded-pill bg-like px-1 text-[10px] font-semibold leading-4 text-on-accent"
           >
             {item.badge}
           </span>

--- a/web/src/components/ui/NotificationRow.tsx
+++ b/web/src/components/ui/NotificationRow.tsx
@@ -56,8 +56,18 @@ export function NotificationRow({
           />
         ) : null}
         <span className="min-w-0 flex-1">
-          <span className={clsx("block text-body text-text", unread && "font-semibold")}>
-            {notification.text}
+          {/* Figma master (92:1208): the actor name is semibold, the action
+              copy stays regular in both read states. */}
+          <span className="block text-body text-text">
+            {notification.actor ? (
+              <span className="font-semibold">
+                {notification.actor.username}{" "}
+              </span>
+            ) : null}
+            {notification.actor &&
+            notification.text.startsWith(notification.actor.username)
+              ? notification.text.slice(notification.actor.username.length + 1)
+              : notification.text}
           </span>
           <time
             dateTime={notification.created_at}

--- a/web/src/components/ui/OrderTimelineRow.test.tsx
+++ b/web/src/components/ui/OrderTimelineRow.test.tsx
@@ -25,14 +25,16 @@ describe("OrderTimelineRow (§8.2b, MI-14)", () => {
   });
 
   it("renders label + timestamp", () => {
+    // Figma master (89:1075): absolute "Jul 12, 14:02"-style stamp under
+    // the label.
     render(
       <OrderTimelineRow
         dot="done"
         label="Requested"
-        timestamp={new Date(Date.now() - 2 * 86_400_000).toISOString()}
+        timestamp="2026-07-12T14:02:00"
       />,
     );
     expect(screen.getByText("Requested")).toBeInTheDocument();
-    expect(screen.getByText("2d")).toBeInTheDocument();
+    expect(screen.getByText("Jul 12, 14:02")).toBeInTheDocument();
   });
 });

--- a/web/src/components/ui/OrderTimelineRow.tsx
+++ b/web/src/components/ui/OrderTimelineRow.tsx
@@ -4,7 +4,7 @@
 // pending / terminal-error · connector drawn / undrawn (MI-14: the dot
 // draws its connector line over 400ms) · label + timestamp.
 import clsx from "clsx";
-import { formatAgo } from "@/lib/format";
+import { format } from "date-fns";
 
 export type TimelineDot = "done" | "current" | "pending" | "terminal-error";
 
@@ -53,20 +53,23 @@ export function OrderTimelineRow({
           />
         ) : null}
       </div>
-      <div className="flex flex-1 items-baseline justify-between gap-3 pb-6">
+      {/* Figma master (89:1075): label with the timestamp stacked beneath;
+          pending rows read "Pending" */}
+      <div className="flex flex-1 flex-col gap-0.5 pb-6">
         <span
           className={clsx(
             "text-body",
             dot === "pending" ? "text-text-2" : "font-semibold text-text",
-            dot === "terminal-error" && "text-error",
           )}
         >
           {label}
         </span>
         {timestamp ? (
-          <time dateTime={timestamp} className="shrink-0 text-caption text-text-2">
-            {formatAgo(timestamp)}
+          <time dateTime={timestamp} className="tnum text-micro text-text-2">
+            {format(new Date(timestamp), "MMM d, HH:mm")}
           </time>
+        ) : dot === "pending" ? (
+          <span className="text-micro text-text-2">Pending</span>
         ) : null}
       </div>
     </div>

--- a/web/src/components/ui/PaymentBox.test.tsx
+++ b/web/src/components/ui/PaymentBox.test.tsx
@@ -30,8 +30,13 @@ describe("PaymentBox (§8.2b, MI-15)", () => {
   });
 
   it("paying state spins and disables", () => {
-    render(<PaymentBox state="paying" role="customer" quoteCents={4_500_000} />);
-    expect(screen.getByRole("button", { name: /paying/i })).toBeDisabled();
+    const { container } = render(
+      <PaymentBox state="paying" role="customer" quoteCents={4_500_000} />,
+    );
+    // Figma Button master: loading swaps the label for a spinner
+    const paying = container.querySelector('button[aria-busy="true"]');
+    expect(paying).not.toBeNull();
+    expect(paying).toBeDisabled();
   });
 
   it("escrow-held morphs to the shield-check (MI-15)", () => {
@@ -40,9 +45,11 @@ describe("PaymentBox (§8.2b, MI-15)", () => {
   });
 
   it("designer view itemizes the 10% fee line", () => {
-    render(<PaymentBox state="released" role="designer" quoteCents={6_200_000} />);
-    expect(screen.getByTestId("fee-line")).toHaveTextContent("−₦6,200");
-    expect(screen.getByText("₦55,800")).toBeInTheDocument();
+    // Figma master (90:1025): the fee is itemized in the quoted body copy
+    render(<PaymentBox state="quoted" role="designer" quoteCents={6_200_000} />);
+    expect(screen.getByTestId("fee-line")).toHaveTextContent(
+      "You receive ₦55,800 after the 10% platform fee",
+    );
   });
 
   it("first-payment escrow explainer expands beneath (MI-15)", () => {
@@ -61,6 +68,10 @@ describe("PaymentBox (§8.2b, MI-15)", () => {
     render(
       <PaymentBox state="dispute-frozen" role="designer" quoteCents={4_500_000} />,
     );
-    expect(screen.getByText(/payout frozen/i)).toBeInTheDocument();
+    // Figma master (90:1093) copy + designer action
+    expect(screen.getByText(/funds frozen/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Respond to dispute" }),
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/components/ui/PaymentBox.tsx
+++ b/web/src/components/ui/PaymentBox.tsx
@@ -5,7 +5,14 @@
 // released / refunded / dispute-frozen · role customer / designer ·
 // itemized 10% fee line (A-1).
 import clsx from "clsx";
-import { Info, ShieldCheck } from "lucide-react";
+import {
+  AlertTriangle,
+  Check,
+  Clock,
+  Info,
+  ShieldCheck,
+  type LucideIcon,
+} from "lucide-react";
 import { formatNaira } from "@/lib/format";
 import { Button } from "./Button";
 
@@ -25,19 +32,109 @@ export interface PaymentBoxProps {
   /** MI-15: escrow explainer expands beneath on first payment. */
   showEscrowExplainer?: boolean;
   onPay?: () => void;
+  /** Secondary CTAs (Edit quote / View payout / dispute actions). */
+  onAction?: (label: string) => void;
   className?: string;
 }
 
 const FEE_RATE = 0.1; // 10% platform fee (A-1, ratified)
 
-const STATE_LINE: Record<PaymentBoxState, string> = {
-  quoted: "Quote ready — payment is held in escrow until you confirm delivery",
-  paying: "Processing payment…",
-  "escrow-held": "Payment held in escrow",
-  released: "Payout released",
-  refunded: "Payment refunded",
-  "dispute-frozen": "Payout frozen while the dispute is resolved",
-};
+interface PaymentShape {
+  icon?: LucideIcon;
+  iconClass?: string;
+  headline: string;
+  body: string;
+  /** body carries the itemized fee copy (design.md §8.2b fee line). */
+  bodyIsFeeLine?: boolean;
+  cta?: { label: string; kind: "gradient-primary" | "quiet"; loading?: boolean };
+}
+
+// Figma masters (90:1103) — copy and anatomy per state × role.
+function shapeFor(
+  state: PaymentBoxState,
+  role: "customer" | "designer",
+  price: string,
+  fee: string,
+  net: string,
+): PaymentShape {
+  switch (state) {
+    case "quoted":
+      return role === "customer"
+        ? {
+            headline: `Quote · ${price}`,
+            body: `Includes 10% platform fee · ${fee}`,
+            bodyIsFeeLine: true,
+            cta: { label: `Pay ${price}`, kind: "gradient-primary" },
+          }
+        : {
+            headline: `Quote sent · ${price}`,
+            body: `You receive ${net} after the 10% platform fee`,
+            bodyIsFeeLine: true,
+            cta: { label: "Edit quote", kind: "quiet" },
+          };
+    case "paying":
+      return role === "customer"
+        ? {
+            headline: `Quote · ${price}`,
+            body: "Confirming payment with your bank…",
+            cta: { label: "Paying", kind: "gradient-primary", loading: true },
+          }
+        : {
+            headline: "Payment in progress",
+            body: "The customer is completing payment",
+          };
+    case "escrow-held":
+      return {
+        icon: ShieldCheck,
+        iconClass: "text-success",
+        headline: `${price} held in escrow`,
+        body:
+          role === "customer"
+            ? "Funds release to the designer when you confirm delivery"
+            : `${net} releases to you on delivery confirmation`,
+      };
+    case "released":
+      return role === "customer"
+        ? {
+            icon: Check,
+            iconClass: "text-success",
+            headline: "Payment released",
+            body: "You confirmed delivery — order complete",
+          }
+        : {
+            icon: Check,
+            iconClass: "text-success",
+            headline: `${net} released to you`,
+            body: "Payout arrives within 2 business days",
+            cta: { label: "View payout", kind: "quiet" },
+          };
+    case "refunded":
+      return role === "customer"
+        ? {
+            icon: Clock,
+            iconClass: "text-warn",
+            headline: `${price} refunded`,
+            body: "Refund to your original payment method in 5–7 days",
+          }
+        : {
+            icon: Clock,
+            iconClass: "text-warn",
+            headline: "Order refunded",
+            body: "Escrow returned to the customer",
+          };
+    case "dispute-frozen":
+      return {
+        icon: AlertTriangle,
+        iconClass: "text-error",
+        headline: "Funds frozen",
+        body: "Escrow is on hold while the dispute is reviewed",
+        cta: {
+          label: role === "customer" ? "View dispute" : "Respond to dispute",
+          kind: "quiet",
+        },
+      };
+  }
+}
 
 export function PaymentBox({
   state,
@@ -46,10 +143,19 @@ export function PaymentBox({
   currency = "NGN",
   showEscrowExplainer = false,
   onPay,
+  onAction,
   className,
 }: PaymentBoxProps) {
   const fee = Math.round(quoteCents * FEE_RATE);
   const net = quoteCents - fee;
+  const shape = shapeFor(
+    state,
+    role,
+    formatNaira(quoteCents, currency),
+    formatNaira(fee, currency),
+    formatNaira(net, currency),
+  );
+  const Icon = shape.icon;
 
   return (
     <section
@@ -57,65 +163,42 @@ export function PaymentBox({
       data-role={role}
       aria-label="Payment"
       className={clsx(
-        "flex flex-col gap-3 rounded-card border border-border bg-bg-elev p-4",
+        "flex flex-col gap-2 rounded-card border border-border bg-bg-elev p-4",
         className,
       )}
     >
-      <div className="flex items-center justify-between">
-        <span className="text-body font-semibold text-text">Payment</span>
-        {(state === "escrow-held" || state === "released") && (
-          <ShieldCheck
-            data-testid="shield-check"
-            size={20}
-            className="text-success"
+      <div className="flex items-center gap-2">
+        {Icon ? (
+          <Icon
+            data-testid={state === "escrow-held" ? "shield-check" : undefined}
+            size={18}
+            className={clsx("shrink-0", shape.iconClass)}
           />
-        )}
+        ) : null}
+        <span className="tnum text-body-lg font-semibold text-text">
+          {shape.headline}
+        </span>
       </div>
 
-      <dl className="flex flex-col gap-1.5 text-body">
-        <div className="flex justify-between">
-          <dt className="text-text-2">Quote</dt>
-          <dd className="tnum font-semibold text-text">
-            {formatNaira(quoteCents, currency)}
-          </dd>
-        </div>
-        {role === "designer" ? (
-          <>
-            <div className="flex justify-between" data-testid="fee-line">
-              <dt className="text-text-2">Platform fee (10%)</dt>
-              <dd className="tnum text-text-2">−{formatNaira(fee, currency)}</dd>
-            </div>
-            <div className="flex justify-between border-t border-border pt-1.5">
-              <dt className="font-semibold text-text">Your payout</dt>
-              <dd className="tnum font-semibold text-text">
-                {formatNaira(net, currency)}
-              </dd>
-            </div>
-          </>
-        ) : null}
-      </dl>
-
       <p
-        className={clsx(
-          "text-caption",
-          state === "dispute-frozen"
-            ? "text-error"
-            : state === "refunded"
-              ? "text-warn"
-              : "text-text-2",
-        )}
+        data-testid={shape.bodyIsFeeLine ? "fee-line" : undefined}
+        className="tnum text-caption text-text-2"
       >
-        {STATE_LINE[state]}
+        {shape.body}
       </p>
 
-      {role === "customer" && (state === "quoted" || state === "paying") ? (
+      {shape.cta ? (
         <Button
-          kind="gradient-primary"
-          loading={state === "paying"}
-          onClick={onPay}
+          kind={shape.cta.kind}
+          loading={shape.cta.loading}
+          onClick={
+            shape.cta.kind === "gradient-primary"
+              ? onPay
+              : () => onAction?.(shape.cta!.label)
+          }
           className="w-full"
         >
-          {state === "paying" ? "Paying…" : `Pay ${formatNaira(quoteCents, currency)}`}
+          {shape.cta.label}
         </Button>
       ) : null}
 

--- a/web/src/components/ui/Popover.tsx
+++ b/web/src/components/ui/Popover.tsx
@@ -32,7 +32,8 @@ export function Popover({
           side={side}
           align={align}
           sideOffset={4}
-          className="z-20 min-w-48 rounded-card border border-border bg-bg-elev py-1 shadow-lg"
+          // Figma master (96:1191): hairline dividers between menu items
+          className="z-20 min-w-48 divide-y divide-border overflow-hidden rounded-card border border-border bg-bg-elev shadow-lg"
         >
           {children}
         </RadixPopover.Content>

--- a/web/src/components/ui/PostCard.tsx
+++ b/web/src/components/ui/PostCard.tsx
@@ -73,8 +73,8 @@ export function PostCard({
         className,
       )}
     >
-      {/* header */}
-      <header className="flex items-center gap-3 px-4 py-3">
+      {/* header — Figma master (52:462): px 12 / py 8 / gap 8 */}
+      <header className="flex items-center gap-2 px-3 py-2">
         <Avatar
           size={32}
           name={post.designer.display_name}
@@ -116,9 +116,15 @@ export function PostCard({
             />
           </span>
         ) : null}
-        {/* MI-4 carousel: desktop hover chevrons + progress dots */}
+        {/* MI-4 carousel: count pill (Figma 52:368) + desktop hover chevrons */}
         {media.length > 1 ? (
           <>
+            <span
+              data-testid="carousel-count"
+              className="tnum absolute right-3 top-3 flex h-[22px] items-center rounded-pill bg-text px-2 text-micro font-semibold text-bg"
+            >
+              {slide + 1}/{media.length}
+            </span>
             {slide > 0 ? (
               <button
                 type="button"
@@ -145,25 +151,29 @@ export function PostCard({
                 <ChevronRight size={16} />
               </button>
             ) : null}
-            <div
-              data-testid="carousel-dots"
-              className="absolute inset-x-0 bottom-2 flex justify-center gap-1"
-            >
-              {media.map((m, i) => (
-                <span
-                  key={m.id}
-                  className={clsx(
-                    "rounded-pill transition-all duration-120 ease-standard",
-                    i === slide
-                      ? "size-1.5 bg-accent-gradient" // active dot 6px, gradient
-                      : "size-1 bg-white/70",
-                  )}
-                />
-              ))}
-            </div>
           </>
         ) : null}
       </div>
+
+      {/* Figma master: progress dots sit below the media, not over it */}
+      {media.length > 1 ? (
+        <div
+          data-testid="carousel-dots"
+          className="flex w-full justify-center gap-1 pt-2.5"
+        >
+          {media.map((m, i) => (
+            <span
+              key={m.id}
+              className={clsx(
+                "rounded-pill transition-all duration-120 ease-standard",
+                i === slide
+                  ? "size-1.5 bg-accent-gradient" // active dot 6px, gradient
+                  : "size-1 bg-border",
+              )}
+            />
+          ))}
+        </div>
+      ) : null}
 
       {/* action row */}
       <ActionRow
@@ -174,27 +184,35 @@ export function PostCard({
         onToggleSave={() => onToggleSave?.()}
         onComment={onComment}
         onShare={onShare}
-        className="px-2 pt-1"
+        className="px-1.5 pt-1"
       />
 
-      {/* like count + caption + comments + timestamp */}
-      <div className="flex flex-col gap-1 px-4">
+      {/* like count + caption + comments + CTA + timestamp — Figma master:
+          one px-16 column at 4px rhythm, semibold caption, inline "more" */}
+      <div className="flex flex-col items-start gap-1 px-4">
         <span className="tnum text-body font-semibold text-text">
           {post.like_count.toLocaleString("en-NG")} likes
         </span>
-        <p className={clsx("text-body text-text", !captionOpen && "line-clamp-2")}>
-          <span className="font-semibold">{post.designer.username}</span>{" "}
-          {post.caption}
+        <p
+          className={clsx(
+            "text-body font-semibold text-text",
+            !captionOpen && "line-clamp-2",
+          )}
+        >
+          {post.designer.username} {post.caption}
+          {!captionOpen && post.caption.length > 80 ? (
+            <>
+              {" "}
+              <button
+                type="button"
+                onClick={() => setCaptionOpen(true)}
+                className="font-normal text-text-2"
+              >
+                more
+              </button>
+            </>
+          ) : null}
         </p>
-        {!captionOpen && post.caption.length > 80 ? (
-          <button
-            type="button"
-            onClick={() => setCaptionOpen(true)}
-            className="w-fit text-body text-text-2"
-          >
-            more
-          </button>
-        ) : null}
         {post.comment_count > 0 ? (
           <button
             type="button"
@@ -204,23 +222,19 @@ export function PostCard({
             View all {post.comment_count} comments
           </button>
         ) : null}
-      </div>
-
-      {/* request CTA — full-width quiet button on designer posts */}
-      {showCta ? (
-        <div className="px-4 pt-3">
+        {/* request CTA — full-width quiet button on designer posts */}
+        {showCta ? (
           <Button kind="quiet" size="md" className="w-full" onClick={onRequest}>
             Request this outfit
           </Button>
-        </div>
-      ) : null}
-
-      <time
-        dateTime={post.created_at}
-        className="px-4 pt-2 text-micro uppercase text-text-2"
-      >
-        {formatAgo(post.created_at)}
-      </time>
+        ) : null}
+        <time
+          dateTime={post.created_at}
+          className="text-micro uppercase tracking-[0.4px] text-text-2"
+        >
+          {formatAgo(post.created_at)}
+        </time>
+      </div>
     </article>
   );
 }

--- a/web/src/components/ui/ProcessingConstellation.test.tsx
+++ b/web/src/components/ui/ProcessingConstellation.test.tsx
@@ -27,10 +27,13 @@ describe("ProcessingConstellation (§8.2b)", () => {
     expect(dots[1].getAttribute("style")).toContain("animation-delay");
   });
 
+  // Figma master (64:748): status caption below the photo.
   it("success / failed announce their status", () => {
     const { rerender } = render(<ProcessingConstellation state="success" />);
-    expect(screen.getByRole("status")).toHaveTextContent("Measurements ready");
+    expect(screen.getByRole("status")).toHaveTextContent("Done");
     rerender(<ProcessingConstellation state="failed" />);
-    expect(screen.getByRole("status")).toHaveTextContent("Capture failed");
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Couldn't measure — retake",
+    );
   });
 });

--- a/web/src/components/ui/ProcessingConstellation.tsx
+++ b/web/src/components/ui/ProcessingConstellation.tsx
@@ -43,79 +43,76 @@ export function ProcessingConstellation({
   imageAlt = "Captured photo",
   className,
 }: ProcessingConstellationProps) {
-  const stroke =
-    state === "failed" ? "var(--ap-error)" : state === "success" ? "var(--ap-success)" : "white";
   return (
-    <div
-      data-state={state}
-      className={clsx(
-        "relative aspect-[3/4] w-full overflow-hidden rounded-card bg-black",
-        className,
-      )}
-    >
-      {imageSrc ? (
-        // eslint-disable-next-line @next/next/no-img-element -- mock/demo asset, unoptimized by design
-        <img
-          src={imageSrc}
-          alt={imageAlt}
-          className="absolute inset-0 size-full object-cover opacity-60"
-        />
-      ) : null}
+    <div data-state={state} className={clsx("flex flex-col gap-2", className)}>
+      <div className="relative aspect-[3/4] w-full overflow-hidden rounded-card bg-black">
+        {imageSrc ? (
+          // eslint-disable-next-line @next/next/no-img-element -- mock/demo asset, unoptimized by design
+          <img
+            src={imageSrc}
+            alt={imageAlt}
+            className="absolute inset-0 size-full object-cover opacity-60"
+          />
+        ) : null}
 
-      <svg
-        data-testid="constellation"
-        viewBox="0 0 200 300"
-        aria-hidden="true"
-        className="absolute inset-0 m-auto h-[85%]"
-      >
-        <g stroke={stroke} strokeOpacity={0.6} strokeWidth={1.5}>
-          {SEGMENTS.map(([a, b]) => (
-            <line
-              key={`${a}-${b}`}
-              x1={LANDMARKS[a][0]}
-              y1={LANDMARKS[a][1]}
-              x2={LANDMARKS[b][0]}
-              y2={LANDMARKS[b][1]}
+        {/* Figma master (64:748): the landmark constellation strokes the
+            accent in every state; the status line sits below the photo. */}
+        <svg
+          data-testid="constellation"
+          viewBox="0 0 200 300"
+          aria-hidden="true"
+          className="absolute inset-0 m-auto h-[85%]"
+        >
+          <g
+            stroke="var(--ap-accent-start)"
+            strokeOpacity={0.6}
+            strokeWidth={1.5}
+          >
+            {SEGMENTS.map(([a, b]) => (
+              <line
+                key={`${a}-${b}`}
+                x1={LANDMARKS[a][0]}
+                y1={LANDMARKS[a][1]}
+                x2={LANDMARKS[b][0]}
+                y2={LANDMARKS[b][1]}
+              />
+            ))}
+          </g>
+          {LANDMARKS.map(([x, y], i) => (
+            <circle
+              key={`${x}-${y}`}
+              data-testid="landmark"
+              cx={x}
+              cy={y}
+              r={4}
+              fill="var(--ap-accent-start)"
+              style={state === "processing" ? { animationDelay: `${i * 90}ms` } : undefined}
+              className={clsx(
+                state === "processing" &&
+                  "animate-[landmark-pulse_1.2s_ease-in-out_infinite] motion-reduce:animate-none",
+              )}
             />
           ))}
-        </g>
-        {LANDMARKS.map(([x, y], i) => (
-          <circle
-            key={`${x}-${y}`}
-            data-testid="landmark"
-            cx={x}
-            cy={y}
-            r={4}
-            fill={stroke}
-            style={state === "processing" ? { animationDelay: `${i * 90}ms` } : undefined}
-            className={clsx(
-              state === "processing" &&
-                "animate-[landmark-pulse_1.2s_ease-in-out_infinite] motion-reduce:animate-none",
-            )}
-          />
-        ))}
-      </svg>
+        </svg>
+      </div>
 
       <div
         role="status"
-        className="absolute inset-x-0 bottom-6 flex flex-col items-center gap-2 px-4 text-white"
+        className={clsx(
+          "flex items-center justify-center gap-1 text-caption",
+          state === "processing" && "text-text-2",
+          state === "success" && "text-success",
+          state === "failed" && "text-error",
+        )}
       >
-        {state === "success" ? (
-          <span className="grid size-10 place-items-center rounded-pill bg-success text-on-accent">
-            <Check size={24} aria-hidden="true" />
-          </span>
-        ) : null}
-        {state === "failed" ? (
-          <span className="grid size-10 place-items-center rounded-pill bg-error text-on-accent">
-            <X size={24} aria-hidden="true" />
-          </span>
-        ) : null}
-        <span className="text-body font-semibold">
+        {state === "success" ? <Check size={14} aria-hidden="true" /> : null}
+        {state === "failed" ? <X size={14} aria-hidden="true" /> : null}
+        <span>
           {state === "processing"
             ? "Measuring…"
             : state === "success"
-              ? "Measurements ready"
-              : "Capture failed"}
+              ? "Done"
+              : "Couldn't measure — retake"}
         </span>
       </div>
     </div>

--- a/web/src/components/ui/QCHintChip.tsx
+++ b/web/src/components/ui/QCHintChip.tsx
@@ -2,7 +2,14 @@
 // Fail codes from capture-qc.md §1–2; canonical retake copy from the
 // flows/vault.md QC-failures row (the same strings the 422 envelope carries).
 import clsx from "clsx";
-import { AlertTriangle } from "lucide-react";
+import {
+  Camera,
+  Ruler,
+  Search,
+  User,
+  X,
+  type LucideIcon,
+} from "lucide-react";
 
 export type QcFailCode =
   | "no_body"
@@ -32,24 +39,40 @@ export const QC_GUIDANCE: Record<QcFailCode, string> = {
   too_far: "Move closer — fill more of the frame",
 };
 
+/** Figma masters (62:634): the leading glyph names the failure family. */
+const QC_ICON: Record<QcFailCode, LucideIcon> = {
+  no_body: User,
+  multiple_bodies: User,
+  partial_body: Ruler,
+  undecodable_image: X,
+  low_resolution: Camera,
+  poor_lighting: Camera,
+  blurry: Camera,
+  not_frontal: User,
+  camera_tilt: Camera,
+  arms_position: User,
+  too_far: Search,
+};
+
 export interface QCHintChipProps {
   code: QcFailCode;
   className?: string;
 }
 
 export function QCHintChip({ code, className }: QCHintChipProps) {
+  const Icon = QC_ICON[code];
   return (
     <span
       role="status"
       data-code={code}
       className={clsx(
-        // On-media capture UI — raw white on a dark scrim is the documented
-        // token exception (web-implementation.md §3 note).
-        "inline-flex max-w-full items-center gap-2 rounded-pill bg-black/70 px-4 py-2 text-body font-semibold text-white backdrop-blur-sm",
+        // Figma master (62:634): inverse surface — text-token bg, bg-token
+        // content (same technique as Toast), 13px semibold.
+        "inline-flex max-w-full items-center gap-2 rounded-pill bg-text px-3 py-2 text-caption font-semibold text-bg drop-shadow-[0_4px_6px_rgba(0,0,0,0.25)]",
         className,
       )}
     >
-      <AlertTriangle size={16} className="shrink-0 text-warn" />
+      <Icon size={16} className="shrink-0" aria-hidden />
       <span className="truncate">{QC_GUIDANCE[code]}</span>
     </span>
   );

--- a/web/src/components/ui/RequestCard.test.tsx
+++ b/web/src/components/ui/RequestCard.test.tsx
@@ -9,7 +9,7 @@ describe("RequestCard (§8.2)", () => {
     render(<RequestCard order={fixtureOrder} role="customer" />);
     expect(screen.getByText(/#APR-1042/)).toBeInTheDocument();
     expect(screen.getByText(/by amara.designs/)).toBeInTheDocument();
-    expect(screen.getByText("in progress")).toBeInTheDocument();
+    expect(screen.getByText("In progress")).toBeInTheDocument();
     expect(screen.getByText("₦45,000")).toBeInTheDocument();
   });
 
@@ -27,7 +27,8 @@ describe("RequestCard (§8.2)", () => {
         onAction={onAction}
       />,
     );
-    await userEvent.click(screen.getByRole("button", { name: "Pay" }));
+    // Figma master (53:344): the pay CTA carries the amount
+    await userEvent.click(screen.getByRole("button", { name: "Pay ₦45,000" }));
     expect(onAction).toHaveBeenCalledWith("Pay");
   });
 
@@ -38,7 +39,9 @@ describe("RequestCard (§8.2)", () => {
         role="designer"
       />,
     );
-    expect(screen.getByRole("button", { name: "Quote" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Send quote" }),
+    ).toBeInTheDocument();
     // no quote yet → budget renders instead
     expect(screen.getByText("₦50,000")).toBeInTheDocument();
   });

--- a/web/src/components/ui/RequestCard.tsx
+++ b/web/src/components/ui/RequestCard.tsx
@@ -13,17 +13,35 @@ import { StatusPill } from "./StatusPill";
 
 export type RequestCardRole = "customer" | "designer";
 
-/** Next action per role per state (order-lifecycle.md §2 permissions). */
-const NEXT_ACTION: Record<RequestCardRole, Partial<Record<OrderStatus, string>>> = {
+/** Next action per role per state — the full ×10 matrix drawn in the
+ * RequestCard masters (53:614); `primary` actions paint the gradient. */
+const NEXT_ACTION: Record<
+  RequestCardRole,
+  Partial<Record<OrderStatus, { label: string; primary?: boolean }>>
+> = {
   customer: {
-    quoted: "Pay",
-    shipped: "Confirm delivery",
-    delivered: "View order",
+    requested: { label: "Cancel request" },
+    quoted: { label: "Pay", primary: true },
+    paid: { label: "View order" },
+    in_progress: { label: "View updates" },
+    shipped: { label: "Confirm delivery", primary: true },
+    delivered: { label: "View order" },
+    refunded: { label: "View details" },
+    declined: { label: "Find similar" },
+    disputed: { label: "View dispute" },
+    cancelled: { label: "View details" },
   },
   designer: {
-    requested: "Quote",
-    paid: "Start work",
-    in_progress: "Mark shipped",
+    requested: { label: "Send quote", primary: true },
+    quoted: { label: "Edit quote" },
+    paid: { label: "Start work", primary: true },
+    in_progress: { label: "Mark shipped", primary: true },
+    shipped: { label: "Add tracking" },
+    delivered: { label: "View payout" },
+    refunded: { label: "View details" },
+    declined: { label: "View request" },
+    disputed: { label: "Respond", primary: true },
+    cancelled: { label: "View details" },
   },
 };
 
@@ -46,13 +64,16 @@ export function RequestCard({
     role === "customer" ? order.designer.username : order.customer.username;
   const action = NEXT_ACTION[role][order.status];
   const amount = order.quote_cents ?? order.budget_cents;
+  const price = amount !== null ? formatNaira(amount, order.currency) : null;
 
   return (
     <div
       data-role={role}
       data-status={order.status}
       className={clsx(
-        "flex items-center gap-4 rounded-card border border-border bg-bg-elev p-4",
+        // Figma master (53:614): p 12 / gap 12, 64px thumb, title/meta/price
+        // column, pill + action stacked at the trailing edge.
+        "flex items-start gap-3 rounded-card border border-border bg-bg-elev p-3",
         className,
       )}
     >
@@ -70,42 +91,41 @@ export function RequestCard({
           className="object-cover"
         />
       </button>
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          {/* 1-line truncation keeps the price visible (as-built fix) */}
-          <button
-            type="button"
-            onClick={onOpen}
-            className="min-w-0 truncate text-left text-body font-semibold text-text"
-          >
-            {order.post.caption}
-          </button>
-        </div>
+      <div className="flex min-w-0 flex-1 flex-col gap-[2px]">
+        {/* 1-line truncation keeps the price visible (as-built fix) */}
+        <button
+          type="button"
+          onClick={onOpen}
+          className="min-w-0 truncate text-left text-body font-semibold text-text"
+        >
+          {order.post.caption}
+        </button>
         <p className="truncate text-caption text-text-2">
           #{order.order_number} · {role === "customer" ? "by" : "for"}{" "}
           {counterparty}
         </p>
-        <div className="mt-1.5 flex items-center gap-3">
-          <StatusPill status={order.status} />
-          {amount !== null ? (
-            <span className="tnum text-body font-semibold text-text">
-              {formatNaira(amount, order.currency)}
-            </span>
-          ) : (
-            <span className="text-caption text-text-2">quote on request</span>
-          )}
-        </div>
+        {price !== null ? (
+          <span className="tnum text-body font-semibold text-text">
+            {price}
+          </span>
+        ) : (
+          <span className="text-caption text-text-2">quote on request</span>
+        )}
       </div>
-      {action ? (
-        <Button
-          kind={action === "Pay" ? "gradient-primary" : "quiet"}
-          size="sm"
-          onClick={() => onAction?.(action)}
-          className="shrink-0"
-        >
-          {action}
-        </Button>
-      ) : null}
+      <div className="flex shrink-0 flex-col items-end gap-2">
+        <StatusPill status={order.status} />
+        {action ? (
+          <Button
+            kind={action.primary ? "gradient-primary" : "quiet"}
+            size="sm"
+            onClick={() => onAction?.(action.label)}
+          >
+            {action.label === "Pay" && price !== null
+              ? `Pay ${price}`
+              : action.label}
+          </Button>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/web/src/components/ui/Select.tsx
+++ b/web/src/components/ui/Select.tsx
@@ -45,10 +45,14 @@ export function Select({
         <RadixSelect.Trigger
           aria-invalid={error ? true : undefined}
           className={clsx(
-            "flex h-11 items-center justify-between gap-2 rounded-card border bg-bg-elev px-3 text-body-lg text-text",
+            // Figma form-kit frame (74:801): 14px value, 1.5px error border,
+            // 2px accent focus, 40% disabled.
+            "flex h-11 items-center justify-between gap-2 rounded-card bg-bg-elev px-3 text-body text-text",
             "transition-colors duration-120 ease-standard motion-reduce:transition-none",
-            "data-[placeholder]:text-text-2 disabled:opacity-50",
-            error ? "border-error" : "border-border focus:border-accent-start",
+            "data-[placeholder]:text-text-2 disabled:opacity-40",
+            error
+              ? "border-[1.5px] border-error"
+              : "border border-border focus:border-2 focus:border-accent-start",
           )}
           {...rest}
         >
@@ -71,7 +75,7 @@ export function Select({
           </RadixSelect.Content>
         </RadixSelect.Portal>
       </RadixSelect.Root>
-      {error ? <span className="text-micro text-error">{error}</span> : null}
+      {error ? <span className="text-caption text-error">{error}</span> : null}
     </div>
   );
 }

--- a/web/src/components/ui/SessionRow.test.tsx
+++ b/web/src/components/ui/SessionRow.test.tsx
@@ -11,7 +11,7 @@ describe("SessionRow (§8.2b)", () => {
       <SessionRow session={fixtureSession} onDelete={onDelete} />,
     );
     expect(container.querySelector('[data-context="history"]')).not.toBeNull();
-    expect(screen.getByText("scan")).toBeInTheDocument();
+    expect(screen.getByText("Scan")).toBeInTheDocument();
     expect(screen.getByText(/Shoulder Width 42.5 cm/)).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Delete session" }));
     expect(onDelete).toHaveBeenCalledOnce();
@@ -24,7 +24,7 @@ describe("SessionRow (§8.2b)", () => {
     const radio = screen.getByRole("radio");
     expect(radio).toHaveAttribute("aria-checked", "true");
     expect(screen.getByTestId("picker-radio")).toBeInTheDocument();
-    expect(screen.getByText("fresh")).toBeInTheDocument();
+    expect(screen.getByText("Fresh")).toBeInTheDocument();
     expect(screen.queryByTestId("freshness-warning")).not.toBeInTheDocument();
   });
 

--- a/web/src/components/ui/SessionRow.tsx
+++ b/web/src/components/ui/SessionRow.tsx
@@ -22,11 +22,12 @@ export interface SessionRowProps {
   className?: string;
 }
 
+// Figma master (93:1158): sentence-case method chips.
 const METHOD_LABEL: Record<string, string> = {
-  mediapipe_2d: "scan",
-  mediapipe_2d_v2: "scan",
-  smpl_v1: "scan (3D)",
-  manual: "manual",
+  mediapipe_2d: "Scan",
+  mediapipe_2d_v2: "Scan",
+  smpl_v1: "Scan (3D)",
+  manual: "Manual",
 };
 
 export function SessionRow({

--- a/web/src/components/ui/Sheet.test.tsx
+++ b/web/src/components/ui/Sheet.test.tsx
@@ -35,10 +35,12 @@ describe("Sheet (§8.2)", () => {
         <p>Body</p>
       </Sheet>,
     );
+    // Figma master (50:256): full-bleed progress track + a single centered
+    // "Step n of N · Label" caption for the current step.
     const stepper = screen.getByTestId("sheet-stepper");
-    expect(stepper).toHaveTextContent("Measurements");
+    expect(stepper).toHaveTextContent("Step 2 of 3 · Notes & budget");
     expect(
-      screen.getByText("Notes & budget"),
+      screen.getByText(/Step 2 of 3/),
     ).toHaveAttribute("aria-current", "step");
   });
 

--- a/web/src/components/ui/Sheet.tsx
+++ b/web/src/components/ui/Sheet.tsx
@@ -40,55 +40,55 @@ export function Sheet({
         <RadixDialog.Content
           className={clsx(
             // z-40 sheet/modal layer; bottom sheet <md, centered modal ≥md
-            "fixed z-40 flex max-h-[85vh] w-full flex-col overflow-hidden bg-bg-elev shadow-lg",
-            "inset-x-0 bottom-0 rounded-t-[8px]",
-            "md:inset-x-auto md:bottom-auto md:left-1/2 md:top-1/2 md:w-[480px] md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-card",
+            "fixed z-40 flex max-h-[85vh] w-full flex-col overflow-hidden bg-bg-elev",
+            "inset-x-0 bottom-0 rounded-t-card shadow-[0_-4px_8px_rgba(0,0,0,0.2)]",
+            "md:inset-x-auto md:bottom-auto md:left-1/2 md:top-1/2 md:w-[480px] md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-card md:shadow-lg",
             className,
           )}
         >
-          <header className="flex items-center justify-between gap-3 border-b border-border px-6 py-4">
-            <RadixDialog.Title className="text-title font-semibold text-text">
+          {/* Figma master (50:296): mobile grabber, centered 16px title */}
+          <div className="flex justify-center pt-2 md:hidden" aria-hidden>
+            <span className="h-1 w-9 rounded-[2px] bg-border" />
+          </div>
+          <header className="flex items-center gap-3 px-4 py-3">
+            <span className="size-9 shrink-0" aria-hidden />
+            <RadixDialog.Title className="flex-1 text-center text-body-lg font-semibold text-text">
               {title}
             </RadixDialog.Title>
             <RadixDialog.Close
               aria-label="Close"
-              className="grid size-9 place-items-center rounded-pill text-text-2 hover:bg-border/40 hover:text-text"
+              className="grid size-9 shrink-0 place-items-center rounded-pill text-text hover:bg-border/40"
             >
-              <X size={20} />
+              <X size={24} />
             </RadixDialog.Close>
           </header>
           {stepper ? <StepperHeader stepper={stepper} /> : null}
-          <div className="overflow-y-auto px-6 py-4">{children}</div>
+          <div className="overflow-y-auto p-4">{children}</div>
         </RadixDialog.Content>
       </RadixDialog.Portal>
     </RadixDialog.Root>
   );
 }
 
+// Figma master (50:256): a full-bleed 4px progress track under the header
+// and a centered "Step n of N · Label" caption.
 function StepperHeader({ stepper }: { stepper: SheetStepper }) {
   const progress = ((stepper.current + 1) / stepper.steps.length) * 100;
   return (
-    <div data-testid="sheet-stepper" className="border-b border-border px-6 py-3">
-      <div className="mb-2 flex justify-between">
-        {stepper.steps.map((step, i) => (
-          <span
-            key={step}
-            aria-current={i === stepper.current ? "step" : undefined}
-            className={clsx(
-              "text-caption",
-              i <= stepper.current ? "font-semibold text-text" : "text-text-2",
-            )}
-          >
-            {step}
-          </span>
-        ))}
-      </div>
-      <div className="h-1 overflow-hidden rounded-pill bg-border">
+    <div data-testid="sheet-stepper">
+      <div className="h-1 w-full bg-border">
         <div
           className="h-full bg-accent-gradient transition-[width] duration-300 ease-standard motion-reduce:transition-none"
           style={{ width: `${progress}%` }}
         />
       </div>
+      <p
+        aria-current="step"
+        className="pt-2 text-center text-caption text-text-2"
+      >
+        Step {stepper.current + 1} of {stepper.steps.length} ·{" "}
+        {stepper.steps[stepper.current]}
+      </p>
     </div>
   );
 }

--- a/web/src/components/ui/Skeleton.tsx
+++ b/web/src/components/ui/Skeleton.tsx
@@ -35,18 +35,24 @@ export function Skeleton({ kind = "line", className }: SkeletonProps) {
   if (kind === "media") {
     return <Shimmer kind={kind} className={clsx("aspect-square w-full", className)} />;
   }
-  // card: feed anatomy — header line + square media + action row (§3)
+  // card: feed anatomy — header, square media, action circles, caption
+  // lines (mirrors the PostCard skeleton master, 52:288)
   return (
     <div data-kind="card" aria-hidden="true" className={clsx("flex flex-col gap-3", className)}>
-      <div className="flex items-center gap-3 px-4 pt-3">
+      <div className="flex items-center gap-3 px-3 pt-2">
         <Shimmer kind="avatar" className="size-8 shrink-0 rounded-pill" />
         <Shimmer kind="line" className="h-3 w-32 rounded-card" />
       </div>
       <Shimmer kind="media" className="aspect-square w-full" />
-      <div className="flex items-center gap-4 px-4 pb-3">
-        <Shimmer kind="line" className="h-6 w-6 rounded-card" />
-        <Shimmer kind="line" className="h-6 w-6 rounded-card" />
-        <Shimmer kind="line" className="h-6 w-6 rounded-card" />
+      <div className="flex items-center gap-4 px-4">
+        <Shimmer kind="line" className="size-6 rounded-pill" />
+        <Shimmer kind="line" className="size-6 rounded-pill" />
+        <Shimmer kind="line" className="size-6 rounded-pill" />
+      </div>
+      <div className="flex flex-col gap-2 px-4 pb-3">
+        <Shimmer kind="line" className="h-3 w-24 rounded-card" />
+        <Shimmer kind="line" className="h-3 w-3/4 rounded-card" />
+        <Shimmer kind="line" className="h-10 w-full rounded-card" />
       </div>
     </div>
   );

--- a/web/src/components/ui/Spinner.tsx
+++ b/web/src/components/ui/Spinner.tsx
@@ -7,8 +7,10 @@ import clsx from "clsx";
 import { useId } from "react";
 
 export interface SpinnerProps {
-  size?: 20 | 28;
-  kind?: "gradient" | "neutral";
+  /** 20 inline / 28 refresh (§8.2b) · 18/16 inside Button loading (39:66). */
+  size?: 16 | 18 | 20 | 28;
+  /** on-accent strokes white — spinners on accent/destructive fills. */
+  kind?: "gradient" | "neutral" | "on-accent";
   /** MI-5: pull-to-refresh grows with pull distance (0–1). */
   progress?: number;
   className?: string;
@@ -55,7 +57,13 @@ export function Spinner({
         cy={c}
         r={r}
         fill="none"
-        stroke={kind === "gradient" ? `url(#${gradientId})` : "var(--ap-text-2)"}
+        stroke={
+          kind === "gradient"
+            ? `url(#${gradientId})`
+            : kind === "on-accent"
+              ? "var(--ap-on-accent)"
+              : "var(--ap-text-2)"
+        }
         strokeWidth={stroke}
         strokeLinecap="round"
         strokeDasharray={circumference}

--- a/web/src/components/ui/StatCard.tsx
+++ b/web/src/components/ui/StatCard.tsx
@@ -50,7 +50,8 @@ export function StatCard({ stat, label, className }: StatCardProps) {
         className,
       )}
     >
-      <span className="tnum bg-accent-gradient bg-clip-text text-display font-bold text-transparent">
+      {/* Figma master (Stage 5): stat values bind to the text token */}
+      <span className="tnum text-display font-bold text-text">
         {stat}
       </span>
       <span className="text-body text-text-2">{label}</span>

--- a/web/src/components/ui/StatusPill.test.tsx
+++ b/web/src/components/ui/StatusPill.test.tsx
@@ -4,12 +4,19 @@ import { ORDER_STATUSES } from "@/models";
 import { StatusPill } from "./StatusPill";
 
 describe("StatusPill (§8.2, MI-14)", () => {
+  // Figma master (47:135): sentence-case labels ("In progress").
+  const label = (status: string) => {
+    const text = status.replace(/_/g, " ");
+    return text.charAt(0).toUpperCase() + text.slice(1);
+  };
+
   it("renders all 10 order states", () => {
     for (const status of ORDER_STATUSES) {
       const { unmount } = render(<StatusPill status={status} />);
-      expect(
-        screen.getByText(status.replace(/_/g, " ")),
-      ).toHaveAttribute("data-status", status);
+      expect(screen.getByText(label(status))).toHaveAttribute(
+        "data-status",
+        status,
+      );
       unmount();
     }
   });
@@ -17,27 +24,30 @@ describe("StatusPill (§8.2, MI-14)", () => {
   it.each(["fresh", "aging", "stale"] as const)(
     "renders freshness=%s",
     (freshness) => {
-      render(<StatusPill status={freshness} />);
-      expect(screen.getByText(freshness)).toHaveAttribute("data-status", freshness);
+      const { container } = render(<StatusPill status={freshness} />);
+      expect(screen.getByText(label(freshness))).toBeInTheDocument();
+      expect(
+        container.querySelector(`[data-status="${freshness}"]`),
+      ).not.toBeNull();
     },
   );
 
   it("maps states to the decided tokens (spot checks)", () => {
     const { rerender } = render(<StatusPill status="quoted" />);
-    expect(screen.getByText("quoted").className).toContain("text-link");
+    expect(screen.getByText("Quoted").className).toContain("text-link");
     rerender(<StatusPill status="delivered" />);
-    expect(screen.getByText("delivered").className).toContain("text-success");
+    expect(screen.getByText("Delivered").className).toContain("text-success");
     rerender(<StatusPill status="in_progress" />);
-    expect(screen.getByText("in progress").className).toContain("text-warn");
+    expect(screen.getByText("In progress").className).toContain("text-warn");
     rerender(<StatusPill status="disputed" />);
-    expect(screen.getByText("disputed").className).toContain("text-error");
+    expect(screen.getByText("Disputed").className).toContain("text-error");
     rerender(<StatusPill status="cancelled" />);
-    expect(screen.getByText("cancelled").className).toContain("text-text-2");
+    expect(screen.getByText("Cancelled").className).toContain("text-text-2");
   });
 
   it("pulses once on status change (MI-14)", () => {
     const { rerender } = render(<StatusPill status="quoted" />);
     rerender(<StatusPill status="paid" />);
-    expect(screen.getByText("paid").className).toContain("status-pulse");
+    expect(screen.getByText("Paid").className).toContain("status-pulse");
   });
 });

--- a/web/src/components/ui/StatusPill.tsx
+++ b/web/src/components/ui/StatusPill.tsx
@@ -12,25 +12,34 @@ import type { Freshness } from "@/models";
 
 export type StatusPillValue = OrderStatus | Freshness;
 
+// Figma master (47:135): borderless pills — a 14% tint of the status token
+// behind a 12px semibold label. fresh strokes the accent gradient.
 const TOKEN_CLASS: Record<StatusPillValue, string> = {
-  quoted: "text-link border-link/40 bg-link/10",
-  shipped: "text-link border-link/40 bg-link/10",
-  paid: "text-success border-success/40 bg-success/10",
-  delivered: "text-success border-success/40 bg-success/10",
-  in_progress: "text-warn border-warn/40 bg-warn/10",
-  refunded: "text-warn border-warn/40 bg-warn/10",
-  declined: "text-error border-error/40 bg-error/10",
-  disputed: "text-error border-error/40 bg-error/10",
-  requested: "text-text-2 border-border bg-bg-elev",
-  cancelled: "text-text-2 border-border bg-bg-elev",
-  fresh: "text-success border-success/40 bg-success/10",
-  aging: "text-warn border-warn/40 bg-warn/10",
-  stale: "text-text-2 border-border bg-bg-elev",
+  quoted: "text-link bg-link/14",
+  shipped: "text-link bg-link/14",
+  paid: "text-success bg-success/14",
+  delivered: "text-success bg-success/14",
+  in_progress: "text-warn bg-warn/14",
+  refunded: "text-warn bg-warn/14",
+  declined: "text-error bg-error/14",
+  disputed: "text-error bg-error/14",
+  requested: "text-text-2 bg-text-2/14",
+  cancelled: "text-text-2 bg-text-2/14",
+  fresh:
+    "bg-[linear-gradient(135deg,color-mix(in_srgb,var(--ap-accent-start)_14%,transparent),color-mix(in_srgb,var(--ap-accent-end)_14%,transparent))]",
+  aging: "text-warn bg-warn/14",
+  stale: "text-text-2 bg-text-2/14",
 };
 
 export interface StatusPillProps {
   status: StatusPillValue;
   className?: string;
+}
+
+/** Figma masters label pills in sentence case ("In progress"). */
+function label(status: StatusPillValue): string {
+  const text = status.replace(/_/g, " ");
+  return text.charAt(0).toUpperCase() + text.slice(1);
 }
 
 export function StatusPill({ status, className }: StatusPillProps) {
@@ -51,7 +60,7 @@ export function StatusPill({ status, className }: StatusPillProps) {
     <span
       data-status={status}
       className={clsx(
-        "inline-flex h-6 items-center rounded-pill border px-3 text-caption font-semibold",
+        "inline-flex h-6 items-center rounded-pill px-2 text-micro font-semibold",
         "transition-colors duration-200 ease-standard motion-reduce:transition-none",
         TOKEN_CLASS[status],
         pulse &&
@@ -59,7 +68,13 @@ export function StatusPill({ status, className }: StatusPillProps) {
         className,
       )}
     >
-      {status.replace(/_/g, " ")}
+      {status === "fresh" ? (
+        <span className="bg-accent-gradient bg-clip-text text-transparent">
+          {label(status)}
+        </span>
+      ) : (
+        label(status)
+      )}
     </span>
   );
 }

--- a/web/src/components/ui/StoryRailItem.tsx
+++ b/web/src/components/ui/StoryRailItem.tsx
@@ -2,6 +2,7 @@
 
 // StoryRailItem — design.md §8.2: state unseen (gradient) / seen (gray) /
 // loading (rotating, MI-8: subtle 1.5s ring rotation while content loads).
+import { useId } from "react";
 import clsx from "clsx";
 import { Avatar } from "./Avatar";
 
@@ -22,6 +23,7 @@ export function StoryRailItem({
   onClick,
   className,
 }: StoryRailItemProps) {
+  const ringGradientId = useId();
   return (
     <button
       type="button"
@@ -29,21 +31,43 @@ export function StoryRailItem({
       data-state={state}
       className={clsx("flex w-16 flex-col items-center gap-1", className)}
     >
-      <span
-        className={clsx(
-          state === "loading" &&
-            "animate-[spin_1.5s_linear_infinite] motion-reduce:animate-none",
-          "rounded-pill",
-        )}
-      >
+      {state === "loading" ? (
+        // Figma master (46:88): dashed gradient ring, rotating while the
+        // story preloads (MI-8).
+        <span className="relative inline-grid place-items-center p-[2px]">
+          <svg
+            viewBox="0 0 60 60"
+            aria-hidden
+            className="absolute inset-0 size-full animate-[spin_1.5s_linear_infinite] motion-reduce:animate-none"
+          >
+            <defs>
+              <linearGradient id={ringGradientId} x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stopColor="var(--ap-accent-start)" />
+                <stop offset="100%" stopColor="var(--ap-accent-end)" />
+              </linearGradient>
+            </defs>
+            <circle
+              cx="30"
+              cy="30"
+              r="29"
+              fill="none"
+              stroke={`url(#${ringGradientId})`}
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeDasharray="6 7"
+            />
+          </svg>
+          <Avatar size={56} name={username} src={avatarUrl} ring="none" />
+        </span>
+      ) : (
         <Avatar
           size={56}
           name={username}
           src={avatarUrl}
           ring={state === "seen" ? "gray" : "gradient"}
         />
-      </span>
-      <span className="w-full truncate text-center text-micro text-text">
+      )}
+      <span className="w-full truncate text-center text-micro text-text-2">
         {username}
       </span>
     </button>

--- a/web/src/components/ui/TabBar.tsx
+++ b/web/src/components/ui/TabBar.tsx
@@ -8,10 +8,10 @@
 import Link from "next/link";
 import clsx from "clsx";
 import {
-  Compass,
   Home,
   Package,
-  PlusSquare,
+  Plus,
+  Search,
   User,
   type LucideIcon,
 } from "lucide-react";
@@ -23,10 +23,12 @@ export interface TabBarItemSpec {
   icon: LucideIcon;
 }
 
+// Figma master (49:384): explore uses the search glyph; create renders the
+// 40px gradient FAB.
 export const DEFAULT_TAB_ITEMS: TabBarItemSpec[] = [
   { key: "home", label: "Home", href: "/dashboard", icon: Home },
-  { key: "explore", label: "Explore", href: "/dashboard/explore", icon: Compass },
-  { key: "create", label: "Create", href: "/dashboard/create", icon: PlusSquare },
+  { key: "explore", label: "Explore", href: "/dashboard/explore", icon: Search },
+  { key: "create", label: "Create", href: "/dashboard/create", icon: Plus },
   { key: "orders", label: "Orders", href: "/dashboard/orders", icon: Package },
   { key: "profile", label: "Profile", href: "/dashboard/profile", icon: User },
 ];
@@ -49,7 +51,7 @@ export function TabBar({
     <nav
       aria-label="Tabs"
       className={clsx(
-        "flex h-12 items-stretch border-t border-border bg-bg",
+        "flex h-14 items-stretch border-t border-border bg-bg",
         className,
       )}
     >
@@ -70,19 +72,33 @@ export function TabBar({
               !active && "text-text-2 hover:text-text",
             )}
           >
-            <span className="relative">
-              <Icon size={24} strokeWidth={active ? 2.5 : 2} />
+            <span className="relative flex flex-col items-center gap-[3px]">
+              {item.key === "create" ? (
+                // Figma master: 40px accent-gradient FAB with a white plus
+                // and the pink glow shadow.
+                <span className="grid size-10 place-items-center rounded-pill bg-accent-gradient text-on-accent shadow-[0_3px_8px_rgba(224,48,107,0.35)]">
+                  <Icon size={20} strokeWidth={2.5} />
+                </span>
+              ) : (
+                <Icon size={24} />
+              )}
               {badge ? (
                 <span
                   key={badge}
                   data-testid="tab-badge"
                   className={clsx(
-                    "tnum absolute -right-2 -top-1.5 grid min-w-4 place-items-center rounded-pill bg-like px-1 text-[10px] font-bold leading-4 text-on-accent",
+                    "tnum absolute -top-2.5 left-1/2 ml-[5.5px] grid min-w-4 -translate-x-1/2 place-items-center rounded-pill bg-like px-1 text-[10px] font-semibold leading-4 text-on-accent",
                     "animate-[pop-in_300ms_var(--ap-ease-standard)] motion-reduce:animate-none",
                   )}
                 >
                   {badge}
                 </span>
+              ) : null}
+              {active ? (
+                <span
+                  data-testid="active-dot"
+                  className="absolute -bottom-[7px] size-1 rounded-pill bg-accent-gradient"
+                />
               ) : null}
             </span>
           </Link>

--- a/web/src/components/ui/ThreadBubble.tsx
+++ b/web/src/components/ui/ThreadBubble.tsx
@@ -42,11 +42,13 @@ export function ThreadBubble({
     >
       <div
         className={clsx(
+          // Figma master (91:1114): sent = inverse surface (text-token
+          // fill), received = soft border-token fill; sending fades.
           "max-w-[75%] overflow-hidden rounded-card text-body",
           content !== "image" && "px-4 py-2.5",
-          sent
-            ? "bg-accent-gradient text-on-accent"
-            : "border border-border bg-bg-elev text-text",
+          sent ? "bg-text text-bg" : "bg-border/40 text-text",
+          content === "image" &&
+            (sent ? "border-4 border-text" : "border-4 border-border/40"),
           state === "sending" && content !== "typing" && "opacity-60",
         )}
       >

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -5,7 +5,7 @@
 // re-toast with Retry (MI-18). Entrance/exit use entrance/exit tokens.
 import { useEffect } from "react";
 import clsx from "clsx";
-import { AlertCircle, CheckCircle2, Info } from "lucide-react";
+import { Check, X } from "lucide-react";
 
 export type ToastKind = "success" | "error" | "neutral";
 
@@ -20,10 +20,10 @@ export interface ToastProps {
   className?: string;
 }
 
-const ICONS: Record<ToastKind, typeof Info> = {
-  success: CheckCircle2,
-  error: AlertCircle,
-  neutral: Info,
+// Figma master (41:2207): success = check, error = x, neutral = no icon.
+const ICONS: Record<Exclude<ToastKind, "neutral">, typeof Check> = {
+  success: Check,
+  error: X,
 };
 
 export function Toast({
@@ -40,32 +40,30 @@ export function Toast({
     return () => clearTimeout(t);
   }, [onDismiss, autoDismissMs]);
 
-  const Icon = ICONS[kind];
+  const Icon = kind === "neutral" ? null : ICONS[kind];
   return (
     <div
       role="status"
       aria-live="polite"
       data-kind={kind}
       className={clsx(
-        "z-50 flex items-center gap-3 rounded-card bg-text px-4 py-3 text-body text-bg shadow-lg",
+        "z-50 flex items-center gap-3 rounded-card bg-text px-4 py-3 text-body text-bg shadow-[0_4px_8px_rgba(0,0,0,0.25)]",
         "animate-[toast-in_250ms_var(--ap-ease-standard)] motion-reduce:animate-none",
         className,
       )}
     >
-      <Icon
-        size={20}
-        className={clsx(
-          kind === "success" && "text-success",
-          kind === "error" && "text-error",
-          kind === "neutral" && "text-bg",
-        )}
-      />
+      {Icon ? (
+        <Icon
+          size={18}
+          className={kind === "success" ? "text-success" : "text-error"}
+        />
+      ) : null}
       <span className="flex-1">{message}</span>
       {kind === "error" && onRetry ? (
         <button
           type="button"
           onClick={onRetry}
-          className="font-semibold text-bg underline-offset-2 hover:underline"
+          className="font-semibold text-accent-start underline-offset-2 hover:underline"
         >
           Retry
         </button>

--- a/web/src/components/ui/WalkthroughStep.tsx
+++ b/web/src/components/ui/WalkthroughStep.tsx
@@ -43,8 +43,9 @@ export function WalkthroughStep({
             key={i}
             data-active={i === step || undefined}
             className={clsx(
-              "rounded-pill transition-all duration-120 ease-standard",
-              i === step ? "h-1.5 w-4 bg-accent-gradient" : "size-1.5 bg-border",
+              // Figma master: equal-size dots; the active one takes accent
+              "size-1.5 rounded-pill transition-colors duration-120 ease-standard",
+              i === step ? "bg-accent-gradient" : "bg-border",
             )}
           />
         ))}


### PR DESCRIPTION
## What

Component-fidelity QA loop over the `/dev/components` gallery vs the Figma Components-page stage masters (file `34GbYXm8TpxMMUaAGGuwMM`: Stage 1 Atoms 38:5 · Stage 2 Molecules & Cards 38:7 · Stage 2b Capture Kit 60:576 · Stage 2c Form Kit 74:801 · Stage 3 Cards & App Chrome 83:857 · Stage 5 Home Sections 142:1515), both themes. Every gallery section was screenshot-diffed against the matching master; divergences were fixed in component code and re-verified with fresh screenshots and a live computed-style spot check.

**48 component sets audited · 33 components fixed · lint / typecheck / 329 tests / build all green.**

## Per-component findings (divergence → fix, severity)

### Stage 1 — Atoms
- **Button** *(major)*: pill radius → `radius/card` 8px; padding 24/16 → 16/12; labels 16/14px → 14/13px semibold; disabled 50% → 40%; loading now swaps the label for a fixed spinner (18/16, on-accent on filled kinds) per the master description; link kind gets real height/padding; pressed overlay tints added.
- **Spinner** *(minor)*: new `on-accent` kind (white arc) for spinners on accent/destructive fills; sizes 16/18 admitted for Button loading.
- **Input** *(major)*: field text 16 → 14px; focus = 2px accent border, error = 1.5px; error helper 12 → 13px; cm/in unit toggle rebuilt as the master's segmented pill (border-token track, text-token active segment); currency adds the NGN suffix + semibold ₦ prefix; textarea counter moved inside the field (error counter reads error); disabled 50 → 40%.
- **Chip** *(medium)*: selected was accent-gradient → solid text-token fill with bg-token label; 13px semibold labels; 6px gap, 14px ✕.
- **Toast** *(medium)*: neutral no longer renders an icon; success/error icons are plain check/✕ at 18; Retry is accent-start; master drop shadow.
- **IconButton** *(minor)*: disabled 40%, pressed surface tint.
- **Avatar** *(medium)*: initials fallback was translucent (ring color bled through — visual bug) → solid border-token fill with text-2 initials (28px at size 96); verified badge was a navy BadgeCheck → accent-gradient disc with white check + 2px bg keyline, flush to the corner, sized per avatar.

### Stage 2 — Molecules & Cards
- **StatusPill** *(medium)*: bordered pills → borderless 14% tint; 12px labels, px-8; sentence-case ("In progress"); `fresh` corrected from success-green to the gradient treatment.
- **StoryRailItem** *(medium)*: loading state now draws the rotating **dashed** gradient ring (was solid); username label text → text-2.
- **MeasurementCard** *(medium)*: metric name 14 semibold → 13 text-2; source chip neutral outline + 12px glyph + sentence case (was link-colored, icon-less); low-confidence chip borderless warn tint incl. the `· 0.62` score; sparkline 120×28 → 168×32; added the master's "Updated 12d ago" meta line (`updatedAt` prop).
- **TabBar** *(major)*: height 48 → 56; explore glyph compass → search; create is now the 40px gradient FAB with glow; active tab = 4px accent dot (was bold stroke); badge geometry per master.
- **Sheet** *(medium)*: added the mobile grabber; title centered at 16px (was left, 20px); stepper rebuilt as full-bleed 4px gradient track + "Step n of N · Label" caption (was label row + inset bar); paddings and mobile up-shadow per master.
- **PostCard** *(medium)*: carousel dots moved below the media (border-token inactive, 6px gradient active); added the 1/5 count pill; header 12/8/8 rhythm; caption semibold with inline "more"; likes/caption/CTA/timestamp unified into the master's 4px column; timestamp tracking.
- **RequestCard** *(medium)*: layout matched to master (pill + CTA stacked at the trailing edge, price in the text column); p-12/gap-12; full ×10 status→action matrix for both roles with master labels ("Send quote", "Pay ₦45,000", "Confirm delivery", "Respond"…), gradient vs quiet per master.
- **EmptyState** *(medium)*: 88px dashed icon ring (was solid 64); 13px text-2 line (was 16 dark); master icons (feed=home, explore=search) and copy; CTA kinds now mixed gradient/quiet per master; added the missing `camera-permission` kind with its two CTAs.
- **Skeleton** *(minor)*: card kind now mirrors the full post anatomy (action circles + caption lines + CTA bar).

### Stage 2b — Capture Kit
- **QCHintChip** *(medium)*: black/70 blur pill → inverse surface (text-token bg / bg-token content, Toast technique); 13px; per-code glyphs (user/ruler/✕/camera/search) instead of a uniform amber triangle.
- **CaptureOverlay** *(medium)*: aspect 3:4 → 9:16; added the 40% scrim, viewfinder corner marks and the top instruction line ("Stand inside the outline" / "Perfect — hold still"); aligned silhouette is now a solid success stroke (dashed only while searching).
- **ProcessingConstellation** *(medium)*: constellation now strokes the accent in every state (was white/green/red); status caption moved below the photo as "Measuring…" / "✓ Done" / "Couldn't measure — retake" (big overlay discs removed).
- **CaptureResults** *(medium)*: header now title + confidence pill (count/mean kept in `title` tooltip); cards stack 1-col; footer is Save-to-vault (gradient, wide) beside Retake (quiet).
- **CaptureOptionCard** *(medium)*: master copy ("Use your camera" / "Enter manually"); gradient icon disc → soft accent tint disc with accent glyph; added the chevron; 14/13px type.
- **ManualMeasureRow** *(medium)*: tape ruler rebuilt — visible tick marks (tall every 5th) under a transparent track with an accent dot thumb (ring when active); active value reads accent.

### Stage 2c — Form Kit
- **FormRow** *(minor)*: helper/error 12 → 13px; visual required-star removed (master has none) — required is announced sr-only.
- **Select / DateInput** *(minor)*: 16 → 14px values; 2px accent focus; 1.5px error border; disabled 40%.
- **AddressFieldset** *(medium)*: Country was a raw "NG" Input → Select showing "Nigeria"; field order per master (address → city → state → country → phone); city/state un-grid to stacked; master helper copy ("Saved with this order…", "Used to recommend designers near you" + "Pre-fills from your last order").

### Stage 3 — Cards & App Chrome
- **GoogleAuthButton** *(medium)*: pill → card radius at 48px, 14px label; loading keeps the G and swaps the label for the spinner; disabled 40%, pressed tint.
- **NavRail** *(medium)*: added the gradient brandmark header ("A"/"Apparule"); explore/create glyphs corrected (search/plus); active = accent dot + semibold text-token (was bold stroke); default items read text-2; support icon → circled-i; 14px labels.
- **AppBar** *(medium)*: root title now paints the gradient wordmark; sub/over-media titles centered at 16px semibold.
- **Tabs** *(none)*: matches master.
- **GridTile** *(minor)*: media-less default shows the camera glyph (was shimmer).
- **OrderTimelineRow** *(medium)*: timestamp moved under the label as an absolute "Jul 12, 14:02" stamp (was trailing relative age); pending rows read "Pending"; terminal-error label no longer red (dot carries the tone).
- **PaymentBox** *(major)*: rebuilt to the master's state×role matrix — icon + headline ("₦45,000 held in escrow", "Funds frozen"…) + body copy per master, tone icons (shield/check/clock/⚠), CTAs incl. "Edit quote", "View payout", "View dispute"/"Respond to dispute"; fee itemized in the quoted body copy.
- **ThreadBubble** *(medium)*: sent bubbles were accent-gradient → inverse text-token surface; received = soft border-token fill (border removed); image bubbles get the master's thick frame.
- **CommentRow** *(minor)*: posting-optimistic keeps the comment text and moves "Posting…" to the meta line.
- **NotificationRow** *(minor)*: actor name semibold with regular action copy (whole line was bold when unread).
- **SessionRow** *(minor)*: method chips sentence case ("Scan"/"Manual").
- **ModerationQueueRow** *(medium)*: master anatomy — "Reported post/comment" headline with the excerpt in the meta; Suspend account is the destructive action (Hide was); Spam pill warn tint; audit line "Actioned · by …".
- **MediaDropzone** *(medium)*: uploading = gradient progress bar + bold count + filename (was spinner+%); error content replaces the dropzone copy (⚠ + headline + type hint); "Up to 10 photos".
- **Banner** *(medium)*: info tone now link-tinted (was plain); action links bind to the tone token (Re-verify=warn, Retry=error); error icon = triangle.
- **Popover** *(minor)*: hairline dividers between menu items.
- **CaughtUpDivider** *(minor)*: check binds to accent (was success green); label semibold text-token.
- **EarningsSummary / TransactionRow** *(medium)*: card labels "Available" / "In escrow"; available value green; row icons per master (card/shield/info, neutral); debits read in the text token, credits in success.
- **UserRow / HomeNav / HomeFooter / Switch / Tooltip** *(none)*: match after the Button/Avatar cascade.

### Stage 5 — Home Sections
- **StatCard** *(medium)*: values were gradient-clipped → text-token per master.
- **WalkthroughStep** *(minor)*: active step dot is an equal-size accent dot (was elongated pill).
- **ComparisonTable** *(medium)*: wrapped in the master's bordered card; Feature header reads as caption; CTAs renamed "Start on Cloud" / "Self-host it".
- **CodeSnippetBlock** *(minor)*: copy affordance is the labeled pill ("Copy" → green-bordered "✓ Copied").
- **CommunityCard** *(minor)*: Join CTA gradient per master (copy kept per the repo accuracy standard — no fabricated member count).

## Intentional adaptations (not "fixed")
- Hover states, focus-visible rings and `active:scale` press motion are web affordances layered on top of the drawn pressed tints.
- ActionRow/PostCard icons sit in ≥44px IconButton hit targets (a11y) — visual gaps approximate the master's 16px icon gaps.
- RequestCard keeps `#order · by/for username` meta and AddressFieldset keeps Recipient name / Address line 2 (data-model needs); master field order/copy adopted around them.
- ModerationQueueRow headline omits the content author (`Report` model carries no author field).
- CaptureOverlay silhouette stays the bespoke SVG path (master ships a flat image asset); shape/stroke semantics match.
- PostCard timestamp uses the shared `formatAgo` relative stamp ("2D") rather than the master's spelled-out "2 HOURS AGO".
- CaptureResults keeps the count/mean summary accessible via the pill's `title` attribute.

## Verification
- Gallery re-screenshot per section (light + dark via `[data-theme]`) after each fix; dark checked for Button/StatusPill/Toast/Avatar/EmptyState and cascade users.
- Live computed-style spot check (Button md: 44px/16px/8px/14px-600; StatusPill: 24px/8px/pill/12px-600) — no unlayered-CSS interference (globals.css has only element-level `body`, intentional helpers and scoped overrides).
- `npm run lint` ✓ · `tsc --noEmit` ✓ · `vitest` 329/329 ✓ · `next build` ✓ (TEST_MODE gallery serves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)