### PR TITLE
feat(web): W2 home — landing from component registry

### DIFF
--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -1,0 +1,175 @@
+// "Marketing site" journey (design.md §8.4, web-implementation.md §7):
+// Part A scroll — every section renders — plus the FAQ accordion, the
+// Try Cloud / Sign in CTA handoff into /signin, and the theme toggle.
+// Runs in TEST_MODE: the star badge deterministically keeps its neutral
+// "Star" label (no third-party fetch in CI).
+import { expect, test } from "@playwright/test";
+
+test.describe("Marketing site — home page", () => {
+  test("all Part A sections render top to bottom", async ({ page }) => {
+    await page.goto("/");
+
+    // A2 hero
+    await expect(
+      page.getByRole("heading", { name: "Two photos. A perfect fit." }),
+    ).toBeVisible();
+    await expect(page.getByTestId("hero-phone")).toBeVisible();
+
+    // A1 nav — neutral star badge in TEST_MODE (accuracy standard)
+    await expect(page.getByTestId("star-badge")).toContainText("Star");
+
+    // A3 stat band — the honest product claims
+    await expect(page.getByText("±2 cm", { exact: true })).toBeVisible();
+    await expect(page.getByText("2 photos", { exact: true })).toBeVisible();
+    await expect(page.getByText("30 days")).toBeVisible();
+
+    // A4 walkthrough
+    await expect(
+      page.getByRole("heading", { name: "How it works" }),
+    ).toBeVisible();
+    await expect(page.getByTestId("walkthrough-rail")).toBeVisible();
+
+    // A4b deep-dives
+    await expect(
+      page.getByRole("heading", { name: "Built around your measurements" }),
+    ).toBeVisible();
+    expect(await page.getByTestId("deep-dive-panel").count()).toBe(4);
+
+    // A5 SMPL
+    await expect(
+      page.getByRole("heading", { name: "AI-assisted body modeling" }),
+    ).toBeVisible();
+
+    // A6 designers
+    await expect(
+      page.getByRole("heading", {
+        name: "Post outfits, get commissioned, get paid",
+      }),
+    ).toBeVisible();
+
+    // A7b developers
+    await expect(
+      page.getByRole("heading", {
+        name: "For developers — hack on the interesting parts",
+      }),
+    ).toBeVisible();
+    expect(await page.getByTestId("dev-topic-card").count()).toBe(3);
+
+    // A7c self-host + A7 architecture diagram
+    await expect(
+      page.getByRole("heading", { name: "Self-host — own your data" }),
+    ).toBeVisible();
+    await expect(page.getByText("docker compose up -d")).toBeVisible();
+    await expect(page.getByTestId("architecture-diagram")).toBeVisible();
+
+    // A9 comparison
+    await expect(
+      page.getByRole("heading", { name: "Cloud or self-host — same product" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Start on Cloud" }),
+    ).toBeVisible();
+
+    // A9b FAQ
+    await expect(
+      page.getByRole("heading", { name: "Frequently asked" }),
+    ).toBeVisible();
+
+    // A8 community
+    await expect(page.getByText("Join the apparule Discord")).toBeVisible();
+
+    // A9c final CTA band
+    await expect(
+      page.getByRole("heading", {
+        name: "Get measured once. Dress like it was always made for you.",
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Open source · MIT licensed · Self-host in one line"),
+    ).toBeVisible();
+
+    // A10 footer
+    await expect(page.getByRole("contentinfo")).toBeVisible();
+    await expect(
+      page
+        .getByRole("contentinfo")
+        .getByRole("link", { name: "Privacy", exact: true }),
+    ).toBeVisible();
+  });
+
+  test("FAQ accordion: first row open, one open at a time, deep-linkable", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const first = page.getByRole("button", {
+      name: "How accurate are camera measurements?",
+    });
+    const second = page.getByRole("button", {
+      name: "What happens to my photos?",
+    });
+
+    await expect(first).toHaveAttribute("aria-expanded", "true");
+    await expect(second).toHaveAttribute("aria-expanded", "false");
+
+    await second.click();
+    await expect(second).toHaveAttribute("aria-expanded", "true");
+    await expect(first).toHaveAttribute("aria-expanded", "false");
+    await expect(
+      page.getByText(/auto-deleted within 30 days/),
+    ).toBeVisible();
+
+    // deep link opens the linked row
+    await page.goto("/#faq-5");
+    await expect(
+      page.getByRole("button", { name: "What license is Apparule under?" }),
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+
+  test("Try Cloud CTA hands off to /signin", async ({ page }) => {
+    await page.goto("/");
+    await page
+      .locator("nav")
+      .getByRole("button", { name: "Try Cloud" })
+      .click();
+    await page.waitForURL("**/signin");
+    await expect(
+      page.getByRole("button", { name: /continue with google/i }),
+    ).toBeVisible();
+  });
+
+  test("Sign in link lands on /signin", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("link", { name: "Sign in" }).click();
+    await page.waitForURL("**/signin");
+  });
+
+  test("hero Self Host CTA scrolls to the self-host section", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: "Self Host" }).first().click();
+    await expect(
+      page.getByRole("heading", { name: "Self-host — own your data" }),
+    ).toBeInViewport();
+  });
+
+  test("theme toggle switches light and dark", async ({ page }) => {
+    await page.goto("/");
+    const html = page.locator("html");
+
+    await page.getByRole("button", { name: /switch to dark theme/i }).click();
+    await expect(html).toHaveAttribute("data-theme", "dark");
+
+    await page.getByRole("button", { name: /switch to light theme/i }).click();
+    await expect(html).toHaveAttribute("data-theme", "light");
+  });
+
+  test("snippet copy button morphs to the copied check", async ({ page }) => {
+    await page.goto("/");
+    await page
+      .getByRole("heading", { name: "Self-host — own your data" })
+      .scrollIntoViewIfNeeded();
+    await page.getByRole("button", { name: "Copy command" }).click();
+    await expect(page.getByTestId("copied-check")).toBeVisible();
+  });
+});

--- a/web/e2e/signin.spec.ts
+++ b/web/e2e/signin.spec.ts
@@ -5,10 +5,11 @@ test.describe("TEST_MODE auth smoke", () => {
   test("signin → dashboard redirect", async ({ page }) => {
     await page.goto("/signin");
 
-    // Exactly one auth CTA (X-1, flows/auth.md).
+    // Exactly one auth CTA (X-1, flows/auth.md) — scoped to the screen
+    // content (the Next dev-tools overlay adds its own button in dev).
     const cta = page.getByRole("button", { name: /continue with google/i });
     await expect(cta).toBeVisible();
-    expect(await page.getByRole("button").count()).toBe(1);
+    expect(await page.locator("main").getByRole("button").count()).toBe(1);
 
     await cta.click();
     await page.waitForURL("**/dashboard");

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,65 +1,66 @@
-import Image from "next/image";
+// Public home page `/` — pages.md Part A (A1–A10 + A4b/A7b/A7c/A9b/A9c),
+// composed from registry component instances against the enriched Figma
+// landing (frame 186:2). Views render-only: demo data flows from
+// controllers/home-demo, the star count from the github repository, and
+// analytics through the controller transport.
+import type { Metadata } from "next";
+import { HomeFooter } from "@/components/ui/HomeFooter";
+import { CommunitySection } from "@/components/home/CommunitySection";
+import { ComparisonSection } from "@/components/home/ComparisonSection";
+import { DesignersSection } from "@/components/home/DesignersSection";
+import { DevelopersSection } from "@/components/home/DevelopersSection";
+import { FaqSection } from "@/components/home/FaqSection";
+import { FeatureDeepDives } from "@/components/home/FeatureDeepDives";
+import { FinalCtaBand } from "@/components/home/FinalCtaBand";
+import { HeroSection } from "@/components/home/HeroSection";
+import { HomeNavBar } from "@/components/home/HomeNavBar";
+import { PageViewTracker } from "@/components/home/PageViewTracker";
+import { SelfHostSection } from "@/components/home/SelfHostSection";
+import { SmplSection } from "@/components/home/SmplSection";
+import { StatBand } from "@/components/home/StatBand";
+import { WalkthroughSection } from "@/components/home/WalkthroughSection";
 
-export default function Home() {
+// Hero copy is the canonical description (canvas 186:18/186:19).
+const DESCRIPTION =
+  "Apparule turns two phone photos into a complete, private body-measurement profile. Commission Lagos designers who sew to your measurements — no size charts, no guesswork.";
+
+export const metadata: Metadata = {
+  title: "Apparule — Two photos. A perfect fit.",
+  description: DESCRIPTION,
+  openGraph: {
+    title: "Apparule — Two photos. A perfect fit.",
+    description: DESCRIPTION,
+    url: "https://apparule.cuesoft.io",
+    siteName: "Apparule",
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Apparule — Two photos. A perfect fit.",
+    description: DESCRIPTION,
+  },
+};
+
+export default function HomePage() {
   return (
-    <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
-          </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
+    <div className="flex min-h-screen flex-col bg-bg text-text">
+      <PageViewTracker path="/" />
+      <HomeNavBar />
+      <main className="flex-1">
+        <HeroSection />
+        <StatBand />
+        <WalkthroughSection />
+        <FeatureDeepDives />
+        <SmplSection />
+        <DesignersSection />
+        <DevelopersSection />
+        <SelfHostSection />
+        <ComparisonSection />
+        <FaqSection />
+        <CommunitySection />
+        <FinalCtaBand />
       </main>
+      <HomeFooter />
     </div>
   );
 }

--- a/web/src/components/home/ArchitectureDiagram.tsx
+++ b/web/src/components/home/ArchitectureDiagram.tsx
@@ -1,0 +1,59 @@
+// A7 architecture mini-diagram (canvas 264:8529) — bespoke token-based
+// boxes + hairline connectors: clients → Go API → Python CV → stores.
+// Bespoke SVG/DOM per the component-reuse policy (no chart/diagram libs).
+import clsx from "clsx";
+
+function Node({
+  children,
+  className,
+}: {
+  children: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={clsx(
+        "flex h-9 items-center justify-center rounded-card border border-border bg-bg-elev px-2 text-caption text-text",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Connector({ className }: { className?: string }) {
+  return <span aria-hidden className={clsx("h-6 w-px bg-border", className)} />;
+}
+
+export function ArchitectureDiagram({ className }: { className?: string }) {
+  return (
+    <div
+      data-testid="architecture-diagram"
+      role="img"
+      aria-label="Architecture: the Flutter app and Next.js web talk to the Go API (api/common), which calls the Python CV service (MediaPipe + SMPL) and stores data in Postgres and S3 media storage"
+      className={clsx("w-full max-w-[300px]", className)}
+    >
+      <div className="grid grid-cols-2 gap-5">
+        <Node>Flutter app</Node>
+        <Node>Next.js web</Node>
+      </div>
+      <div className="grid grid-cols-2 justify-items-center">
+        <Connector />
+        <Connector />
+      </div>
+      <Node>Go API · api/common</Node>
+      <div className="flex justify-center">
+        <Connector />
+      </div>
+      <Node>Python CV · MediaPipe + SMPL</Node>
+      <div className="flex justify-center">
+        <Connector />
+      </div>
+      <div className="grid grid-cols-2 gap-5">
+        <Node>Postgres</Node>
+        <Node>S3 media</Node>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/home/CommunitySection.tsx
+++ b/web/src/components/home/CommunitySection.tsx
@@ -1,0 +1,34 @@
+// A8 Community (canvas 186:171–186:183) — Discord card (live member count
+// stays neutral until a real count exists — accuracy standard), roadmap
+// link, CueLABS note.
+import { CommunityCard } from "@/components/ui/CommunityCard";
+
+export function CommunitySection() {
+  return (
+    <section
+      id="community"
+      aria-labelledby="community-heading"
+      className="mx-auto w-full max-w-[1080px] scroll-mt-20 px-6 py-12"
+    >
+      <h2 id="community-heading" className="text-title-lg font-bold text-text">
+        Community
+      </h2>
+      <div className="mt-6 flex flex-col items-start gap-8 md:flex-row md:items-center md:gap-10">
+        <CommunityCard />
+        <div>
+          <a
+            href="https://github.com/cuesoftinc/apparule#roadmap"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-body font-semibold text-link hover:underline"
+          >
+            Roadmap →
+          </a>
+          <p className="mt-3 text-caption text-text-2">
+            An open-source product by Cuesoft CueLABS
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/home/ComparisonSection.tsx
+++ b/web/src/components/home/ComparisonSection.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+// A9 Cloud vs Self-host (canvas 186:184/186:185) — the ComparisonTable with
+// its CTA row: Cloud → Try Cloud handoff (/signin), OSS → docs quickstart.
+import { useRouter } from "next/navigation";
+import { ComparisonTable } from "@/components/ui/ComparisonTable";
+import { track } from "@/controllers/analytics";
+
+export function ComparisonSection() {
+  const router = useRouter();
+
+  return (
+    <section
+      id="compare"
+      aria-labelledby="compare-heading"
+      className="mx-auto flex w-full max-w-[1080px] scroll-mt-20 flex-col items-center px-6 py-12"
+    >
+      <h2 id="compare-heading" className="self-start text-title-lg font-bold text-text">
+        Cloud or self-host — same product
+      </h2>
+      <div className="mt-6 flex w-full justify-center">
+        <ComparisonTable
+          onTryCloud={() => {
+            track("try_cloud_click", { section: "comparison" });
+            router.push("/signin");
+          }}
+          onSelfHost={() => {
+            track("self_host_click", { section: "comparison" });
+            window.open(
+              "https://docs.apparule.cuesoft.io/self-host",
+              "_blank",
+              "noopener",
+            );
+          }}
+        />
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/home/DesignersSection.tsx
+++ b/web/src/components/home/DesignersSection.tsx
@@ -1,0 +1,39 @@
+// A6 For designers — "Post outfits, get commissioned, get paid" with the
+// earnings composition (canvas 186:131–186:150): EarningsSummary + two
+// TransactionRows carrying the canvas demo figures.
+import {
+  EarningsSummary,
+  TransactionRow,
+} from "@/components/ui/EarningsSummary";
+import { designerEarningsDemo } from "@/controllers/home-demo";
+
+export function DesignersSection() {
+  return (
+    <section
+      id="designers"
+      aria-labelledby="designers-heading"
+      className="mx-auto w-full max-w-[1080px] scroll-mt-20 px-6 py-12"
+    >
+      <div className="flex flex-col items-start gap-10 md:flex-row md:items-center md:gap-16">
+        <div className="max-w-[480px] flex-1">
+          <h2 id="designers-heading" className="text-title-lg font-bold text-text">
+            Post outfits, get commissioned, get paid
+          </h2>
+          <p className="mt-4 text-body-lg text-text-2">
+            Every request arrives with the customer&apos;s measurement
+            snapshot. Quote, sew, ship — funds sit in escrow and release on
+            delivery confirmation.
+          </p>
+        </div>
+        <div className="w-full max-w-[400px] shrink-0">
+          <EarningsSummary earnings={designerEarningsDemo.earnings} />
+          <div className="mt-2">
+            {designerEarningsDemo.transactions.map((t) => (
+              <TransactionRow key={t.entry.id} entry={t.entry} label={t.label} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/home/DevelopersSection.tsx
+++ b/web/src/components/home/DevelopersSection.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+// A7b For developers — Contribute (canvas 198:225–198:6490): stack line ·
+// three "interesting problems" cards · links (good-first-issues,
+// CONTRIBUTING.md, Discord) · GitHub star badge reusing the A1 fetch.
+// Cards lift 2px on hover; `github_click` / `contribute_click` fire here.
+import { Camera, User, Wallet } from "lucide-react";
+import { DiscordMark } from "@/components/icons/DiscordMark";
+import { GitHubMark } from "@/components/icons/GitHubMark";
+import { track } from "@/controllers/analytics";
+import { useGithubStars } from "@/controllers/use-github-stars";
+import { GITHUB_REPO_URL } from "@/models/repositories/github-repo";
+
+const TOPICS = [
+  {
+    icon: Camera,
+    title: "MediaPipe pose QC",
+    body: "Quality gates in Python that reject blur, tilt and partial bodies before they reach the model — 11 failure codes, each with its own retake guidance.",
+  },
+  {
+    icon: User,
+    title: "SMPL body modeling",
+    body: "Fit a parametric body mesh from two views, then turn vertices into tape-measure girths. CV that ships to real tailors, not a paper demo.",
+  },
+  {
+    icon: Wallet,
+    title: "Escrow order lifecycle",
+    body: "A Go state machine that moves real money: quotes, escrow holds, auto-refund deadlines, payouts. Every transition tested against fixtures.",
+  },
+] as const;
+
+const LINK_CLASSES =
+  "inline-flex items-center gap-2 text-body font-semibold text-link transition-transform duration-120 ease-standard hover:-translate-y-0.5 hover:underline motion-reduce:transition-none motion-reduce:hover:translate-y-0";
+
+export function DevelopersSection() {
+  const stars = useGithubStars();
+
+  return (
+    <section
+      id="developers"
+      aria-labelledby="developers-heading"
+      className="mx-auto w-full max-w-[1080px] scroll-mt-20 px-6 py-12"
+    >
+      <h2 id="developers-heading" className="text-title-lg font-bold text-text">
+        For developers — hack on the interesting parts
+      </h2>
+      <p className="mt-3 text-body text-text-2">
+        Flutter · Go · Python CV · Next.js — MIT licensed, api/common +
+        function-named services
+      </p>
+      <div className="mt-8 grid gap-6 md:grid-cols-3">
+        {TOPICS.map((topic) => (
+          <div
+            key={topic.title}
+            data-testid="dev-topic-card"
+            className="rounded-card border border-border bg-bg-elev p-6 transition-transform duration-120 ease-standard hover:-translate-y-0.5 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
+          >
+            {/* canvas 198:229…: topic glyphs bind the text token */}
+            <topic.icon size={24} className="text-text" aria-hidden />
+            <h3 className="mt-3 text-body-lg font-semibold text-text">
+              {topic.title}
+            </h3>
+            <p className="mt-3 text-body text-text-2">{topic.body}</p>
+          </div>
+        ))}
+      </div>
+      <div className="mt-10 flex flex-wrap items-center gap-x-8 gap-y-4">
+        <a
+          href={`${GITHUB_REPO_URL}/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22`}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => {
+            track("github_click", { section: "developers" });
+            track("contribute_click", { link: "good_first_issues" });
+          }}
+          className={LINK_CLASSES}
+        >
+          <GitHubMark size={18} />
+          Good first issues →
+        </a>
+        <a
+          href={`${GITHUB_REPO_URL}/blob/main/CONTRIBUTING.md`}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => {
+            track("github_click", { section: "developers" });
+            track("contribute_click", { link: "contributing" });
+          }}
+          className={LINK_CLASSES}
+        >
+          CONTRIBUTING.md →
+        </a>
+        <a
+          href="https://discord.gg/cuesoft"
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => track("contribute_click", { link: "discord" })}
+          className={LINK_CLASSES}
+        >
+          <DiscordMark size={18} />
+          #apparule-dev on Discord →
+        </a>
+        <a
+          href={GITHUB_REPO_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-testid="dev-star-badge"
+          onClick={() => track("github_click", { section: "developers" })}
+          className="inline-flex h-9 items-center gap-2 rounded-pill border border-border px-4 text-body font-semibold text-text transition-transform duration-120 ease-standard hover:-translate-y-0.5 hover:bg-border/30 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
+        >
+          <GitHubMark size={16} />
+          Star on GitHub
+          {stars !== null ? (
+            <span className="tnum text-text-2">
+              {stars.toLocaleString("en-NG")}
+            </span>
+          ) : null}
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/home/FaqSection.tsx
+++ b/web/src/components/home/FaqSection.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+// A9b FAQ (canvas 200:6483/200:6484) — five product Q&As, one open at a
+// time, first expanded by default (FAQItem master rule), rows deep-linkable
+// via #faq-n. Questions are the canvas copy; the first answer is the canvas
+// text and the collapsed rows' answers are composed from the docs claims
+// (pages.md A9b topics — the Figma file only renders the expanded row).
+// `faq_open` fires on expand.
+import { useEffect, useSyncExternalStore } from "react";
+import { FAQGroup, FAQItem } from "@/components/ui/FAQItem";
+import { track } from "@/controllers/analytics";
+
+const FAQS = [
+  {
+    id: "faq-1",
+    question: "How accurate are camera measurements?",
+    answer:
+      "We target within ±2 cm of a professional tape measure for most values. Good lighting and a full-body frame matter — the capture guide checks both, and you can correct any value manually.",
+  },
+  {
+    id: "faq-2",
+    question: "What happens to my photos?",
+    answer:
+      "Capture photos are used to compute your measurements, then auto-deleted within 30 days. The measurements live in your private vault — visible to no one, and shared only as a frozen snapshot inside a commission request you choose to send.",
+  },
+  {
+    id: "faq-3",
+    question: "How do payments and escrow work?",
+    answer:
+      "You pay when you accept a designer's quote, and the money is held in escrow — not sent ahead. Funds release to the designer when you confirm delivery; opening a dispute freezes payout until it's resolved. The platform fee is an itemized 10% of the quote.",
+  },
+  {
+    id: "faq-4",
+    question: "What do I need to self-host?",
+    answer:
+      "Docker and one command: docker compose up -d brings up everything that ships — api-common (Go), api-measure (Python CV), and the web app — on your own Postgres and S3-compatible storage. The self-host guide covers sizing and configuration.",
+  },
+  {
+    id: "faq-5",
+    question: "What license is Apparule under?",
+    answer:
+      "MIT. The whole product — mobile app, web, API, and the measurement pipeline — is open source under the MIT license: fork it, self-host it, build on it.",
+  },
+] as const;
+
+function subscribeHash(callback: () => void): () => void {
+  window.addEventListener("hashchange", callback);
+  return () => window.removeEventListener("hashchange", callback);
+}
+
+export function FaqSection() {
+  // First row open by default (Figma master rule); a #faq-n deep link
+  // re-keys the group to open the linked row instead (pages.md A9b).
+  const hash = useSyncExternalStore(
+    subscribeHash,
+    () => window.location.hash.replace("#", ""),
+    () => "",
+  );
+  const deepLink = FAQS.some((f) => f.id === hash) ? hash : null;
+  const initialOpenId = deepLink ?? "faq-1";
+
+  useEffect(() => {
+    if (deepLink) {
+      document.getElementById(deepLink)?.scrollIntoView({ block: "center" });
+    }
+  }, [deepLink]);
+
+  return (
+    <section
+      id="faq"
+      aria-labelledby="faq-heading"
+      className="mx-auto w-full max-w-[1080px] scroll-mt-20 px-6 py-12"
+    >
+      <h2 id="faq-heading" className="text-title-lg font-bold text-text">
+        Frequently asked
+      </h2>
+      <FAQGroup
+        key={initialOpenId}
+        defaultOpenId={initialOpenId}
+        className="mt-6 max-w-[800px]"
+      >
+        {FAQS.map((faq) => (
+          <FAQItem
+            key={faq.id}
+            id={faq.id}
+            question={faq.question}
+            onOpenChange={(open) => {
+              if (open) track("faq_open", { faq: faq.id });
+            }}
+          >
+            {faq.answer}
+          </FAQItem>
+        ))}
+      </FAQGroup>
+    </section>
+  );
+}

--- a/web/src/components/home/FeatureDeepDives.tsx
+++ b/web/src/components/home/FeatureDeepDives.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+// A4b Feature deep-dives — benefit-led split panels, alternating media/text
+// (canvas 197:2/197:3, four panels): benefit headline · body · composed
+// dashboard preview · quiet docs link. Panels fade-up on scroll-into-view
+// (once, same rule as A3).
+import clsx from "clsx";
+import { Reveal } from "./Reveal";
+import {
+  DashExploreThumb,
+  DashOrderDetailThumb,
+  DashOrdersThumb,
+  DashVaultThumb,
+} from "./dash-thumbs";
+
+const DOCS_BASE = "https://docs.apparule.cuesoft.io";
+
+const PANELS = [
+  {
+    headline: "Capture once, keep it fresh",
+    body: "Two photos become a full set of body measurements in a private vault only you can see. Freshness tracking nudges you when it's time to retake — no stale numbers on new orders.",
+    href: `${DOCS_BASE}/vault`,
+    thumb: <DashVaultThumb />,
+    mediaFirst: false,
+  },
+  {
+    headline: "Find designers near you",
+    body: "Follow Lagos designers and browse real commissioned work, filtered by style, budget and turnaround. Proximity ranking surfaces ateliers close to you, so fittings and delivery stay easy.",
+    href: `${DOCS_BASE}/discover`,
+    thumb: <DashExploreThumb />,
+    mediaFirst: true,
+  },
+  {
+    headline: "Escrow-protected commissions",
+    body: "Pay when you accept a quote — funds are held in escrow, not sent ahead. Money releases when the outfit is delivered, and a dispute freezes payout until it's resolved.",
+    href: `${DOCS_BASE}/orders`,
+    thumb: <DashOrdersThumb />,
+    mediaFirst: false,
+  },
+  {
+    headline: "Your measurements ride with every order",
+    body: "Each request carries a locked snapshot of exactly the values you chose to share. Your designer sews to those numbers — no more guessing sizes over chat.",
+    href: `${DOCS_BASE}/measurements`,
+    thumb: <DashOrderDetailThumb />,
+    mediaFirst: true,
+  },
+] as const;
+
+export function FeatureDeepDives() {
+  return (
+    <section
+      aria-labelledby="deep-dives-heading"
+      className="mx-auto w-full max-w-[1080px] px-6 py-12"
+    >
+      <h2 id="deep-dives-heading" className="text-title-lg font-bold text-text">
+        Built around your measurements
+      </h2>
+      <div className="mt-8 flex flex-col gap-12">
+        {PANELS.map((panel) => (
+          <Reveal key={panel.headline}>
+            <div
+              data-testid="deep-dive-panel"
+              className={clsx(
+                "flex flex-col items-start gap-8 md:items-center md:gap-12",
+                panel.mediaFirst ? "md:flex-row-reverse" : "md:flex-row",
+              )}
+            >
+              <div className="max-w-[536px] flex-1">
+                <h3 className="text-title font-semibold text-text">
+                  {panel.headline}
+                </h3>
+                <p className="mt-4 text-body text-text-2">{panel.body}</p>
+                <a
+                  href={panel.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-6 inline-block text-body font-semibold text-link hover:underline"
+                >
+                  Read more →
+                </a>
+              </div>
+              <div className="w-full max-w-[560px] shrink-0 md:w-[52%]">
+                {panel.thumb}
+              </div>
+            </div>
+          </Reveal>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/home/FinalCtaBand.tsx
+++ b/web/src/components/home/FinalCtaBand.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+// A9c Final CTA band (canvas 201:2) — full-width accent-gradient band:
+// one-line close + the A2 CTA pair as on-accent pills (white fill / white
+// outline), MIT microcopy. CTA hover lifts 2px (as A2);
+// `try_cloud_click` / `self_host_click` fire here.
+import { useRouter } from "next/navigation";
+import { track } from "@/controllers/analytics";
+
+const PILL_BASE =
+  "flex items-center justify-center rounded-pill px-7 py-3.5 text-body-lg font-semibold transition-transform duration-120 ease-standard hover:-translate-y-0.5 active:scale-[0.98] motion-reduce:transition-none motion-reduce:hover:translate-y-0";
+
+export function FinalCtaBand() {
+  const router = useRouter();
+
+  return (
+    <section
+      aria-labelledby="final-cta-heading"
+      className="bg-accent-gradient px-6 py-9"
+    >
+      <div className="mx-auto flex max-w-[1080px] flex-col items-center gap-5 text-center">
+        <h2
+          id="final-cta-heading"
+          className="text-display font-bold tracking-[-0.5px] text-on-accent"
+        >
+          Get measured once. Dress like it was always made for you.
+        </h2>
+        <div className="flex flex-wrap justify-center gap-4">
+          <button
+            type="button"
+            className={`${PILL_BASE} bg-on-accent text-accent-start`}
+            onClick={() => {
+              track("try_cloud_click", { section: "final-cta" });
+              router.push("/signin");
+            }}
+          >
+            Try Cloud
+          </button>
+          <button
+            type="button"
+            className={`${PILL_BASE} border-[1.5px] border-on-accent text-on-accent`}
+            onClick={() => {
+              track("self_host_click", { section: "final-cta" });
+              document
+                .getElementById("self-host")
+                ?.scrollIntoView({ behavior: "smooth", block: "start" });
+            }}
+          >
+            Self Host
+          </button>
+        </div>
+        <p className="text-caption text-on-accent">
+          Open source · MIT licensed · Self-host in one line
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/home/HeroPhoneMock.tsx
+++ b/web/src/components/home/HeroPhoneMock.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+// Hero phone mock (pages.md A2): phone frame auto-playing a silent
+// feed → capture → request loop, composed from real registry components at
+// mobile scale (Figma 186:25: 390-wide feed scaled 0.775 inside an 8px
+// text-token bezel). The loop pauses on hover and under reduced motion
+// (A2 interaction rule); scenes crossfade on the entrance duration.
+import { useEffect, useRef, useState } from "react";
+import clsx from "clsx";
+import { Bell, Send } from "lucide-react";
+import { AppBar } from "@/components/ui/AppBar";
+import { CaptureOverlay } from "@/components/ui/CaptureOverlay";
+import { OrderTimelineRow } from "@/components/ui/OrderTimelineRow";
+import { PaymentBox } from "@/components/ui/PaymentBox";
+import { PostCard } from "@/components/ui/PostCard";
+import { RequestCard } from "@/components/ui/RequestCard";
+import { StoryRailItem } from "@/components/ui/StoryRailItem";
+import { TabBar } from "@/components/ui/TabBar";
+import { heroOrder, heroPosts, heroStories } from "@/controllers/home-demo";
+import { MiniScreen } from "./MiniScreen";
+
+const SCENES = ["feed", "capture", "request"] as const;
+type Scene = (typeof SCENES)[number];
+
+const PHONE_W = 390;
+const PHONE_H = 844;
+const SCALE = 0.775;
+const SCENE_MS = 4000;
+
+function StatusBar() {
+  return (
+    <div className="flex h-11 shrink-0 items-end px-6 pb-1">
+      <span className="tnum text-body font-semibold text-text">9:41</span>
+    </div>
+  );
+}
+
+function FeedScene() {
+  return (
+    <div className="relative flex h-full flex-col overflow-hidden bg-bg">
+      <StatusBar />
+      <AppBar
+        title="Apparule"
+        trailing={
+          <span className="flex items-center gap-4 text-text">
+            <Bell size={24} />
+            <Send size={24} />
+          </span>
+        }
+      />
+      <div className="flex shrink-0 gap-3 overflow-hidden px-3 py-2">
+        {heroStories.map((story) => (
+          <StoryRailItem
+            key={story.username}
+            username={story.username}
+            avatarUrl={story.avatarUrl}
+            state={story.state}
+          />
+        ))}
+      </div>
+      {/* onRequest shows the "Request this outfit" CTA — decorative here
+          (the whole mock is pointer-inert) */}
+      <PostCard post={heroPosts[0]} onRequest={() => {}} className="shrink-0" />
+      <PostCard post={heroPosts[1]} onRequest={() => {}} className="shrink-0" />
+      <TabBar activeKey="home" ordersBadge={3} className="absolute inset-x-0 bottom-0" />
+    </div>
+  );
+}
+
+function CaptureScene() {
+  return (
+    <div className="flex h-full flex-col justify-center bg-black">
+      <CaptureOverlay guide="searching">
+        {/* eslint-disable-next-line @next/next/no-img-element -- demo asset in the scaled mock */}
+        <img src="/demo/outfit-w05.jpg" alt="" className="size-full object-cover" />
+      </CaptureOverlay>
+    </div>
+  );
+}
+
+function RequestScene() {
+  return (
+    <div className="relative flex h-full flex-col bg-bg">
+      <StatusBar />
+      <AppBar kind="sub" title="Order #APR-1042" />
+      <div className="flex flex-col gap-4 px-3 py-4">
+        <RequestCard order={heroOrder} role="customer" />
+        <div>
+          <OrderTimelineRow dot="done" connector="drawn" label="Requested" />
+          <OrderTimelineRow dot="done" connector="drawn" label="Paid — held in escrow" />
+          <OrderTimelineRow dot="current" connector="none" label="In progress" />
+        </div>
+        <PaymentBox state="escrow-held" role="customer" quoteCents={4_500_000} />
+      </div>
+      <TabBar activeKey="orders" className="absolute inset-x-0 bottom-0" />
+    </div>
+  );
+}
+
+export function HeroPhoneMock({ className }: { className?: string }) {
+  const [scene, setScene] = useState<Scene>("feed");
+  const [paused, setPaused] = useState(false);
+  const reducedRef = useRef(false);
+
+  useEffect(() => {
+    if (
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      reducedRef.current = true;
+      return; // reduced motion: the loop never advances (static feed)
+    }
+    if (paused) return;
+    const id = window.setInterval(() => {
+      setScene((s) => SCENES[(SCENES.indexOf(s) + 1) % SCENES.length]);
+    }, SCENE_MS);
+    return () => window.clearInterval(id);
+  }, [paused]);
+
+  return (
+    <div
+      data-testid="hero-phone"
+      data-scene={scene}
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+      className={clsx(
+        // Figma 186:25: 8px bezel bound to the text token, 48px radius
+        "relative overflow-hidden rounded-[48px] border-8 border-text bg-bg",
+        className,
+      )}
+    >
+      <MiniScreen width={PHONE_W} height={PHONE_H} scale={SCALE}>
+        <div className="relative h-full w-full">
+          {SCENES.map((name) => (
+            <div
+              key={name}
+              data-scene-layer={name}
+              aria-hidden={name !== scene}
+              className={clsx(
+                "absolute inset-0 transition-opacity duration-250 ease-standard motion-reduce:transition-none",
+                name === scene ? "opacity-100" : "opacity-0",
+              )}
+            >
+              {name === "feed" ? (
+                <FeedScene />
+              ) : name === "capture" ? (
+                <CaptureScene />
+              ) : (
+                <RequestScene />
+              )}
+            </div>
+          ))}
+        </div>
+      </MiniScreen>
+    </div>
+  );
+}

--- a/web/src/components/home/HeroSection.tsx
+++ b/web/src/components/home/HeroSection.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+// A2 Hero — H1 + subcopy + dual CTA Try Cloud / Self Host + the phone-mock
+// demo loop (canvas 186:18–186:25). CTA hover lifts 2px; Try Cloud hands
+// off to /signin (the §8.4 marketing → app flow), Self Host jumps to the
+// A7c section.
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/Button";
+import { track } from "@/controllers/analytics";
+import { HeroPhoneMock } from "./HeroPhoneMock";
+
+export function HeroSection() {
+  const router = useRouter();
+
+  return (
+    <section aria-labelledby="hero-heading" className="mx-auto w-full max-w-[1080px] px-6">
+      <div className="flex flex-col items-start gap-12 pb-16 pt-10 md:flex-row md:items-center md:gap-16 md:pb-20 md:pt-16">
+        <div className="max-w-[520px]">
+          <h1
+            id="hero-heading"
+            className="text-display font-bold tracking-[-0.5px] text-text"
+          >
+            Two photos. A perfect fit.
+          </h1>
+          <p className="mt-6 max-w-[480px] text-body-lg text-text-2">
+            Apparule turns two phone photos into a complete, private
+            body-measurement profile. Commission Lagos designers who sew to
+            your measurements — no size charts, no guesswork.
+          </p>
+          <div className="mt-8 flex flex-wrap gap-4">
+            <Button
+              className="h-12 w-[150px] hover:-translate-y-0.5 motion-reduce:hover:translate-y-0"
+              onClick={() => {
+                track("try_cloud_click", { section: "hero" });
+                router.push("/signin");
+              }}
+            >
+              Try Cloud
+            </Button>
+            <Button
+              kind="quiet"
+              className="h-12 w-[150px] hover:-translate-y-0.5 motion-reduce:hover:translate-y-0"
+              onClick={() => {
+                track("self_host_click", { section: "hero" });
+                document
+                  .getElementById("self-host")
+                  ?.scrollIntoView({ behavior: "smooth", block: "start" });
+              }}
+            >
+              Self Host
+            </Button>
+          </div>
+          <p className="mt-4 text-caption text-text-2">
+            Open source · Self-host in one line
+          </p>
+        </div>
+        <div className="mx-auto shrink-0 md:mx-0 md:ml-auto">
+          <HeroPhoneMock />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/home/HomeNavBar.tsx
+++ b/web/src/components/home/HomeNavBar.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+// A1 nav wrapper — HomeNav instance wired to the controllers: live star
+// count (count-up once, neutral "Star" fallback), Try Cloud → /signin
+// handoff, `github_click` / `try_cloud_click`, and the theme toggle
+// (W2 adaptation: the public surface needs light/dark switching for the
+// §8.4 journey; mirrors the NavRail footer toggle).
+import { useRouter } from "next/navigation";
+import { Moon, Sun } from "lucide-react";
+import { HomeNav } from "@/components/ui/HomeNav";
+import { IconButton } from "@/components/ui/IconButton";
+import { useTheme } from "@/design/ThemeProvider";
+import { track } from "@/controllers/analytics";
+import { useGithubStars } from "@/controllers/use-github-stars";
+
+export function HomeNavBar() {
+  const router = useRouter();
+  const stars = useGithubStars();
+  const { preference, setPreference } = useTheme();
+  const nextTheme = preference === "dark" ? "light" : "dark";
+
+  return (
+    <HomeNav
+      starCount={stars}
+      onGithubClick={() => track("github_click", { section: "nav" })}
+      onTryCloud={() => {
+        track("try_cloud_click", { section: "nav" });
+        router.push("/signin");
+      }}
+      trailing={
+        <IconButton
+          size="sm"
+          aria-label={`Switch to ${nextTheme} theme`}
+          onClick={() => setPreference(nextTheme)}
+        >
+          {preference === "dark" ? <Sun size={20} /> : <Moon size={20} />}
+        </IconButton>
+      }
+    />
+  );
+}

--- a/web/src/components/home/MiniScreen.tsx
+++ b/web/src/components/home/MiniScreen.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+// MiniScreen — scaled mini preview for the home page's walkthrough and
+// deep-dive thumbs: real component instances composed at natural size and
+// scaled down, exactly how the Figma thumbs are built (mobile screens at
+// 0.4 of 390, dashboard screens at 0.42 of 1440 — canvas 195:2…/264:8…).
+// Decorative: aria-hidden + inert to pointer/tab order. `fluid` previews
+// downscale further to their container below the natural clip width
+// (375-wide adaptation — Figma is a fixed 1440 canvas).
+import clsx from "clsx";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+
+export interface MiniScreenProps {
+  /** Natural design size the children are composed at. */
+  width: number;
+  height: number;
+  scale: number;
+  /** Clip the scaled result to this box (defaults to width×height ×scale). */
+  clipWidth?: number;
+  clipHeight?: number;
+  /** Shrink with the container when narrower than clipWidth. */
+  fluid?: boolean;
+  className?: string;
+  children: ReactNode;
+}
+
+export function MiniScreen({
+  width,
+  height,
+  scale,
+  clipWidth,
+  clipHeight,
+  fluid = false,
+  className,
+  children,
+}: MiniScreenProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [factor, setFactor] = useState(1);
+  const clipW = clipWidth ?? Math.round(width * scale);
+  const clipH = clipHeight ?? Math.round(height * scale);
+
+  useEffect(() => {
+    if (!fluid) return;
+    const node = ref.current;
+    if (!node || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width ?? clipW;
+      setFactor(Math.min(1, w / clipW));
+    });
+    // Observe the parent so our own fixed height never feeds back.
+    observer.observe(node.parentElement ?? node);
+    return () => observer.disconnect();
+  }, [fluid, clipW]);
+
+  const outer: CSSProperties = fluid
+    ? { width: "100%", maxWidth: clipW, height: clipH * factor }
+    : { width: clipW, height: clipH };
+
+  return (
+    <div
+      ref={ref}
+      aria-hidden
+      data-testid="mini-screen"
+      className={clsx(
+        "pointer-events-none select-none overflow-hidden",
+        className,
+      )}
+      style={outer}
+    >
+      <div
+        style={{
+          width,
+          height,
+          transform: `scale(${scale * factor})`,
+          transformOrigin: "top left",
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/home/PageViewTracker.tsx
+++ b/web/src/components/home/PageViewTracker.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+// Fires the pages.md Part A `page_view` event on mount (analytics
+// controller; no-op/log transport until Upstat ingestion lands at D2).
+import { usePageView } from "@/controllers/analytics";
+
+export function PageViewTracker({ path }: { path: string }) {
+  usePageView(path);
+  return null;
+}

--- a/web/src/components/home/Reveal.tsx
+++ b/web/src/components/home/Reveal.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+// Reveal — the A3/A4b fade-up-on-scroll-into-view rule (once, entrance
+// duration, reduced-motion safe). StatCard carries its own copy of the
+// behavior per its Figma description; panels and section blocks wrap in
+// this instead.
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import clsx from "clsx";
+
+export function Reveal({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node || typeof IntersectionObserver === "undefined") {
+      setVisible(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.2 },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      data-visible={visible}
+      className={clsx(
+        "transition-all duration-250 ease-standard motion-reduce:transition-none",
+        visible ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0",
+        "motion-reduce:translate-y-0 motion-reduce:opacity-100",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/web/src/components/home/SelfHostSection.tsx
+++ b/web/src/components/home/SelfHostSection.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+// A7c Self-host (canvas 186:160–186:170, 198:6492/6493, 264:8529) —
+// data-ownership pitch · the shared `docker compose up -d` snippet with
+// copy-✓ morph (A7 asset) · "what ships" line · architecture mini-diagram ·
+// docs quickstart link. `self_host_click` fires on the docs handoff.
+import { CodeSnippetBlock } from "@/components/ui/CodeSnippetBlock";
+import { track } from "@/controllers/analytics";
+import { ArchitectureDiagram } from "./ArchitectureDiagram";
+
+export function SelfHostSection() {
+  return (
+    <section
+      id="self-host"
+      aria-labelledby="self-host-heading"
+      className="mx-auto w-full max-w-[1080px] scroll-mt-20 px-6 py-12"
+    >
+      <div className="flex flex-col items-start gap-10 md:flex-row md:gap-16">
+        <div className="max-w-[560px] flex-1">
+          <h2 id="self-host-heading" className="text-title-lg font-bold text-text">
+            Self-host — own your data
+          </h2>
+          <p className="mt-4 text-body text-text-2">
+            Run Apparule for your atelier, your fashion school, or your
+            city&apos;s designer community. One command brings up every
+            service — API, CV pipeline, dashboard — on your own Postgres and
+            S3-compatible storage. Your customers&apos; measurements never
+            leave your box.
+          </p>
+          <div className="mt-6 max-w-[420px]">
+            <CodeSnippetBlock code="docker compose up -d" />
+          </div>
+          <p className="mt-3 text-caption text-text-2">
+            All services, your storage, no lock-in.
+          </p>
+          <p className="mt-1 text-caption text-text-2">
+            Ships <code className="font-mono">api-common</code> ·{" "}
+            <code className="font-mono">api-measure</code> ·{" "}
+            <code className="font-mono">web</code>
+          </p>
+          <a
+            href="https://docs.apparule.cuesoft.io/self-host"
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => track("self_host_click", { section: "self-host" })}
+            className="mt-4 inline-block text-body font-semibold text-link hover:underline"
+          >
+            Read the self-host guide →
+          </a>
+        </div>
+        <div className="w-full max-w-[300px] shrink-0 md:pt-4">
+          <ArchitectureDiagram />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/home/SmplSection.tsx
+++ b/web/src/components/home/SmplSection.tsx
@@ -1,0 +1,41 @@
+// A5 SMPL/AI section (APP-003) — "AI-assisted body modeling" explainer with
+// the looping landmark-constellation animation (same asset as MI-12) and a
+// GitBook deep-dive link (canvas 186:83–186:86).
+import { ProcessingConstellation } from "@/components/ui/ProcessingConstellation";
+
+export function SmplSection() {
+  return (
+    <section
+      aria-labelledby="smpl-heading"
+      className="mx-auto w-full max-w-[1080px] px-6 py-12"
+    >
+      <div className="flex flex-col items-start gap-10 md:flex-row md:items-center md:gap-16">
+        <div className="max-w-[480px] flex-1">
+          <h2 id="smpl-heading" className="text-title-lg font-bold text-text">
+            AI-assisted body modeling
+          </h2>
+          <p className="mt-4 text-body-lg text-text-2">
+            Two photos become a full measurement set. SMPL landmark detection
+            maps your proportions — no tape, no guessing. The constellation
+            you see while it works is the real model output.
+          </p>
+          <a
+            href="https://docs.apparule.cuesoft.io/ai-modeling"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-6 inline-block text-body font-semibold text-link hover:underline"
+          >
+            Read the deep-dive on GitBook →
+          </a>
+        </div>
+        <div className="w-70 shrink-0">
+          <ProcessingConstellation
+            state="processing"
+            imageSrc="/demo/outfit-w05.jpg"
+            imageAlt="Full-length photo with pose landmarks drawn over it"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/home/StatBand.tsx
+++ b/web/src/components/home/StatBand.tsx
@@ -1,0 +1,29 @@
+// A3 Problem strip — heading + 3 StatCards (canvas 186:38/186:39).
+// Accuracy standard: product claims only (±2 cm target · 2 photos ·
+// 30-day photo auto-delete), never invented research statistics.
+import { StatCard } from "@/components/ui/StatCard";
+
+const STATS = [
+  { stat: "±2 cm", label: "target accuracy vs a professional tape measure" },
+  { stat: "2 photos", label: "all it takes to build a full measurement profile" },
+  { stat: "30 days", label: "capture photos auto-delete — measurements stay yours" },
+] as const;
+
+export function StatBand() {
+  return (
+    <section
+      id="product"
+      aria-labelledby="stats-heading"
+      className="mx-auto w-full max-w-[1080px] scroll-mt-20 px-6 py-12"
+    >
+      <h2 id="stats-heading" className="text-title-lg font-bold text-text">
+        Made-to-measure, without the guesswork
+      </h2>
+      <div className="mt-6 grid gap-6 sm:grid-cols-3">
+        {STATS.map((s) => (
+          <StatCard key={s.stat} stat={s.stat} label={s.label} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/home/WalkthroughSection.tsx
+++ b/web/src/components/home/WalkthroughSection.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+// A4 Product walkthrough — 4 steps Capture → Vault → Discover → Commission
+// (canvas 186:49/186:50): WalkthroughStep instances with composed mini
+// previews in the screenshot slots. Step dots + keyboard arrows; the
+// scroll-jacked panel is adapted to a snap-scrolling rail on desktop and a
+// vertical stack on mobile (pages.md: scroll-jack disabled on mobile).
+// First engagement fires `demo_start`.
+import { useRef } from "react";
+import { WalkthroughStep } from "@/components/ui/WalkthroughStep";
+import { track } from "@/controllers/analytics";
+import {
+  CaptureThumb,
+  ExploreThumb,
+  OrdersThumb,
+  VaultThumb,
+} from "./mobile-thumbs";
+
+const STEPS = [
+  {
+    title: "Capture",
+    body: "Two photos — your measurements, automatically",
+    thumb: <CaptureThumb />,
+  },
+  {
+    title: "Vault",
+    body: "Private history, freshness-tracked",
+    thumb: <VaultThumb />,
+  },
+  {
+    title: "Discover",
+    body: "Follow designers, find your style",
+    thumb: <ExploreThumb />,
+  },
+  {
+    title: "Commission",
+    body: "Request with your measurements attached",
+    thumb: <OrdersThumb />,
+  },
+] as const;
+
+export function WalkthroughSection() {
+  const railRef = useRef<HTMLDivElement>(null);
+  const engagedRef = useRef(false);
+
+  function engage() {
+    if (engagedRef.current) return;
+    engagedRef.current = true;
+    track("demo_start", { section: "walkthrough" });
+  }
+
+  function onKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") return;
+    event.preventDefault();
+    engage();
+    const rail = railRef.current;
+    if (!rail) return;
+    const stepWidth = rail.scrollWidth / STEPS.length;
+    rail.scrollBy({
+      left: event.key === "ArrowRight" ? stepWidth : -stepWidth,
+      behavior: "smooth",
+    });
+  }
+
+  return (
+    <section
+      aria-labelledby="walkthrough-heading"
+      className="mx-auto w-full max-w-[1080px] px-6 py-12"
+    >
+      <h2 id="walkthrough-heading" className="text-title-lg font-bold text-text">
+        How it works
+      </h2>
+      <div
+        ref={railRef}
+        role="group"
+        aria-label="Product walkthrough — use arrow keys to move between steps"
+        tabIndex={0}
+        onKeyDown={onKeyDown}
+        onScroll={engage}
+        data-testid="walkthrough-rail"
+        // xl:-mr-40 — the Figma walkthrough row runs 1192 wide, extending
+        // right past the 1080 heading grid; below xl the rail snap-scrolls
+        className="mt-6 flex snap-x snap-mandatory flex-col gap-8 overflow-x-auto pb-2 md:flex-row md:gap-6 xl:-mr-40"
+      >
+        {STEPS.map((step, i) => (
+          <WalkthroughStep
+            key={step.title}
+            title={step.title}
+            body={step.body}
+            thumb={step.thumb}
+            step={i as 0 | 1 | 2 | 3}
+            className="snap-start"
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/home/dash-thumbs.tsx
+++ b/web/src/components/home/dash-thumbs.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+// A4b deep-dive thumbs — mini dashboard screens composed from real registry
+// components at natural size (1440-wide), scaled 0.42 and clipped to the
+// 560×300 panel-thumb box exactly like the Figma thumbs (264:8/264:8037/
+// 264:8161/264:8175). Composed previews are the W2 adaptation (pages.md
+// A4b real-screen thumbnails arrive with the W3 dashboards).
+import { Avatar } from "@/components/ui/Avatar";
+import { Button } from "@/components/ui/Button";
+import { Chip } from "@/components/ui/Chip";
+import { GridTile } from "@/components/ui/GridTile";
+import { Input } from "@/components/ui/Input";
+import { MeasurementCard } from "@/components/ui/MeasurementCard";
+import { NavRail } from "@/components/ui/NavRail";
+import { OrderTimelineRow } from "@/components/ui/OrderTimelineRow";
+import { PaymentBox } from "@/components/ui/PaymentBox";
+import { RequestCard } from "@/components/ui/RequestCard";
+import { Tabs } from "@/components/ui/Tabs";
+import { ThreadBubble } from "@/components/ui/ThreadBubble";
+import {
+  demoExploreChips,
+  demoGridImages,
+  demoMeasurements,
+  demoOrders,
+  heroOrder,
+} from "@/controllers/home-demo";
+import { MiniScreen } from "./MiniScreen";
+
+// Figma thumb geometry: dashboard composed at 1440, scaled 0.42, clipped
+// to the 560×300 panel-thumb.
+const DASH_W = 1440;
+const DASH_H = 1024;
+const SCALE = 0.42;
+const CLIP_W = 560;
+const CLIP_H = 300;
+
+/** ISO timestamp n days back (OrderTimelineRow formats real dates). */
+function timelineDaysAgo(days: number): string {
+  return new Date(Date.now() - days * 86_400_000).toISOString();
+}
+
+function DashShell({
+  activeKey,
+  children,
+}: {
+  activeKey: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <MiniScreen
+      width={DASH_W}
+      height={DASH_H}
+      scale={SCALE}
+      clipWidth={CLIP_W}
+      clipHeight={CLIP_H}
+      fluid
+      className="rounded-card border border-border bg-bg"
+    >
+      <div className="flex h-full bg-bg">
+        <NavRail expanded activeKey={activeKey} className="shrink-0" />
+        <div className="min-w-0 flex-1 px-24 py-8">{children}</div>
+      </div>
+    </MiniScreen>
+  );
+}
+
+/** "Capture once, keep it fresh" — B4 vault (264:8). */
+export function DashVaultThumb() {
+  return (
+    <DashShell activeKey="vault">
+      <div className="flex items-center gap-5">
+        <Avatar size={96} ring="gradient" name="Kiki Adeyemi" src="/demo/outfit-w16.jpg" />
+        <div className="flex flex-col items-start gap-1">
+          <span className="text-title font-semibold text-text">
+            Measured 12 days ago
+          </span>
+          <span className="text-caption text-text-2">
+            Fresh — 14 measurements on file · vault is private to you
+          </span>
+          <Button size="sm">Retake</Button>
+        </div>
+      </div>
+      <div className="mt-6 grid w-[728px] grid-cols-3 gap-4">
+        {demoMeasurements.map((m) => (
+          <MeasurementCard
+            key={m.name}
+            name={m.name}
+            valueCm={m.valueCm}
+            source={m.source}
+            confidence={m.confidence}
+            history={m.history}
+          />
+        ))}
+      </div>
+      <p className="mt-4 text-body font-semibold text-link">
+        +8 more measurements →
+      </p>
+      <p className="mt-3 max-w-[600px] text-caption text-text-2">
+        Sessions are kept until you delete them. A snapshot is shared only
+        when you send a request.
+      </p>
+      <p className="mt-2 flex gap-6 text-caption font-semibold text-link">
+        <span>Download my data</span>
+        <span>Delete all measurements</span>
+      </p>
+    </DashShell>
+  );
+}
+
+/** "Find designers near you" — B2 explore (264:8037). */
+export function DashExploreThumb() {
+  return (
+    <DashShell activeKey="explore">
+      <div className="w-[630px]">
+        <Input kind="search" placeholder="Designers, styles, tags" readOnly />
+      </div>
+      <div className="mt-4 flex w-[720px] gap-2 overflow-hidden">
+        {demoExploreChips.map((label, i) => (
+          <Chip key={label} label={label} kind={i === 0 ? "selected" : "default"} />
+        ))}
+        {/* canvas 264:8047: trailing removable location chip */}
+        <Chip label="Lagos" kind="removable" onRemove={() => {}} />
+      </div>
+      <div className="mt-4 grid w-[924px] grid-cols-3 gap-2">
+        {demoGridImages.slice(0, 9).map((img) => (
+          <GridTile key={img.src} src={img.src} alt={img.alt} />
+        ))}
+      </div>
+    </DashShell>
+  );
+}
+
+/** "Escrow-protected commissions" — B3 orders list (264:8161). */
+export function DashOrdersThumb() {
+  return (
+    <DashShell activeKey="orders">
+      <div className="w-[630px]">
+        <Tabs labels={["As customer", "As designer"]} active="first" onChange={() => {}} />
+        <div className="mt-4 flex flex-col gap-4">
+          {demoOrders.map((order) => (
+            <RequestCard key={order.id} order={order} role="customer" />
+          ))}
+        </div>
+      </div>
+    </DashShell>
+  );
+}
+
+/** "Your measurements ride with every order" — B3 order detail (264:8175). */
+export function DashOrderDetailThumb() {
+  return (
+    <DashShell activeKey="orders">
+      <div className="flex gap-10">
+        <div className="w-[630px] shrink-0">
+          <p className="text-title font-semibold text-text">
+            Order #APR-1042 — Ankara two-piece
+          </p>
+          <div className="mt-4">
+            <RequestCard order={heroOrder} role="customer" />
+          </div>
+          <p className="mt-4 text-caption text-text-2">
+            Measurement snapshot — locked to this order · sent Jul 12
+          </p>
+          <div className="mt-2 flex gap-2">
+            {["shoulder 42.5", "hip 96.2", "sleeve 58.0", "waist 78.4", "+10 more"].map(
+              (v) => (
+                <span
+                  key={v}
+                  className="tnum rounded-pill border border-border px-3 py-1 text-caption text-text-2"
+                >
+                  {v}
+                </span>
+              ),
+            )}
+          </div>
+          <div className="mt-4">
+            <OrderTimelineRow dot="done" connector="drawn" label="Requested" timestamp={timelineDaysAgo(10)} />
+            <OrderTimelineRow dot="done" connector="drawn" label="Quoted — ₦45,000" timestamp={timelineDaysAgo(8)} />
+            <OrderTimelineRow dot="done" connector="drawn" label="Paid — held in escrow" timestamp={timelineDaysAgo(6)} />
+            <OrderTimelineRow dot="current" connector="undrawn" label="In progress" timestamp={timelineDaysAgo(4)} />
+            <OrderTimelineRow dot="pending" connector="none" label="Delivered" />
+          </div>
+          <div className="mt-4">
+            <PaymentBox
+              state="escrow-held"
+              role="customer"
+              quoteCents={4_500_000}
+            />
+          </div>
+        </div>
+        <div className="w-[380px] shrink-0 rounded-card border border-border bg-bg-elev p-4">
+          <p className="text-caption font-semibold text-text-2">
+            Thread — amara.designs
+          </p>
+          <div className="mt-3 flex flex-col gap-3">
+            <ThreadBubble side="received" text="Sewing started today — shoulders first." />
+            <ThreadBubble side="sent" text="Can't wait! The fabric is gorgeous." />
+            <ThreadBubble side="received" content="image" imageUrl="/demo/outfit-w14.jpg" />
+          </div>
+          <div className="mt-4">
+            <Input placeholder="Message amara.designs" readOnly />
+          </div>
+        </div>
+      </div>
+    </DashShell>
+  );
+}

--- a/web/src/components/home/interactive.test.tsx
+++ b/web/src/components/home/interactive.test.tsx
@@ -1,0 +1,286 @@
+// Interactive home sections — hero CTAs, walkthrough engagement, FAQ
+// accordion + deep links, comparison/final-CTA handoffs, nav theme toggle,
+// hero phone-mock scene loop.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  setAnalyticsTransport,
+  type AnalyticsEvent,
+} from "@/controllers/analytics";
+import { ThemeProvider } from "@/design/ThemeProvider";
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+const stars = vi.fn<() => Promise<number | null>>(() =>
+  Promise.resolve(null),
+);
+vi.mock("@/models/repositories/github-repo", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@/models/repositories/github-repo")>();
+  return {
+    ...original,
+    githubRepo: { stars: () => stars() },
+  };
+});
+
+import { ComparisonSection } from "./ComparisonSection";
+import { DevelopersSection } from "./DevelopersSection";
+import { FaqSection } from "./FaqSection";
+import { FinalCtaBand } from "./FinalCtaBand";
+import { HeroPhoneMock } from "./HeroPhoneMock";
+import { HeroSection } from "./HeroSection";
+import { HomeNavBar } from "./HomeNavBar";
+import { WalkthroughSection } from "./WalkthroughSection";
+
+let events: AnalyticsEvent[] = [];
+
+beforeEach(() => {
+  events = [];
+  setAnalyticsTransport({ send: (e) => events.push(e) });
+  push.mockClear();
+  window.HTMLElement.prototype.scrollBy ??= () => {};
+  window.location.hash = "";
+});
+
+afterEach(() => {
+  setAnalyticsTransport(null);
+  document.documentElement.removeAttribute("data-theme");
+  window.localStorage.clear();
+  vi.useRealTimers(); // safety net — a timed-out test must not leak fake timers
+});
+
+const names = () => events.map((e) => e.name);
+
+describe("HeroSection (A2)", () => {
+  it("renders the canvas H1, subcopy and open-source microcopy", () => {
+    render(<HeroSection />);
+    expect(
+      screen.getByRole("heading", { name: "Two photos. A perfect fit." }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/two phone photos into a complete, private/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Open source · Self-host in one line"),
+    ).toBeInTheDocument();
+  });
+
+  it("Try Cloud tracks and hands off to /signin", async () => {
+    render(<HeroSection />);
+    await userEvent.click(screen.getByRole("button", { name: "Try Cloud" }));
+    expect(names()).toContain("try_cloud_click");
+    expect(push).toHaveBeenCalledWith("/signin");
+  });
+
+  it("Self Host tracks self_host_click", async () => {
+    render(<HeroSection />);
+    await userEvent.click(screen.getByRole("button", { name: "Self Host" }));
+    expect(names()).toContain("self_host_click");
+  });
+});
+
+describe("HeroPhoneMock loop (A2)", () => {
+  it("starts on the feed scene rendering the demo posts through the controller", () => {
+    render(<HeroPhoneMock />);
+    expect(screen.getByTestId("hero-phone")).toHaveAttribute(
+      "data-scene",
+      "feed",
+    );
+    expect(screen.getByText("amara.designs")).toBeInTheDocument();
+    expect(screen.getByText("kikithreads")).toBeInTheDocument();
+    expect(screen.getAllByText("Request this outfit").length).toBeGreaterThan(0);
+  });
+
+  it("advances feed → capture on the loop timer and pauses on hover", () => {
+    vi.useFakeTimers();
+    render(<HeroPhoneMock />);
+    const phone = screen.getByTestId("hero-phone");
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(phone).toHaveAttribute("data-scene", "capture");
+
+    fireEvent.mouseEnter(phone);
+    act(() => {
+      vi.advanceTimersByTime(8000);
+    });
+    expect(phone).toHaveAttribute("data-scene", "capture"); // paused
+
+    fireEvent.mouseLeave(phone);
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(phone).toHaveAttribute("data-scene", "request"); // resumed
+  });
+});
+
+describe("WalkthroughSection (A4)", () => {
+  it("renders the four steps with per-instance active dots", () => {
+    render(<WalkthroughSection />);
+    // getAllByText: step titles can recur inside the composed previews
+    for (const title of ["Capture", "Vault", "Discover", "Commission"]) {
+      expect(screen.getAllByText(title).length).toBeGreaterThan(0);
+    }
+    expect(screen.getAllByTestId("step-dots")).toHaveLength(4);
+  });
+
+  it("keyboard arrows engage the walkthrough — demo_start fires once", async () => {
+    render(<WalkthroughSection />);
+    const rail = screen.getByTestId("walkthrough-rail");
+    rail.focus();
+    await userEvent.keyboard("{ArrowRight}{ArrowRight}{ArrowLeft}");
+    expect(names().filter((n) => n === "demo_start")).toHaveLength(1);
+  });
+});
+
+describe("FaqSection (A9b)", () => {
+  it("keeps the first row expanded by default, one open at a time", async () => {
+    render(<FaqSection />);
+    const first = screen.getByRole("button", {
+      name: "How accurate are camera measurements?",
+    });
+    expect(first).toHaveAttribute("aria-expanded", "true");
+
+    const second = screen.getByRole("button", {
+      name: "What happens to my photos?",
+    });
+    await userEvent.click(second);
+    expect(second).toHaveAttribute("aria-expanded", "true");
+    expect(first).toHaveAttribute("aria-expanded", "false");
+    expect(names()).toContain("faq_open");
+  });
+
+  it("renders all five product questions with honest answers", () => {
+    render(<FaqSection />);
+    expect(
+      screen.getByText(/±2 cm of a professional tape measure/),
+    ).toBeInTheDocument();
+    for (const q of [
+      "How accurate are camera measurements?",
+      "What happens to my photos?",
+      "How do payments and escrow work?",
+      "What do I need to self-host?",
+      "What license is Apparule under?",
+    ]) {
+      expect(screen.getByText(q)).toBeInTheDocument();
+    }
+  });
+
+  it("deep-links open the matching row (#faq-n)", async () => {
+    window.location.hash = "#faq-4";
+    render(<FaqSection />);
+    const linked = await screen.findByRole("button", {
+      name: "What do I need to self-host?",
+    });
+    expect(linked).toHaveAttribute("aria-expanded", "true");
+  });
+});
+
+describe("ComparisonSection (A9)", () => {
+  it("Start on Cloud hands off to /signin with try_cloud_click", async () => {
+    render(<ComparisonSection />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Start on Cloud" }),
+    );
+    expect(names()).toContain("try_cloud_click");
+    expect(push).toHaveBeenCalledWith("/signin");
+  });
+
+  it("Self-host it opens the docs quickstart with self_host_click", async () => {
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    render(<ComparisonSection />);
+    await userEvent.click(screen.getByRole("button", { name: "Self-host it" }));
+    expect(names()).toContain("self_host_click");
+    expect(open).toHaveBeenCalledWith(
+      "https://docs.apparule.cuesoft.io/self-host",
+      "_blank",
+      "noopener",
+    );
+    open.mockRestore();
+  });
+});
+
+describe("FinalCtaBand (A9c)", () => {
+  it("repeats the CTA pair with the MIT microcopy and fires the events", async () => {
+    render(<FinalCtaBand />);
+    expect(
+      screen.getByText(
+        "Get measured once. Dress like it was always made for you.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Open source · MIT licensed · Self-host in one line"),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Try Cloud" }));
+    expect(names()).toContain("try_cloud_click");
+    expect(push).toHaveBeenCalledWith("/signin");
+
+    await userEvent.click(screen.getByRole("button", { name: "Self Host" }));
+    expect(names()).toContain("self_host_click");
+  });
+});
+
+describe("DevelopersSection (A7b)", () => {
+  it("renders the three interesting-problem cards and the contribute links", () => {
+    render(<DevelopersSection />);
+    expect(screen.getAllByTestId("dev-topic-card")).toHaveLength(3);
+    expect(screen.getByText("MediaPipe pose QC")).toBeInTheDocument();
+    expect(screen.getByText("SMPL body modeling")).toBeInTheDocument();
+    expect(screen.getByText("Escrow order lifecycle")).toBeInTheDocument();
+    // neutral star badge — no invented count
+    expect(screen.getByTestId("dev-star-badge")).toHaveTextContent(
+      "Star on GitHub",
+    );
+  });
+
+  it("fires github_click / contribute_click on the links", async () => {
+    render(<DevelopersSection />);
+    const link = screen.getByRole("link", { name: /good first issues/i });
+    link.addEventListener("click", (e) => e.preventDefault());
+    await userEvent.click(link);
+    expect(names()).toContain("github_click");
+    expect(names()).toContain("contribute_click");
+  });
+});
+
+describe("HomeNavBar (A1)", () => {
+  it("toggles the theme (light ↔ dark) from the nav", async () => {
+    render(
+      <ThemeProvider>
+        <HomeNavBar />
+      </ThemeProvider>,
+    );
+    const toggle = screen.getByRole("button", { name: /switch to dark theme/i });
+    await userEvent.click(toggle);
+    expect(document.documentElement).toHaveAttribute("data-theme", "dark");
+    await userEvent.click(
+      screen.getByRole("button", { name: /switch to light theme/i }),
+    );
+    expect(document.documentElement).toHaveAttribute("data-theme", "light");
+  });
+
+  it("Try Cloud in the nav tracks and routes to /signin", async () => {
+    render(
+      <ThemeProvider>
+        <HomeNavBar />
+      </ThemeProvider>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Try Cloud" }));
+    expect(names()).toContain("try_cloud_click");
+    expect(push).toHaveBeenCalledWith("/signin");
+  });
+
+  it("renders the neutral Star badge while no live count exists", () => {
+    render(
+      <ThemeProvider>
+        <HomeNavBar />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("star-badge")).toHaveTextContent("Star");
+  });
+});

--- a/web/src/components/home/mobile-thumbs.tsx
+++ b/web/src/components/home/mobile-thumbs.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+// A4 walkthrough thumbs — mini mobile screens composed from real registry
+// components at natural size (390-wide), scaled 0.4 into the 280×180
+// screenshot slot exactly like the Figma thumbs (195:2/195:5/195:6309/
+// 195:6333). W2 adaptation per pages.md A4: composed component previews
+// stand in for exported Stage-4 raster thumbnails until W3.
+import { AppBar } from "@/components/ui/AppBar";
+import { Avatar } from "@/components/ui/Avatar";
+import { Button } from "@/components/ui/Button";
+import { CaptureOptionCard } from "@/components/ui/CaptureOptionCard";
+import { CaptureOverlay } from "@/components/ui/CaptureOverlay";
+import { Chip } from "@/components/ui/Chip";
+import { GridTile } from "@/components/ui/GridTile";
+import { Input } from "@/components/ui/Input";
+import { MeasurementCard } from "@/components/ui/MeasurementCard";
+import { RequestCard } from "@/components/ui/RequestCard";
+import { TabBar } from "@/components/ui/TabBar";
+import { Tabs } from "@/components/ui/Tabs";
+import {
+  demoExploreChips,
+  demoGridImages,
+  demoMeasurements,
+  demoOrders,
+} from "@/controllers/home-demo";
+import { MiniScreen } from "./MiniScreen";
+
+// Figma thumb geometry: phone screens at 156 = 390 × 0.4, top-anchored
+// 12px inside the 280×180 slot.
+const PHONE_W = 390;
+const PHONE_H = 844;
+const SCALE = 0.4;
+
+function ThumbShell({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="absolute inset-0 flex justify-center pt-3">
+      <MiniScreen
+        width={PHONE_W}
+        height={PHONE_H}
+        scale={SCALE}
+        clipHeight={168}
+        className="rounded-lg border border-border bg-bg"
+      >
+        {children}
+      </MiniScreen>
+    </span>
+  );
+}
+
+function StatusBar() {
+  return (
+    <div className="flex h-11 shrink-0 items-end px-6 pb-1">
+      <span className="tnum text-caption font-semibold text-text">9:41</span>
+    </div>
+  );
+}
+
+/** Step 1 — Capture: silhouette guide over the camera viewport (C6). */
+export function CaptureThumb() {
+  return (
+    <ThumbShell>
+      <div className="flex h-full flex-col bg-black">
+        <CaptureOverlay guide="searching">
+          {/* eslint-disable-next-line @next/next/no-img-element -- demo asset in a scaled preview */}
+          <img
+            src="/demo/outfit-w05.jpg"
+            alt=""
+            className="size-full object-cover"
+          />
+        </CaptureOverlay>
+      </div>
+    </ThumbShell>
+  );
+}
+
+/** Step 2 — Vault: freshness header + cards + retake sheet (C7). */
+export function VaultThumb() {
+  return (
+    <ThumbShell>
+      <div className="relative flex h-full flex-col bg-bg">
+        <StatusBar />
+        <AppBar kind="sub" title="Measurement vault" onBack={() => {}} />
+        <div className="flex items-center gap-4 px-4 py-4">
+          <Avatar size={96} ring="gradient" name="Kiki Adeyemi" src="/demo/outfit-w16.jpg" />
+          <div className="flex flex-col items-start gap-1">
+            <span className="text-body-lg font-semibold text-text">
+              Measured 12 days ago
+            </span>
+            <span className="text-caption text-text-2">
+              Up to date · 14 measurements
+            </span>
+            <Button size="sm">Retake</Button>
+          </div>
+        </div>
+        <div className="flex flex-col gap-3 px-4">
+          {demoMeasurements.slice(0, 2).map((m) => (
+            <MeasurementCard
+              key={m.name}
+              name={m.name}
+              valueCm={m.valueCm}
+              source={m.source}
+              confidence={m.confidence}
+              history={m.history}
+            />
+          ))}
+        </div>
+        <div className="absolute inset-x-0 bottom-0 flex flex-col gap-3 rounded-t-2xl border-t border-border bg-bg-elev px-4 pb-4 pt-2">
+          <span className="mx-auto h-1 w-9 rounded-pill bg-border" />
+          <span className="text-body-lg font-semibold text-text">
+            Retake your measurements
+          </span>
+          <CaptureOptionCard mode="webcam-upload" />
+          <CaptureOptionCard mode="manual-entry" />
+        </div>
+      </div>
+    </ThumbShell>
+  );
+}
+
+/** Step 3 — Discover: search + filter chips + explore grid (C3). */
+export function ExploreThumb() {
+  return (
+    <ThumbShell>
+      <div className="relative flex h-full flex-col bg-bg">
+        <StatusBar />
+        <div className="px-4 pb-2">
+          <Input kind="search" placeholder="Designers, styles, tags" readOnly />
+        </div>
+        <div className="flex gap-2 overflow-hidden px-4 pb-3">
+          {demoExploreChips.map((label, i) => (
+            <Chip key={label} label={label} kind={i === 0 ? "selected" : "default"} />
+          ))}
+        </div>
+        <div className="grid grid-cols-3 gap-0.5">
+          {demoGridImages.slice(0, 9).map((img) => (
+            <GridTile key={img.src} src={img.src} alt={img.alt} />
+          ))}
+        </div>
+        <TabBar activeKey="explore" className="absolute inset-x-0 bottom-0" />
+      </div>
+    </ThumbShell>
+  );
+}
+
+/** Step 4 — Commission: orders list with the status pills (C8). */
+export function OrdersThumb() {
+  return (
+    <ThumbShell>
+      <div className="relative flex h-full flex-col bg-bg">
+        <StatusBar />
+        <AppBar kind="sub" title="Orders" />
+        <div className="px-4 pt-2">
+          <Tabs labels={["As customer", "As designer"]} active="first" onChange={() => {}} />
+        </div>
+        <div className="flex flex-col gap-3 px-4 pt-3">
+          {demoOrders.slice(0, 4).map((order) => (
+            <RequestCard key={order.id} order={order} role="customer" />
+          ))}
+        </div>
+        <TabBar activeKey="orders" ordersBadge={2} className="absolute inset-x-0 bottom-0" />
+      </div>
+    </ThumbShell>
+  );
+}

--- a/web/src/components/home/sections.test.tsx
+++ b/web/src/components/home/sections.test.tsx
@@ -1,0 +1,138 @@
+// Static-composition home sections (A3/A4b/A5/A6/A7c/A8) — render checks
+// against the enriched-landing copy + accuracy-standard invariants.
+import { afterEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { setAnalyticsTransport, type AnalyticsEvent } from "@/controllers/analytics";
+import { ThemeProvider } from "@/design/ThemeProvider";
+import { ArchitectureDiagram } from "./ArchitectureDiagram";
+import { CommunitySection } from "./CommunitySection";
+import { DesignersSection } from "./DesignersSection";
+import { FeatureDeepDives } from "./FeatureDeepDives";
+import { SelfHostSection } from "./SelfHostSection";
+import { SmplSection } from "./SmplSection";
+import { StatBand } from "./StatBand";
+
+afterEach(() => setAnalyticsTransport(null));
+
+describe("StatBand (A3)", () => {
+  it("renders the three product claims — and only honest ones", () => {
+    render(<StatBand />);
+    expect(screen.getByText("±2 cm")).toBeInTheDocument();
+    expect(screen.getByText("2 photos")).toBeInTheDocument();
+    expect(screen.getByText("30 days")).toBeInTheDocument();
+    expect(
+      screen.getByText(/target accuracy vs a professional tape measure/),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("FeatureDeepDives (A4b)", () => {
+  it("renders the four alternating benefit panels with docs links", () => {
+    // ThemeProvider: the composed NavRail previews read the theme context
+    render(
+      <ThemeProvider>
+        <FeatureDeepDives />
+      </ThemeProvider>,
+    );
+    const panels = screen.getAllByTestId("deep-dive-panel");
+    expect(panels).toHaveLength(4);
+    expect(screen.getByText("Capture once, keep it fresh")).toBeInTheDocument();
+    expect(screen.getByText("Find designers near you")).toBeInTheDocument();
+    expect(screen.getByText("Escrow-protected commissions")).toBeInTheDocument();
+    expect(
+      screen.getByText("Your measurements ride with every order"),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("link", { name: /read more/i })).toHaveLength(4);
+  });
+
+  it("thumbs are composed component previews, decorative to AT", () => {
+    render(
+      <ThemeProvider>
+        <FeatureDeepDives />
+      </ThemeProvider>,
+    );
+    const screens = screen.getAllByTestId("mini-screen");
+    expect(screens.length).toBeGreaterThanOrEqual(4);
+    for (const node of screens) {
+      expect(node).toHaveAttribute("aria-hidden");
+    }
+  });
+});
+
+describe("SmplSection (A5)", () => {
+  it("renders the AI-modeling explainer with the MI-12 constellation", () => {
+    render(<SmplSection />);
+    expect(screen.getByText("AI-assisted body modeling")).toBeInTheDocument();
+    expect(screen.getByTestId("constellation")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /read the deep-dive on gitbook/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("DesignersSection (A6)", () => {
+  it("renders the earnings composition from the demo controller", () => {
+    render(<DesignersSection />);
+    expect(
+      screen.getByText("Post outfits, get commissioned, get paid"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("balance-card")).toHaveTextContent("₦82,500");
+    expect(screen.getByTestId("pending-card")).toHaveTextContent("₦45,000");
+    expect(screen.getByText("Payout to GTBank •••• 4521")).toBeInTheDocument();
+    expect(
+      screen.getByText("Escrow held · order #APR-1042"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("SelfHostSection (A7c)", () => {
+  it("renders pitch, one-liner, what-ships and the docs link", () => {
+    render(<SelfHostSection />);
+    expect(screen.getByText("Self-host — own your data")).toBeInTheDocument();
+    expect(screen.getByText(/docker compose up -d/)).toBeInTheDocument();
+    expect(screen.getByText("api-common")).toBeInTheDocument();
+    expect(screen.getByText("api-measure")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /read the self-host guide/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("fires self_host_click on the docs handoff", async () => {
+    const events: AnalyticsEvent[] = [];
+    setAnalyticsTransport({ send: (e) => events.push(e) });
+    render(<SelfHostSection />);
+    const link = screen.getByRole("link", { name: /read the self-host guide/i });
+    // avoid jsdom navigation noise
+    link.addEventListener("click", (e) => e.preventDefault());
+    link.click();
+    expect(events.map((e) => e.name)).toContain("self_host_click");
+  });
+});
+
+describe("ArchitectureDiagram (A7)", () => {
+  it("names every service tier of the mini-diagram", () => {
+    render(<ArchitectureDiagram />);
+    for (const label of [
+      "Flutter app",
+      "Next.js web",
+      "Go API · api/common",
+      "Python CV · MediaPipe + SMPL",
+      "Postgres",
+      "S3 media",
+    ]) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+});
+
+describe("CommunitySection (A8)", () => {
+  it("renders the Discord card with the neutral member line (no invented count)", () => {
+    render(<CommunitySection />);
+    expect(screen.getByText("Join the apparule Discord")).toBeInTheDocument();
+    expect(screen.getByTestId("member-badge")).not.toHaveTextContent("members");
+    expect(screen.getByRole("link", { name: "Roadmap →" })).toBeInTheDocument();
+    expect(
+      screen.getByText("An open-source product by Cuesoft CueLABS"),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/icons/DiscordMark.tsx
+++ b/web/src/components/icons/DiscordMark.tsx
@@ -1,10 +1,17 @@
 // Brand glyph `icon/brand-discord` — the Discord mark (not Lucide; approved
 // brand addition per the shared-foundations iconography rule, design.md §2).
-export function DiscordMark({ size = 16 }: { size?: number }) {
+export function DiscordMark({
+  size = 16,
+  className,
+}: {
+  size?: number;
+  className?: string;
+}) {
   return (
     <svg
       width={size}
       height={size}
+      className={className}
       viewBox="0 0 127.14 96.36"
       fill="currentColor"
       aria-hidden="true"

--- a/web/src/components/ui/CommunityCard.test.tsx
+++ b/web/src/components/ui/CommunityCard.test.tsx
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { CommunityCard } from "./CommunityCard";
 
-describe("CommunityCard (§8.2b marketing)", () => {
-  it("renders the neutral badge with no invented member count", () => {
+describe("CommunityCard (§8.2b marketing — compact master 144:3724)", () => {
+  it("renders the neutral member line with no invented count", () => {
     render(<CommunityCard />);
-    expect(screen.getByTestId("member-badge")).toHaveTextContent("Discord");
+    expect(screen.getByTestId("member-badge")).toHaveTextContent(
+      "Fit checks & dev chat, daily",
+    );
     expect(screen.getByTestId("member-badge")).not.toHaveTextContent("members");
   });
 
@@ -14,8 +16,10 @@ describe("CommunityCard (§8.2b marketing)", () => {
     expect(screen.getByTestId("member-badge")).toHaveTextContent("412 members");
   });
 
-  it("carries the join CTA", () => {
+  it("carries the Join CTA", () => {
     render(<CommunityCard />);
-    expect(screen.getByRole("button", { name: "Join Discord" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Join Discord" }),
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/components/ui/CommunityCard.tsx
+++ b/web/src/components/ui/CommunityCard.tsx
@@ -1,13 +1,16 @@
-// CommunityCard — design.md §8.2b Home section kit: Discord card. Accuracy
-// standard (2026-07-18): the master carries a neutral badge — no member
-// count on canvases; the live count arrives at runtime (null → neutral).
+"use client";
+
+// CommunityCard — design.md §8.2b Home section kit: Discord card, compact
+// horizontal master 144:3724 (enriched landing): icon/brand-discord 32 ·
+// title + member line · Join CTA. Accuracy standard (2026-07-18): no
+// invented member counts — the live count arrives at runtime (null →
+// neutral copy, count rendered only when real).
 import clsx from "clsx";
-import { Users } from "lucide-react";
 import { DiscordMark } from "@/components/icons/DiscordMark";
 import { Button } from "./Button";
 
 export interface CommunityCardProps {
-  /** Live member count fetched at runtime; null renders the neutral badge. */
+  /** Live member count fetched at runtime; null renders the neutral line. */
   memberCount?: number | null;
   discordHref?: string;
   className?: string;
@@ -21,42 +24,42 @@ export function CommunityCard({
   return (
     <div
       className={clsx(
-        "flex w-full max-w-sm flex-col gap-4 rounded-card border border-border bg-bg-elev p-6",
+        // Figma master: gap 14 / pl 20 / pr 16 / py 16 — master geometry
+        "flex w-full max-w-[440px] items-center gap-3.5 rounded-card border border-border bg-bg-elev py-4 pl-5 pr-4",
         className,
       )}
     >
-      <div className="flex items-center gap-3">
-        <span className="grid size-11 place-items-center rounded-pill bg-accent-gradient text-on-accent">
-          <DiscordMark size={22} />
-        </span>
-        <div>
-          <p className="text-body-lg font-semibold text-text">Join the community</p>
-          <p
-            data-testid="member-badge"
-            className="flex items-center gap-1 text-caption text-text-2"
-          >
-            <Users size={14} />
-            {memberCount === null ? (
-              "Discord"
-            ) : (
+      {/* Discord brand blurple — documented raw-hex exception (brand glyph
+          color, not a UI token; identical both themes, as on the canvas) */}
+      <DiscordMark size={32} className="shrink-0 text-[#5865F2]" />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-body-lg font-semibold text-text">
+          Join the apparule Discord
+        </p>
+        <p
+          data-testid="member-badge"
+          className="truncate text-body text-text-2"
+        >
+          {memberCount === null ? (
+            <>Fit checks &amp; dev chat, daily</>
+          ) : (
+            <>
               <span className="tnum">
                 {memberCount.toLocaleString("en-NG")} members
               </span>
-            )}
-          </p>
-        </div>
+              {" · fit checks & dev chat, daily"}
+            </>
+          )}
+        </p>
       </div>
-      <p className="text-body text-text-2">
-        Builders, designers, and tailors shaping open-source fashion tech —
-        roadmap talk, capture-QC debugging, and show-and-tell.
-      </p>
-      {/* Figma master (Stage 5): the Join CTA paints the gradient */}
       <Button
         kind="gradient-primary"
         size="sm"
-        onClick={() => window.open(discordHref, "_blank")}
+        aria-label="Join Discord"
+        className="shrink-0"
+        onClick={() => window.open(discordHref, "_blank", "noopener")}
       >
-        Join Discord
+        Join
       </Button>
     </div>
   );

--- a/web/src/components/ui/ComparisonTable.tsx
+++ b/web/src/components/ui/ComparisonTable.tsx
@@ -1,8 +1,10 @@
 // ComparisonTable — design.md §8.2b Home section kit: Cloud vs OSS + CTA
 // row (pages.md A9: Cloud column ends in Try Cloud, OSS column in Self
-// Host → docs quickstart).
+// Host → docs quickstart). Figma master 143:2 (enriched landing, 2026-07-18):
+// icon/check (success) = included, icon/x (text-2) = not available; 100px
+// rows, 140px CTA columns closing in "Start on Cloud" / "Self-host it".
 import clsx from "clsx";
-import { Check, Minus } from "lucide-react";
+import { Check, X } from "lucide-react";
 import { Button } from "./Button";
 
 export interface ComparisonRow {
@@ -11,18 +13,20 @@ export interface ComparisonRow {
   oss: boolean | string;
 }
 
+// The Figma master's row set (143:9–143:59) — capability rows only, no
+// invented pricing (accuracy standard).
 const DEFAULT_ROWS: ComparisonRow[] = [
-  { feature: "AI body measurement", cloud: true, oss: true },
-  { feature: "Social feed & commissions", cloud: true, oss: true },
-  { feature: "Escrow payments (Paystack)", cloud: true, oss: "bring your own keys" },
-  { feature: "Managed hosting & backups", cloud: true, oss: false },
-  { feature: "Your data on your metal", cloud: false, oss: true },
-  { feature: "Support", cloud: "included", oss: "community" },
+  { feature: "Instant setup", cloud: true, oss: false },
+  { feature: "Automatic updates", cloud: true, oss: false },
+  { feature: "Custom domain", cloud: true, oss: true },
+  { feature: "Runs on your infrastructure", cloud: false, oss: true },
+  { feature: "Offline / air-gapped", cloud: false, oss: true },
+  { feature: "Priority support & SLA", cloud: true, oss: false },
 ];
 
 function Cell({ value }: { value: boolean | string }) {
-  if (value === true) return <Check size={18} className="mx-auto text-success" aria-label="Included" />;
-  if (value === false) return <Minus size={18} className="mx-auto text-text-2" aria-label="Not included" />;
+  if (value === true) return <Check size={24} className="mx-auto text-success" aria-label="Included" />;
+  if (value === false) return <X size={24} className="mx-auto text-text-2" aria-label="Not included" />;
   return <span className="text-caption text-text-2">{value}</span>;
 }
 
@@ -40,23 +44,23 @@ export function ComparisonTable({
   className,
 }: ComparisonTableProps) {
   return (
-    // Figma master (Stage 5): the table sits in a bordered card; the
-    // Feature header reads as a caption, CTAs are "Start on Cloud" /
-    // "Self-host it".
     <div
       className={clsx(
-        "w-full max-w-2xl overflow-hidden rounded-card border border-border bg-bg-elev",
+        "w-full max-w-[640px] overflow-hidden rounded-card border border-border bg-bg-elev",
         className,
       )}
     >
       <table className="w-full border-collapse text-body">
         <thead>
           <tr className="border-b border-border text-left">
-            <th className="px-4 py-3 text-caption font-normal text-text-2">
+            {/* Figma master: Feature reads Caption/13 Semi Bold in text-2 */}
+            <th className="h-25 px-6 text-caption font-semibold text-text-2">
               Feature
             </th>
-            <th className="w-36 py-3 text-center font-semibold text-text">Cloud</th>
-            <th className="w-36 px-4 py-3 text-center font-semibold text-text">
+            <th className="h-25 w-35 text-center text-body-lg font-semibold text-text">
+              Cloud
+            </th>
+            <th className="h-25 w-35 px-6 pl-0 text-center text-body-lg font-semibold text-text">
               Self-host
             </th>
           </tr>
@@ -64,23 +68,23 @@ export function ComparisonTable({
         <tbody>
           {rows.map((row) => (
             <tr key={row.feature} className="border-b border-border">
-              <td className="px-4 py-3 text-text">{row.feature}</td>
-              <td className="py-3 text-center">
+              <td className="h-25 px-6 text-text">{row.feature}</td>
+              <td className="h-25 text-center">
                 <Cell value={row.cloud} />
               </td>
-              <td className="px-4 py-3 text-center">
+              <td className="h-25 px-6 pl-0 text-center">
                 <Cell value={row.oss} />
               </td>
             </tr>
           ))}
           <tr data-testid="cta-row">
-            <td className="py-4" />
-            <td className="py-4 text-center">
+            <td className="h-25 px-6" />
+            <td className="h-25 text-center">
               <Button kind="gradient-primary" size="sm" onClick={onTryCloud}>
                 Start on Cloud
               </Button>
             </td>
-            <td className="px-4 py-4 text-center">
+            <td className="h-25 px-6 pl-0 text-center">
               <Button kind="quiet" size="sm" onClick={onSelfHost}>
                 Self-host it
               </Button>

--- a/web/src/components/ui/EarningsSummary.tsx
+++ b/web/src/components/ui/EarningsSummary.tsx
@@ -49,10 +49,16 @@ const KIND_META = {
 
 export interface TransactionRowProps {
   entry: EarningsEntry;
+  /**
+   * Optional label override — the enriched-landing instances (186:140/150)
+   * carry free-text first lines ("Payout to GTBank •••• 4521"); defaults to
+   * the derived `{kind} · {order_number}` line.
+   */
+  label?: string;
   className?: string;
 }
 
-export function TransactionRow({ entry, className }: TransactionRowProps) {
+export function TransactionRow({ entry, label, className }: TransactionRowProps) {
   const meta = KIND_META[entry.kind];
   const Icon = meta.icon;
   const negative = entry.amount_cents < 0;
@@ -69,7 +75,7 @@ export function TransactionRow({ entry, className }: TransactionRowProps) {
       </span>
       <div className="min-w-0 flex-1">
         <p className="text-body font-semibold text-text">
-          {meta.label} · {entry.order_number}
+          {label ?? `${meta.label} · ${entry.order_number}`}
         </p>
         <p className="truncate text-micro text-text-2">
           {formatAgo(entry.created_at)}

--- a/web/src/components/ui/FAQItem.tsx
+++ b/web/src/components/ui/FAQItem.tsx
@@ -37,11 +37,19 @@ export interface FAQItemProps {
   /** Deep-link id, e.g. "faq-1" (renders as the row's DOM id). */
   id: string;
   question: string;
+  /** Analytics seam — pages.md A9b `faq_open` fires from the page here. */
+  onOpenChange?: (open: boolean) => void;
   children: ReactNode;
   className?: string;
 }
 
-export function FAQItem({ id, question, children, className }: FAQItemProps) {
+export function FAQItem({
+  id,
+  question,
+  onOpenChange,
+  children,
+  className,
+}: FAQItemProps) {
   const group = useContext(FAQGroupContext);
   const [localOpen, setLocalOpen] = useState(false);
   const open = group ? group.openId === id : localOpen;
@@ -51,6 +59,7 @@ export function FAQItem({ id, question, children, className }: FAQItemProps) {
     } else {
       setLocalOpen((o) => !o);
     }
+    onOpenChange?.(!open);
   };
 
   return (

--- a/web/src/components/ui/HomeFooter.tsx
+++ b/web/src/components/ui/HomeFooter.tsx
@@ -8,13 +8,15 @@ export interface FooterColumn {
   links: { label: string; href: string }[];
 }
 
+// Canvas footer content (Home instance 186:272, enriched landing).
 const DEFAULT_COLUMNS: FooterColumn[] = [
   {
     heading: "Product",
     links: [
-      { label: "How it works", href: "/#product" },
+      { label: "Features", href: "/#product" },
+      { label: "Try Cloud", href: "/signin" },
+      { label: "Self Host", href: "/#self-host" },
       { label: "For designers", href: "/#designers" },
-      { label: "Cloud vs self-host", href: "/#compare" },
     ],
   },
   {
@@ -22,7 +24,9 @@ const DEFAULT_COLUMNS: FooterColumn[] = [
     links: [
       { label: "Quickstart", href: "https://docs.apparule.cuesoft.io" },
       { label: "API reference", href: "/docs/api" },
-      { label: "Self-hosting", href: "https://docs.apparule.cuesoft.io/self-host" },
+      { label: "GitBook", href: "https://docs.apparule.cuesoft.io" },
+      { label: "Self-host guide", href: "https://docs.apparule.cuesoft.io/self-host" },
+      { label: "Contributing", href: "https://github.com/cuesoftinc/apparule/blob/main/CONTRIBUTING.md" },
     ],
   },
   {
@@ -31,6 +35,8 @@ const DEFAULT_COLUMNS: FooterColumn[] = [
       { label: "GitHub", href: "https://github.com/cuesoftinc/apparule" },
       { label: "Discord", href: "https://discord.gg/cuesoft" },
       { label: "Roadmap", href: "https://github.com/cuesoftinc/apparule#roadmap" },
+      { label: "Good first issues", href: "https://github.com/cuesoftinc/apparule/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22" },
+      { label: "CueLABS", href: "https://cuesoft.io" },
     ],
   },
 ];
@@ -49,8 +55,8 @@ export function HomeFooter({ columns = DEFAULT_COLUMNS, className }: HomeFooterP
             Apparule
           </span>
           <p className="mt-2 text-caption text-text-2">
-            Precision measurement meets social fashion. A CueLABS open-source
-            product.
+            AI body measurement and made-to-measure fashion — open source,
+            made for Lagos.
           </p>
         </div>
         {columns.map((column) => (
@@ -69,7 +75,7 @@ export function HomeFooter({ columns = DEFAULT_COLUMNS, className }: HomeFooterP
         ))}
       </div>
       <div className="mx-auto mt-10 flex max-w-5xl flex-wrap items-center gap-x-6 gap-y-2 border-t border-border pt-6 text-caption text-text-2">
-        <span>© {new Date().getFullYear()} Cuesoft</span>
+        <span>© {new Date().getFullYear()} Cuesoft · CueLABS</span>
         <a href="/privacy" className="hover:text-text">
           Privacy
         </a>

--- a/web/src/components/ui/HomeNav.tsx
+++ b/web/src/components/ui/HomeNav.tsx
@@ -4,7 +4,7 @@
 // + Sign in + Try Cloud (gradient) · state top / stuck-blurred (blurs on
 // scroll). Accuracy standard: the badge renders "Star" with no number until
 // the live count arrives at runtime (fetched client-side by the page, A1).
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import clsx from "clsx";
 import Link from "next/link";
 import { Star } from "lucide-react";
@@ -22,6 +22,14 @@ export interface HomeNavProps {
   starCount?: number | null;
   githubHref?: string;
   onTryCloud?: () => void;
+  /** Analytics seam: `github_click` fires here (pages.md A1). */
+  onGithubClick?: () => void;
+  /**
+   * Trailing slot before Sign in — the page mounts the theme toggle here
+   * (W2 adaptation: light/dark QA + the §8.4 marketing journey need a
+   * public-surface toggle; the Figma nav master carries no toggle).
+   */
+  trailing?: ReactNode;
   className?: string;
 }
 
@@ -36,6 +44,8 @@ export function HomeNav({
   starCount = null,
   githubHref = "https://github.com/cuesoftinc/apparule",
   onTryCloud,
+  onGithubClick,
+  trailing,
   className,
 }: HomeNavProps) {
   const [stuck, setStuck] = useState(false);
@@ -80,7 +90,9 @@ export function HomeNav({
           target="_blank"
           rel="noopener noreferrer"
           data-testid="star-badge"
-          className="flex h-9 items-center gap-2 rounded-pill border border-border px-3 text-body font-semibold text-text hover:bg-border/30"
+          onClick={onGithubClick}
+          // hidden <sm: 375-width adaptation (Figma nav is 1440-only)
+          className="hidden h-9 items-center gap-2 rounded-pill border border-border px-3 text-body font-semibold text-text hover:bg-border/30 sm:flex"
         >
           <GitHubMark size={16} />
           <Star size={14} className="text-warn" />
@@ -88,7 +100,11 @@ export function HomeNav({
             {starCount === null ? "Star" : starCount.toLocaleString("en-NG")}
           </span>
         </a>
-        <Link href="/signin" className="text-body font-semibold text-text hover:text-text-2">
+        {trailing}
+        <Link
+          href="/signin"
+          className="whitespace-nowrap text-body font-semibold text-text hover:text-text-2"
+        >
           Sign in
         </Link>
         <Button kind="gradient-primary" size="sm" onClick={onTryCloud}>

--- a/web/src/components/ui/OrderTimelineRow.tsx
+++ b/web/src/components/ui/OrderTimelineRow.tsx
@@ -65,7 +65,13 @@ export function OrderTimelineRow({
           {label}
         </span>
         {timestamp ? (
-          <time dateTime={timestamp} className="tnum text-micro text-text-2">
+          // suppressHydrationWarning: render-time timestamps may differ
+          // between server and client by design
+          <time
+            dateTime={timestamp}
+            suppressHydrationWarning
+            className="tnum text-micro text-text-2"
+          >
             {format(new Date(timestamp), "MMM d, HH:mm")}
           </time>
         ) : dot === "pending" ? (

--- a/web/src/components/ui/PostCard.tsx
+++ b/web/src/components/ui/PostCard.tsx
@@ -228,8 +228,11 @@ export function PostCard({
             Request this outfit
           </Button>
         ) : null}
+        {/* suppressHydrationWarning: relative timestamps are computed at
+            render time and may differ between server and client by design */}
         <time
           dateTime={post.created_at}
+          suppressHydrationWarning
           className="text-micro uppercase tracking-[0.4px] text-text-2"
         >
           {formatAgo(post.created_at)}

--- a/web/src/components/ui/WalkthroughStep.tsx
+++ b/web/src/components/ui/WalkthroughStep.tsx
@@ -1,15 +1,22 @@
 "use client";
 
-// WalkthroughStep — design.md §8.2b Home section kit: screenshot + 2 lines
-// + step dots ×4 (as built 2026-07-18: the A4 walkthrough's four steps;
-// active dot set per instance).
+// WalkthroughStep — design.md §8.2b Home section kit: screenshot slot +
+// 2 lines + step dots ×4 (as built 2026-07-18: the A4 walkthrough's four
+// steps; the active dot is set per instance — accent-start marks the
+// current step). Figma master 142:3686: 280 wide, 280×180 slot on bg-elev.
+// The slot takes either a real screen thumbnail (`imageSrc`) or a composed
+// mini preview of real components (`thumb`) — the W2 adaptation until the
+// Stage-4 frame exports land (pages.md A4 note).
 import clsx from "clsx";
 import Image from "next/image";
+import type { ReactNode } from "react";
 
 export interface WalkthroughStepProps {
   /** Real screen thumbnail (exported Stage-4 frame, pages.md A4). */
-  imageSrc: string;
-  imageAlt: string;
+  imageSrc?: string;
+  imageAlt?: string;
+  /** Composed mini preview (real component instances) — fills the slot. */
+  thumb?: ReactNode;
   title: string;
   body: string;
   /** 0-based active dot of the four. */
@@ -19,7 +26,8 @@ export interface WalkthroughStepProps {
 
 export function WalkthroughStep({
   imageSrc,
-  imageAlt,
+  imageAlt = "",
+  thumb,
   title,
   body,
   step,
@@ -28,24 +36,27 @@ export function WalkthroughStep({
   return (
     <figure
       data-step={step}
-      className={clsx("flex w-72 shrink-0 flex-col gap-4", className)}
+      className={clsx("flex w-70 shrink-0 flex-col gap-4", className)}
     >
-      <span className="relative block aspect-[9/16] w-full overflow-hidden rounded-card border border-border bg-border/30">
-        <Image src={imageSrc} alt={imageAlt} fill sizes="288px" className="object-cover" />
+      <span className="relative block h-45 w-full overflow-hidden rounded-card border border-border bg-bg-elev">
+        {thumb ??
+          (imageSrc ? (
+            <Image src={imageSrc} alt={imageAlt} fill sizes="280px" className="object-cover" />
+          ) : null)}
       </span>
       <figcaption className="flex flex-col gap-1">
         <span className="text-body-lg font-semibold text-text">{title}</span>
         <span className="text-body text-text-2">{body}</span>
       </figcaption>
-      <span data-testid="step-dots" className="flex gap-1.5">
+      <span data-testid="step-dots" className="flex gap-2">
         {[0, 1, 2, 3].map((i) => (
           <span
             key={i}
             data-active={i === step || undefined}
             className={clsx(
-              // Figma master: equal-size dots; the active one takes accent
-              "size-1.5 rounded-pill transition-colors duration-120 ease-standard",
-              i === step ? "bg-accent-gradient" : "bg-border",
+              // Figma master: 8px dots; the active one binds accent-start
+              "size-2 rounded-pill transition-colors duration-120 ease-standard",
+              i === step ? "bg-accent-start" : "bg-border",
             )}
           />
         ))}

--- a/web/src/controllers/analytics.test.ts
+++ b/web/src/controllers/analytics.test.ts
@@ -1,0 +1,58 @@
+// Analytics controller — event register + transport seam (pages.md Part A).
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import {
+  setAnalyticsTransport,
+  track,
+  usePageView,
+  type AnalyticsEvent,
+} from "./analytics";
+
+afterEach(() => {
+  setAnalyticsTransport(null);
+});
+
+describe("analytics controller", () => {
+  it("routes events through the injected transport with name/props/ts", () => {
+    const events: AnalyticsEvent[] = [];
+    setAnalyticsTransport({ send: (e) => events.push(e) });
+
+    track("try_cloud_click", { section: "hero" });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].name).toBe("try_cloud_click");
+    expect(events[0].props).toEqual({ section: "hero" });
+    expect(typeof events[0].ts).toBe("number");
+  });
+
+  it("never throws when the transport fails", () => {
+    setAnalyticsTransport({
+      send: () => {
+        throw new Error("transport down");
+      },
+    });
+    expect(() => track("faq_open", { faq: "faq-1" })).not.toThrow();
+  });
+
+  it("default transport logs via console.debug (TEST_MODE/dev observable no-op)", () => {
+    const debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+    track("self_host_click");
+    // vitest runs with NODE_ENV=test and TEST_MODE unset — the default
+    // transport stays silent (no-op outside TEST_MODE/dev)…
+    expect(debug).not.toHaveBeenCalled();
+    debug.mockRestore();
+  });
+
+  it("usePageView fires page_view once on mount with the path", () => {
+    const events: AnalyticsEvent[] = [];
+    setAnalyticsTransport({ send: (e) => events.push(e) });
+
+    const { rerender } = renderHook(({ path }) => usePageView(path), {
+      initialProps: { path: "/" },
+    });
+    rerender({ path: "/" });
+
+    expect(events.filter((e) => e.name === "page_view")).toHaveLength(1);
+    expect(events[0].props).toEqual({ path: "/" });
+  });
+});

--- a/web/src/controllers/analytics.ts
+++ b/web/src/controllers/analytics.ts
@@ -1,0 +1,66 @@
+"use client";
+
+// Analytics controller — the pages.md Part A event register (page_view,
+// demo_start, github_click, try_cloud_click, self_host_click) plus the W2
+// iteration events (contribute_click, faq_open). Events fire through a
+// transport interface; Upstat ingestion (D2) lands behind it later —
+// today's default transport no-ops in production and logs in TEST_MODE /
+// development so journeys are observable without a backend.
+import { useEffect } from "react";
+import { env } from "@/config/env";
+
+export type AnalyticsEventName =
+  | "page_view"
+  | "demo_start"
+  | "github_click"
+  | "try_cloud_click"
+  | "self_host_click"
+  | "contribute_click"
+  | "faq_open";
+
+export interface AnalyticsEvent {
+  name: AnalyticsEventName;
+  props?: Record<string, string | number | boolean>;
+  /** Epoch ms, stamped at track() time. */
+  ts: number;
+}
+
+/** Transport seam — Upstat ingestion implements this at D2. */
+export interface AnalyticsTransport {
+  send(event: AnalyticsEvent): void;
+}
+
+/** Default transport: log in TEST_MODE/dev, no-op otherwise. */
+const consoleTransport: AnalyticsTransport = {
+  send(event) {
+    if (env.testMode || process.env.NODE_ENV === "development") {
+      console.debug("[analytics]", event.name, event.props ?? {});
+    }
+  },
+};
+
+let transport: AnalyticsTransport = consoleTransport;
+
+/** Swap the transport (Upstat later; tests inject a spy). */
+export function setAnalyticsTransport(next: AnalyticsTransport | null): void {
+  transport = next ?? consoleTransport;
+}
+
+/** Fire an event through the active transport (never throws). */
+export function track(
+  name: AnalyticsEventName,
+  props?: Record<string, string | number | boolean>,
+): void {
+  try {
+    transport.send({ name, props, ts: Date.now() });
+  } catch {
+    // analytics must never break the product surface
+  }
+}
+
+/** page_view on mount (per path — re-fires on client-side navigation). */
+export function usePageView(path: string): void {
+  useEffect(() => {
+    track("page_view", { path });
+  }, [path]);
+}

--- a/web/src/controllers/home-demo.ts
+++ b/web/src/controllers/home-demo.ts
@@ -1,0 +1,324 @@
+// Home marketing demo data — the docs-coherent Figma dataset the enriched
+// landing renders (canvas 186:2): the hero phone-mock feed, the walkthrough
+// and deep-dive mini previews, and the A6 earnings figures. This is the
+// controller-owned data source for the public page (views render-only; no
+// network on the marketing surface — same narrative as the mock-server
+// seed, demo content only, never product claims).
+import type { CommissionRequest, Earnings, OrderStatus, Post } from "@/models";
+
+function hoursAgo(hours: number): string {
+  return new Date(Date.now() - hours * 3_600_000).toISOString();
+}
+
+function daysAgo(days: number): string {
+  return hoursAgo(days * 24);
+}
+
+// ---- Hero phone mock (A2) ---------------------------------------------------
+
+export interface DemoStory {
+  username: string;
+  avatarUrl: string | null;
+  state: "unseen" | "seen";
+}
+
+/** Story rail per the canvas: amara / tunde.a / kiki unseen, zuri / bisi seen. */
+export const heroStories: DemoStory[] = [
+  { username: "amara", avatarUrl: "/demo/outfit-w00.jpg", state: "unseen" },
+  { username: "tunde.a", avatarUrl: "/demo/outfit-w15.jpg", state: "unseen" },
+  { username: "kiki", avatarUrl: "/demo/outfit-w16.jpg", state: "unseen" },
+  { username: "zuri", avatarUrl: "/demo/outfit-w05.jpg", state: "seen" },
+  { username: "bisi", avatarUrl: "/demo/outfit-w13.jpg", state: "seen" },
+];
+
+function makeHeroPost(input: {
+  id: string;
+  username: string;
+  displayName: string;
+  avatar: string;
+  caption: string;
+  media: { file: string; alt: string }[];
+  likes: number;
+  createdHoursAgo: number;
+}): Post {
+  return {
+    id: input.id,
+    designer: {
+      id: `des-${input.username}`,
+      username: input.username,
+      display_name: input.displayName,
+      avatar_url: input.avatar,
+      verified: false, // canvas post headers carry no verified badge
+    },
+    caption: input.caption,
+    style_tags: [],
+    base_price_cents: null,
+    currency: "NGN",
+    turnaround_days: 14,
+    media: input.media.map((m, position) => ({
+      id: `${input.id}-m${position}`,
+      post_id: input.id,
+      url: `/demo/${m.file}`,
+      position,
+      alt_text: m.alt,
+      width: 1024,
+      height: 1280,
+    })),
+    like_count: input.likes,
+    comment_count: 0,
+    liked: false,
+    saved: false,
+    created_at: hoursAgo(input.createdHoursAgo),
+  };
+}
+
+/** The two feed posts on the canvas (186:35/186:36). */
+export const heroPosts: Post[] = [
+  makeHeroPost({
+    id: "demo-ankara-two-piece",
+    username: "amara.designs",
+    displayName: "Amara Designs",
+    avatar: "/demo/outfit-w00.jpg",
+    caption:
+      "Ankara two-piece with structured shoulders, made to your measurements — DM slots open for June.",
+    media: [
+      { file: "outfit-w00.jpg", alt: "Model in a vibrant ankara two-piece" },
+    ],
+    likes: 2_141,
+    createdHoursAgo: 2,
+  }),
+  makeHeroPost({
+    id: "demo-asooke-set",
+    username: "kikithreads",
+    displayName: "Kiki Threads",
+    avatar: "/demo/outfit-w16.jpg",
+    caption:
+      "Matching aso-oke set — hand-loomed in Ilorin, sized from your vault.",
+    media: [
+      { file: "outfit-w13.jpg", alt: "Matching aso-oke set at a ceremony" },
+      { file: "outfit-w14.jpg", alt: "Aso-oke fabric detail" },
+      { file: "outfit-w10.jpg", alt: "Designer at the loom" },
+      { file: "outfit-w06.jpg", alt: "Aso-oke set worn by dancers" },
+      { file: "outfit-w16.jpg", alt: "Couple in matching aso-oke" },
+    ],
+    likes: 3_872,
+    createdHoursAgo: 5,
+  }),
+];
+
+// ---- Demo orders (hero request scene · walkthrough/deep-dive thumbs) --------
+
+export function makeDemoOrder(
+  status: OrderStatus,
+  overrides: Partial<CommissionRequest> = {},
+): CommissionRequest {
+  return {
+    id: `demo-req-${status}`,
+    order_number: "APR-1042",
+    post: {
+      id: "demo-ankara-two-piece",
+      caption: "Ankara two-piece with structured shoulders",
+      thumb_url: "/demo/outfit-w00.jpg",
+    },
+    customer: { id: "acc-kiki", username: "kiki.adeyemi", avatar_url: null },
+    designer: {
+      id: "des-amara",
+      username: "amara.designs",
+      avatar_url: "/demo/outfit-w00.jpg",
+    },
+    status,
+    notes: "",
+    budget_cents: 5_000_000,
+    quote_cents: 4_500_000,
+    currency: "NGN",
+    due_at: daysAgo(-10),
+    target_date: null,
+    tracking: null,
+    decline_reason: null,
+    dispute: null,
+    delivery: {
+      recipient_name: "Kiki Adeyemi",
+      phone: "+2348012345678",
+      line1: "14 Adeola Odeku St",
+      city: "Lagos",
+      state: "Lagos",
+      country: "NG",
+    },
+    snapshot: {
+      id: "demo-snap",
+      request_id: `demo-req-${status}`,
+      values: {
+        method: "mediapipe_2d_v2",
+        measured_at: daysAgo(12),
+        measurements: [
+          { name: "shoulder_width", value_cm: 42.5 },
+          { name: "hip_width", value_cm: 36.8 },
+        ],
+      },
+      created_at: daysAgo(6),
+    },
+    events: [],
+    payment:
+      status === "paid" || status === "in_progress" || status === "shipped"
+        ? {
+            id: "demo-pay",
+            request_id: `demo-req-${status}`,
+            provider: "paystack",
+            state: "held",
+            currency: "NGN",
+            amount_cents: 4_500_000,
+            platform_fee_cents: 450_000,
+          }
+        : null,
+    created_at: daysAgo(6),
+    ...overrides,
+  };
+}
+
+/** The order the hero's "request" scene and the order-detail thumb show. */
+export const heroOrder = makeDemoOrder("in_progress");
+
+/**
+ * Orders-list thumbs (canvas 264:8164…): varied outfits/designers across a
+ * slice of the ×10 pill set.
+ */
+export const demoOrders: CommissionRequest[] = [
+  makeDemoOrder("quoted", {
+    id: "demo-req-quoted",
+    order_number: "APR-1046",
+    post: {
+      id: "demo-asooke-wrap",
+      caption: "Aso-oke wrap set",
+      thumb_url: "/demo/outfit-w13.jpg",
+    },
+    designer: { id: "des-kiki", username: "kikithreads", avatar_url: "/demo/outfit-w16.jpg" },
+    quote_cents: 6_200_000,
+  }),
+  makeDemoOrder("in_progress", {
+    id: "demo-req-in-progress",
+    order_number: "APR-1044",
+    post: {
+      id: "demo-agbada",
+      caption: "Agbada jacket — ceremony cut",
+      thumb_url: "/demo/outfit-w15.jpg",
+    },
+    designer: { id: "des-tunde", username: "tunde.o", avatar_url: "/demo/outfit-w15.jpg" },
+    quote_cents: 8_800_000,
+  }),
+  makeDemoOrder("shipped", {
+    id: "demo-req-shipped",
+    order_number: "APR-1042",
+  }),
+  makeDemoOrder("delivered", {
+    id: "demo-req-delivered",
+    order_number: "APR-1039",
+    post: {
+      id: "demo-print-couple",
+      caption: "Matching print set for two",
+      thumb_url: "/demo/outfit-w16.jpg",
+    },
+    quote_cents: 3_800_000,
+  }),
+  makeDemoOrder("declined", {
+    id: "demo-req-declined",
+    order_number: "APR-1035",
+    post: {
+      id: "demo-evening",
+      caption: "Statement eveningwear",
+      thumb_url: "/demo/outfit-w03.jpg",
+    },
+    designer: { id: "des-bisi", username: "maisonbisi", avatar_url: "/demo/outfit-w03.jpg" },
+    quote_cents: 8_000_000,
+  }),
+];
+
+// ---- Vault + explore thumbs -------------------------------------------------
+
+export interface DemoMeasurement {
+  name: string;
+  valueCm: number;
+  source: "scan" | "manual";
+  history: number[];
+  /** MeasurementCard low-confidence chip (<0.7) — canvas 264:19. */
+  confidence?: number;
+}
+
+// The canvas vault set (264:14–264:19): shoulder/hip/sleeve · waist/inseam/
+// chest, chest carrying the low-confidence 0.62 chip.
+export const demoMeasurements: DemoMeasurement[] = [
+  { name: "Shoulder width", valueCm: 42.5, source: "scan", history: [41.8, 42.1, 42.5] },
+  { name: "Hip circumference", valueCm: 96.2, source: "scan", history: [95.4, 95.9, 96.2] },
+  { name: "Sleeve length", valueCm: 58.0, source: "manual", history: [57.6, 57.8, 58.0] },
+  { name: "Waist", valueCm: 78.4, source: "scan", history: [79.1, 78.8, 78.4] },
+  { name: "Inseam", valueCm: 81.0, source: "manual", history: [80.4, 80.7, 81.0] },
+  { name: "Chest circumference", valueCm: 101.5, source: "scan", history: [100.8, 101.2, 101.5], confidence: 0.62 },
+];
+
+export const demoGridImages: { src: string; alt: string }[] = [
+  { src: "/demo/outfit-w00.jpg", alt: "Ankara gown" },
+  { src: "/demo/outfit-w01.jpg", alt: "Ankara look, full length" },
+  { src: "/demo/outfit-w03.jpg", alt: "Statement evening look" },
+  { src: "/demo/outfit-w05.jpg", alt: "Orange runway outfit" },
+  { src: "/demo/outfit-w06.jpg", alt: "Dancers in traditional dress" },
+  { src: "/demo/outfit-w10.jpg", alt: "Designer cutting cloth" },
+  { src: "/demo/outfit-w13.jpg", alt: "Aso-oke outfit" },
+  { src: "/demo/outfit-w14.jpg", alt: "African print fabrics" },
+  { src: "/demo/outfit-w15.jpg", alt: "Matching print shirts" },
+];
+
+// Canvas explore filter row (264:8040): "near me" leads selected; the
+// dashboard variant appends a removable "Lagos" chip.
+export const demoExploreChips = [
+  "Near me",
+  "Ankara",
+  "Aso-oke",
+  "Bridal",
+  "₦ under 50k",
+  "2-week turnaround",
+];
+
+// ---- A6 designer earnings (canvas 186:133/140/150) ---------------------------
+
+export interface DemoTransaction {
+  entry: Earnings["transactions"][number];
+  /** Canvas free-text first line (TransactionRow label override). */
+  label: string;
+}
+
+export const designerEarningsDemo: {
+  earnings: Earnings;
+  transactions: DemoTransaction[];
+} = {
+  earnings: {
+    balance_cents: 8_250_000, // ₦82,500 released
+    pending_cents: 4_500_000, // ₦45,000 in escrow
+    currency: "NGN",
+    transactions: [],
+  },
+  transactions: [
+    {
+      entry: {
+        id: "demo-t1",
+        kind: "payout",
+        amount_cents: -8_250_000,
+        currency: "NGN",
+        order_number: "APR-1038",
+        provider_ref: "PSK-8843763",
+        created_at: daysAgo(4), // Jul 14 on the canvas
+      },
+      label: "Payout to GTBank •••• 4521",
+    },
+    {
+      entry: {
+        id: "demo-t2",
+        kind: "escrow_held",
+        amount_cents: 4_500_000,
+        currency: "NGN",
+        order_number: "APR-1042",
+        provider_ref: "PSK-9841577",
+        created_at: daysAgo(6), // Jul 12 on the canvas
+      },
+      label: "Escrow held · order #APR-1042",
+    },
+  ],
+};

--- a/web/src/controllers/use-github-stars.test.ts
+++ b/web/src/controllers/use-github-stars.test.ts
@@ -1,0 +1,42 @@
+// GitHub stars controller — runtime count with graceful "Star" fallback
+// (pages.md A1/A7b; accuracy standard: no invented counts).
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+const stars = vi.fn<() => Promise<number | null>>();
+vi.mock("@/models/repositories/github-repo", () => ({
+  githubRepo: { stars: () => stars() },
+}));
+
+import { resetGithubStarsCache, useGithubStars } from "./use-github-stars";
+
+beforeEach(() => {
+  stars.mockReset();
+  resetGithubStarsCache();
+});
+
+describe("useGithubStars", () => {
+  it("resolves to the fetched count (count-up settles on the real value)", async () => {
+    stars.mockResolvedValue(1234);
+    const { result } = renderHook(() => useGithubStars());
+    expect(result.current).toBeNull(); // neutral until the fetch lands
+    // the 800ms count-up settles on the real value (jsdom rAF is slow)
+    await waitFor(() => expect(result.current).toBe(1234), { timeout: 4000 });
+  });
+
+  it("stays null on failure — the badge keeps its neutral Star label", async () => {
+    stars.mockResolvedValue(null);
+    const { result } = renderHook(() => useGithubStars());
+    await waitFor(() => expect(stars).toHaveBeenCalled());
+    expect(result.current).toBeNull();
+  });
+
+  it("fetches once and shares the cache across subscribers", async () => {
+    stars.mockResolvedValue(77);
+    const a = renderHook(() => useGithubStars());
+    const b = renderHook(() => useGithubStars());
+    await waitFor(() => expect(a.result.current).toBe(77), { timeout: 4000 });
+    await waitFor(() => expect(b.result.current).toBe(77), { timeout: 4000 });
+    expect(stars).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/controllers/use-github-stars.ts
+++ b/web/src/controllers/use-github-stars.ts
@@ -1,0 +1,76 @@
+"use client";
+
+// GitHub star-count controller (pages.md A1/A7b): fetched once client-side,
+// shared between the nav badge and the A7b developer badge, animating a
+// count-up once per session (A1 "animates count-up once"). Failures resolve
+// to null → the badge keeps its neutral "Star" label.
+import { useEffect, useState } from "react";
+import { githubRepo } from "@/models/repositories/github-repo";
+
+const COUNT_UP_MS = 800;
+
+// Module-level cache: one fetch and one count-up per session, however many
+// components subscribe.
+let cached: number | null | undefined;
+let inflight: Promise<number | null> | null = null;
+let countUpPlayed = false;
+
+/** Test hook — reset the module cache between cases. */
+export function resetGithubStarsCache(): void {
+  cached = undefined;
+  inflight = null;
+  countUpPlayed = false;
+}
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function" ||
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+/** Displayed star count (null until fetched / on failure). */
+export function useGithubStars(): number | null {
+  const [display, setDisplay] = useState<number | null>(
+    typeof cached === "number" ? cached : null,
+  );
+
+  useEffect(() => {
+    // Effect-safe (react-hooks/set-state-in-effect): setDisplay only runs
+    // in promise/rAF callbacks; a warm cache resolves immediately.
+    const source =
+      cached !== undefined
+        ? Promise.resolve(cached)
+        : (inflight ??= githubRepo.stars());
+    let raf = 0;
+    let cancelled = false;
+
+    void source.then((value) => {
+      cached = value;
+      if (cancelled) return;
+      if (value === null || countUpPlayed || prefersReducedMotion()) {
+        setDisplay(value);
+        return;
+      }
+      // Count-up 0 → value over COUNT_UP_MS, once per session.
+      countUpPlayed = true;
+      const start = performance.now();
+      const tick = (now: number) => {
+        const t = Math.min((now - start) / COUNT_UP_MS, 1);
+        // ease-out — settles gently like the Figma spec's entrance easing
+        const eased = 1 - (1 - t) * (1 - t);
+        setDisplay(Math.round(value * eased));
+        if (t < 1 && !cancelled) raf = requestAnimationFrame(tick);
+      };
+      raf = requestAnimationFrame(tick);
+    });
+
+    return () => {
+      cancelled = true;
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  return display;
+}

--- a/web/src/models/repositories/github-repo.test.ts
+++ b/web/src/models/repositories/github-repo.test.ts
@@ -1,0 +1,45 @@
+// GitHub repo — the only network call on the marketing surface; every
+// failure path resolves to null (neutral badge, accuracy standard).
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { githubRepo } from "./github-repo";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("githubRepo.stars", () => {
+  it("returns stargazers_count on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ stargazers_count: 321 }), {
+          status: 200,
+        }),
+      ),
+    );
+    await expect(githubRepo.stars()).resolves.toBe(321);
+  });
+
+  it("returns null on a non-OK response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("{}", { status: 403 })),
+    );
+    await expect(githubRepo.stars()).resolves.toBeNull();
+  });
+
+  it("returns null when the payload has no numeric count", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
+    );
+    await expect(githubRepo.stars()).resolves.toBeNull();
+  });
+
+  it("returns null on network failure", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    await expect(githubRepo.stars()).resolves.toBeNull();
+  });
+});

--- a/web/src/models/repositories/github-repo.ts
+++ b/web/src/models/repositories/github-repo.ts
@@ -1,0 +1,31 @@
+// GitHub repository metadata — the home page's live star count
+// (pages.md A1/A7b: "the live count is populated at runtime; static designs
+// render the badge with no number"). This is a third-party surface, not
+// api/common, but network access still lives in the models layer (MVC rule).
+//
+// Graceful degradation: any failure resolves to null and the badge keeps
+// its neutral "Star" label (accuracy standard — never an invented count).
+// TEST_MODE skips the network entirely so CI is deterministic and offline.
+import { env } from "@/config/env";
+
+export const GITHUB_REPO = "cuesoftinc/apparule";
+export const GITHUB_REPO_URL = `https://github.com/${GITHUB_REPO}`;
+
+export const githubRepo = {
+  /** Star count for the badge; null → neutral "Star" fallback. */
+  async stars(repo: string = GITHUB_REPO): Promise<number | null> {
+    if (env.testMode) return null;
+    try {
+      const res = await fetch(`https://api.github.com/repos/${repo}`, {
+        headers: { Accept: "application/vnd.github+json" },
+      });
+      if (!res.ok) return null;
+      const body = (await res.json()) as { stargazers_count?: unknown };
+      return typeof body.stargazers_count === "number"
+        ? body.stargazers_count
+        : null;
+    } catch {
+      return null;
+    }
+  },
+};


### PR DESCRIPTION
## W2 — Public home page `/` from the component registry

Builds pages.md **Part A** (A1–A10 + iteration rows A4b/A7b/A7c/A9b/A9c) against the enriched Figma landing (`34GbYXm8TpxMMUaAGGuwMM`, frame 186:2), composed entirely from `components/ui` registry instances. Views are render-only; all data flows through controllers.

### Sections
- **A1 nav** — HomeNav + live GitHub star fetch (count-up once, neutral "Star" fallback; TEST_MODE skips the network for deterministic CI) + theme toggle
- **A2 hero** — canvas H1/subcopy/CTAs + phone mock auto-playing a silent **feed → capture → request** loop from real components (pauses on hover / reduced motion); demo feed via `controllers/home-demo`
- **A3 stat band** — the honest product claims only (±2 cm target · 2 photos · 30-day photo auto-delete)
- **A4 walkthrough** — 4 WalkthroughSteps, thumbs = **composed mini previews of real components** (adaptation; Stage-4 frame exports can replace at W3); dots + arrow keys; vertical stack on mobile; `demo_start` on engage
- **A4b deep-dives** — 4 alternating panels with composed dashboard previews (vault / explore / orders / order-detail incl. snapshot strip, timeline, escrow PaymentBox, thread)
- **A5 SMPL** — explainer + ProcessingConstellation (MI-12 asset) + GitBook link
- **A6 designers** — EarningsSummary + TransactionRows with the canvas figures
- **A7b developers** — stack line, 3 topic cards, good-first-issues / CONTRIBUTING / Discord links, star badge reusing the A1 fetch
- **A7c self-host** — pitch, shared `docker compose up -d` snippet (copy ✓ morph), what-ships line, architecture mini-diagram (bespoke, token-based)
- **A9 comparison** — enriched-master rows; Cloud CTA → /signin, OSS CTA → docs quickstart
- **A9b FAQ** — 5 rows, first expanded, one-open-at-a-time, `#faq-n` deep links, `faq_open`
- **A8 community** — Discord card (member count stays neutral until a real runtime count exists)
- **A9c CTA band** — gradient band, on-accent pills, MIT microcopy
- **A10 footer** — canvas columns/legal/language

### Analytics (pages.md register)
`controllers/analytics.ts`: `page_view` · `demo_start` · `github_click` · `try_cloud_click` · `self_host_click` · `contribute_click` · `faq_open` behind an `AnalyticsTransport` interface — Upstat ingestion plugs in at D2; the default transport no-ops (logs in TEST_MODE/dev). Star fetch lives in `models/repositories/github-repo.ts` (MVC network rule).

### Figma-QA findings self-fixed
- **ComparisonTable** registry component predated the enriched master (143:2): excluded cells now render `icon/x` (was Minus), header/row geometry + the master's six capability rows
- **CommunityCard** rebuilt to the compact horizontal master (144:3724); the canvas instance carries an invented "4,280 members" count — kept **neutral at runtime** per the accuracy standard (design.md §8.2b)
- **WalkthroughStep** aligned to the as-built master (280×180 slot, 8px dots, accent-start active) + a `thumb` slot for composed previews
- **HomeFooter** defaults aligned to the canvas instance content (tagline, 4/5/5 columns, `© Cuesoft · CueLABS`)
- Hydration fix: `suppressHydrationWarning` on PostCard/OrderTimelineRow `<time>` (render-time relative timestamps)
- Hero feed story-rail flex-shrink bug; canvas-matched demo data (vault set incl. the 0.62-confidence chest card, explore chips, varied orders)

### Adaptations (logged)
- Composed component previews stand in for the A4/A4b "real screen thumbnail" exports until W3 (noted in pages.md A4 directive as the swap point); previews are `aria-hidden` + pointer-inert
- Theme toggle added to HomeNav trailing slot (public surface needs light/dark for the §8.4 journey; Figma nav master carries no toggle); star badge hides < `sm` (Figma is 1440-only)
- Symmetric 1080px section grid approximates the canvas's left-anchored 180px layout; the walkthrough row breaks out right (`xl:-mr-40`) to fit all four steps as on the canvas
- FAQ answers 2–5 composed from docs claims (the Figma file only renders the expanded first answer); TransactionRow meta keeps the registry's derived relative-date format
- Buttons in the hero are the Figma instance geometry (150×48) via className override; `demoExploreChips`/orders content mirrors canvas overrides
- signin.spec's "exactly one button" scoped to `main` (the Next dev-tools overlay adds its own button in dev)

### Tests
- **Unit:** 367 passing (38 new — analytics, github-stars, github-repo, all home sections incl. FAQ deep-link, hero loop pause, theme toggle)
- **E2E:** 9 passing — new `e2e/home.spec.ts` "Marketing site" journey (sections render, FAQ accordion + deep link, Try Cloud/Sign in → /signin, hero Self Host scroll, theme toggle, snippet copy morph)
- lint · typecheck · vitest · playwright · production build all green

Self-QA ran section-by-section screenshot comparison (both themes, 1440 + 375w) against the Figma frame renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
