### PR TITLE
docs(design): pin the marketing container canon (1080px @ 1440)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -54,6 +54,9 @@
 - Desktop dashboard: IG-desktop pattern — slim left icon rail (72px, expands
   to 244px on ≥1264px) + centered content column (max 630px feed / 935px
   profile) + right meta column where useful.
+- Marketing (public home): a single centered content container — 1080px wide
+  at 1440, 24px minimum gutters, full-bleed backgrounds only; every section's
+  inner content aligns to it. **[Decided 2026-07-19]**
 - Media ratios: 1:1 default, 4:5 portrait max in feed (IG rules); carousels up
   to 10 images.
 - Radii: 8px cards/sheets, full-round avatars/pills. Hairline borders over
@@ -352,6 +355,14 @@ pass — `Sheet`: the master's slot strokes are removed (slots render clean in
 instances); `Input` textarea kind: inner text-area height fixed;
 `RequestCard`: the title truncates to 1 line (ellipsis) so the price is
 always visible.
+
+*As-built (2026-07-19):* the Home frame's sections were normalized to the §2
+marketing container (1080px at 1440, x 180–1260) — the A4 walkthrough,
+A4b deep-dives and A7b topic rows previously sat on a ~1192px breakout, the
+nav/footer on 1200px, and the stat band overhung to 1356px; right-column
+visuals (hero phone, constellation, earnings block, architecture diagram) now
+right-align to the container edge. Full-bleed section backgrounds (e.g. the
+A9c CTA band) stay 1440.
 
 ### 8.3 Design-prep needed from content
 


### PR DESCRIPTION
## What

Pins the public-home marketing container in `docs/design.md` and records the Figma retro-fix that normalized the Home frame to it.

- **§2 Layout** — new bullet: single centered content container, **1080px wide at 1440**, 24px minimum gutters, full-bleed backgrounds only; every section's inner content aligns to it. **[Decided 2026-07-19]**
- **§8.2b** — as-built note (2026-07-19): Home frame sections were normalized to the container in the design file — the A4 walkthrough / A4b deep-dives / A7b topics rows sat on a ~1192px breakout, nav/footer on 1200px, the stat band overhung to 1356px; right-column visuals now right-align to x=1260. Full-bleed bands (A9c CTA) stay 1440.

## Why

The landing's sections didn't share one content container (verified on the built site, which mirrors the design). The design file (`34GbYXm8TpxMMUaAGGuwMM`, frame "A — Home" 186:2) has been retro-fixed to zero deviations; this PR makes the container the documented contract so design and code converge on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)