### PR TITLE
fix(web): live-site QA — containers, semantic landmarks, CSS hygiene

### DIFF
--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -173,3 +173,105 @@ test.describe("Marketing site — home page", () => {
     await expect(page.getByTestId("copied-check")).toBeVisible();
   });
 });
+
+// W2.1 live-QA regressions (live-site sweep, design.md container canon
+// [Decided 2026-07-19]): one 1080 content column (x 180–1260 at 1440),
+// no horizontal overflow, single-landmark semantics, circular avatars.
+test.describe("W2.1 live-QA — containers, landmarks, avatars", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("one main / banner nav / footer / h1 per page", async ({ page }) => {
+    await page.goto("/");
+    expect(await page.locator("main").count()).toBe(1);
+    expect(await page.locator("body > div > nav").count()).toBe(1);
+    expect(await page.getByRole("contentinfo").count()).toBe(1);
+    expect(await page.locator("h1").count()).toBe(1);
+  });
+
+  test("every section, the nav and the footer share the 1080 content column", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const edges = await page.evaluate(() => {
+      const vw = document.documentElement.clientWidth;
+      const measured: { label: string; left: number; right: number }[] = [];
+      for (const section of document.querySelectorAll("main > section")) {
+        const rect = section.getBoundingClientRect();
+        const label = section.getAttribute("aria-labelledby") ?? "section";
+        if (rect.width >= vw - 1) {
+          // full-bleed band — its inner div carries the column
+          const inner = section.firstElementChild!.getBoundingClientRect();
+          measured.push({ label, left: inner.x, right: inner.right });
+        } else {
+          // px-6 sections: content column = box minus the 24px gutters
+          measured.push({ label, left: rect.x + 24, right: rect.right - 24 });
+        }
+      }
+      const navInner = document
+        .querySelector("body > div > nav > div")!
+        .getBoundingClientRect();
+      measured.push({ label: "nav", left: navInner.x, right: navInner.right });
+      const footInner = document
+        .querySelector("footer > div")!
+        .getBoundingClientRect();
+      measured.push({
+        label: "footer",
+        left: footInner.x,
+        right: footInner.right,
+      });
+      return measured;
+    });
+    for (const { label, left, right } of edges) {
+      expect(left, `${label} left edge`).toBeGreaterThan(179);
+      expect(left, `${label} left edge`).toBeLessThan(181);
+      expect(right, `${label} right edge`).toBeGreaterThan(1259);
+      expect(right, `${label} right edge`).toBeLessThan(1261);
+    }
+  });
+
+  test("no horizontal overflow at 1440 and 390", async ({ page }) => {
+    for (const width of [1440, 390]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto("/");
+      const overflow = await page.evaluate(() => ({
+        doc: document.documentElement.scrollWidth,
+        client: document.documentElement.clientWidth,
+      }));
+      expect(overflow.doc, `scrollWidth at ${width}`).toBe(overflow.client);
+      // the walkthrough rail must scroll inside its box, never overflow it
+      const rail = page.getByTestId("walkthrough-rail");
+      const fits = await rail.evaluate(
+        (el) => el.getBoundingClientRect().right <= window.innerWidth,
+      );
+      expect(fits, `walkthrough rail inside viewport at ${width}`).toBe(true);
+    }
+  });
+
+  test("avatar photos render as true circles (no lozenges)", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    // let the hero demo loop + reveal-on-scroll content mount
+    await page.getByTestId("hero-phone").waitFor();
+    const ratios = await page.evaluate(() => {
+      const out: { src: string; ratio: number }[] = [];
+      for (const img of document.querySelectorAll<HTMLImageElement>(
+        "[data-ring] img",
+      )) {
+        const rect = img.getBoundingClientRect();
+        if (rect.width === 0) continue;
+        out.push({
+          src: (img.currentSrc || img.src).split("/").pop() ?? "",
+          ratio: rect.width / rect.height,
+        });
+      }
+      return out;
+    });
+    expect(ratios.length).toBeGreaterThan(0);
+    for (const { src, ratio } of ratios) {
+      expect(Math.abs(ratio - 1), `avatar ${src} aspect ratio`).toBeLessThan(
+        0.05,
+      );
+    }
+  });
+});

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -58,19 +58,25 @@
   background-image: var(--ap-accent-gradient);
 }
 
-body {
-  background: var(--ap-bg);
-  color: var(--ap-text);
-  font-family: var(--ap-font-sans);
-  font-size: 14px; /* design.md §2 — 14 is base */
-}
+/* Element-level globals live in the base layer so utilities and component
+   classes can still override them — unlayered element selectors beat every
+   @layer rule and have caused production breakage before (W2.1 live-QA,
+   CSS-hygiene rule). */
+@layer base {
+  body {
+    background: var(--ap-bg);
+    color: var(--ap-text);
+    font-family: var(--ap-font-sans);
+    font-size: 14px; /* design.md §2 — 14 is base */
+  }
 
-/* Focus states — 2px accent ring, 2px offset, :focus-visible only (shared
-   foundations rule, design.md §2). Gradient rings aren't expressible via
-   outline-color; accent-start is the ring hue. */
-:focus-visible {
-  outline: 2px solid var(--ap-accent-start);
-  outline-offset: 2px;
+  /* Focus states — 2px accent ring, 2px offset, :focus-visible only (shared
+     foundations rule, design.md §2). Gradient rings aren't expressible via
+     outline-color; accent-start is the ring hue. */
+  :focus-visible {
+    outline: 2px solid var(--ap-accent-start);
+    outline-offset: 2px;
+  }
 }
 
 /* Tabular numerals for measurements and money (design.md §2 Type) */

--- a/web/src/components/home/CommunitySection.tsx
+++ b/web/src/components/home/CommunitySection.tsx
@@ -8,7 +8,7 @@ export function CommunitySection() {
     <section
       id="community"
       aria-labelledby="community-heading"
-      className="mx-auto w-full max-w-[1080px] scroll-mt-20 px-6 py-12"
+      className="mx-auto w-full max-w-[1128px] scroll-mt-20 px-6 py-12"
     >
       <h2 id="community-heading" className="text-title-lg font-bold text-text">
         Community

--- a/web/src/components/home/ComparisonSection.tsx
+++ b/web/src/components/home/ComparisonSection.tsx
@@ -13,7 +13,7 @@ export function ComparisonSection() {
     <section
       id="compare"
       aria-labelledby="compare-heading"
-      className="mx-auto flex w-full max-w-[1080px] scroll-mt-20 flex-col items-center px-6 py-12"
+      className="mx-auto flex w-full max-w-[1128px] scroll-mt-20 flex-col items-center px-6 py-12"
     >
       <h2 id="compare-heading" className="self-start text-title-lg font-bold text-text">
         Cloud or self-host — same product

--- a/web/src/components/home/DesignersSection.tsx
+++ b/web/src/components/home/DesignersSection.tsx
@@ -12,7 +12,7 @@ export function DesignersSection() {
     <section
       id="designers"
       aria-labelledby="designers-heading"
-      className="mx-auto w-full max-w-[1080px] scroll-mt-20 px-6 py-12"
+      className="mx-auto w-full max-w-[1128px] scroll-mt-20 px-6 py-12"
     >
       <div className="flex flex-col items-start gap-10 md:flex-row md:items-center md:gap-16">
         <div className="max-w-[480px] flex-1">

--- a/web/src/components/home/DevelopersSection.tsx
+++ b/web/src/components/home/DevelopersSection.tsx
@@ -39,7 +39,7 @@ export function DevelopersSection() {
     <section
       id="developers"
       aria-labelledby="developers-heading"
-      className="mx-auto w-full max-w-[1080px] scroll-mt-20 px-6 py-12"
+      className="mx-auto w-full max-w-[1128px] scroll-mt-20 px-6 py-12"
     >
       <h2 id="developers-heading" className="text-title-lg font-bold text-text">
         For developers — hack on the interesting parts

--- a/web/src/components/home/FaqSection.tsx
+++ b/web/src/components/home/FaqSection.tsx
@@ -69,7 +69,7 @@ export function FaqSection() {
     <section
       id="faq"
       aria-labelledby="faq-heading"
-      className="mx-auto w-full max-w-[1080px] scroll-mt-20 px-6 py-12"
+      className="mx-auto w-full max-w-[1128px] scroll-mt-20 px-6 py-12"
     >
       <h2 id="faq-heading" className="text-title-lg font-bold text-text">
         Frequently asked

--- a/web/src/components/home/FeatureDeepDives.tsx
+++ b/web/src/components/home/FeatureDeepDives.tsx
@@ -50,7 +50,7 @@ export function FeatureDeepDives() {
   return (
     <section
       aria-labelledby="deep-dives-heading"
-      className="mx-auto w-full max-w-[1080px] px-6 py-12"
+      className="mx-auto w-full max-w-[1128px] px-6 py-12"
     >
       <h2 id="deep-dives-heading" className="text-title-lg font-bold text-text">
         Built around your measurements
@@ -61,11 +61,12 @@ export function FeatureDeepDives() {
             <div
               data-testid="deep-dive-panel"
               className={clsx(
-                "flex flex-col items-start gap-8 md:items-center md:gap-12",
+                // canon deep-dive split: 528 + 24 gutter + 528 = 1080
+                "flex flex-col items-start gap-8 md:items-center md:gap-6",
                 panel.mediaFirst ? "md:flex-row-reverse" : "md:flex-row",
               )}
             >
-              <div className="max-w-[536px] flex-1">
+              <div className="max-w-[528px] flex-1">
                 <h3 className="text-title font-semibold text-text">
                   {panel.headline}
                 </h3>
@@ -79,7 +80,7 @@ export function FeatureDeepDives() {
                   Read more →
                 </a>
               </div>
-              <div className="w-full max-w-[560px] shrink-0 md:w-[52%]">
+              <div className="w-full max-w-[560px] shrink-0 md:w-[528px] md:max-w-none">
                 {panel.thumb}
               </div>
             </div>

--- a/web/src/components/home/FinalCtaBand.tsx
+++ b/web/src/components/home/FinalCtaBand.tsx
@@ -18,6 +18,8 @@ export function FinalCtaBand() {
       aria-labelledby="final-cta-heading"
       className="bg-accent-gradient px-6 py-9"
     >
+      {/* Canonical 1080 content column (design.md container canon) keeps
+          the band's content box flush with sibling sections (W2.1 live-QA). */}
       <div className="mx-auto flex max-w-[1080px] flex-col items-center gap-5 text-center">
         <h2
           id="final-cta-heading"

--- a/web/src/components/home/HeroSection.tsx
+++ b/web/src/components/home/HeroSection.tsx
@@ -13,7 +13,7 @@ export function HeroSection() {
   const router = useRouter();
 
   return (
-    <section aria-labelledby="hero-heading" className="mx-auto w-full max-w-[1080px] px-6">
+    <section aria-labelledby="hero-heading" className="mx-auto w-full max-w-[1128px] px-6">
       <div className="flex flex-col items-start gap-12 pb-16 pt-10 md:flex-row md:items-center md:gap-16 md:pb-20 md:pt-16">
         <div className="max-w-[520px]">
           <h1

--- a/web/src/components/home/SelfHostSection.tsx
+++ b/web/src/components/home/SelfHostSection.tsx
@@ -13,7 +13,7 @@ export function SelfHostSection() {
     <section
       id="self-host"
       aria-labelledby="self-host-heading"
-      className="mx-auto w-full max-w-[1080px] scroll-mt-20 px-6 py-12"
+      className="mx-auto w-full max-w-[1128px] scroll-mt-20 px-6 py-12"
     >
       <div className="flex flex-col items-start gap-10 md:flex-row md:gap-16">
         <div className="max-w-[560px] flex-1">

--- a/web/src/components/home/SmplSection.tsx
+++ b/web/src/components/home/SmplSection.tsx
@@ -7,7 +7,7 @@ export function SmplSection() {
   return (
     <section
       aria-labelledby="smpl-heading"
-      className="mx-auto w-full max-w-[1080px] px-6 py-12"
+      className="mx-auto w-full max-w-[1128px] px-6 py-12"
     >
       <div className="flex flex-col items-start gap-10 md:flex-row md:items-center md:gap-16">
         <div className="max-w-[480px] flex-1">

--- a/web/src/components/home/StatBand.tsx
+++ b/web/src/components/home/StatBand.tsx
@@ -14,7 +14,7 @@ export function StatBand() {
     <section
       id="product"
       aria-labelledby="stats-heading"
-      className="mx-auto w-full max-w-[1080px] scroll-mt-20 px-6 py-12"
+      className="mx-auto w-full max-w-[1128px] scroll-mt-20 px-6 py-12"
     >
       <h2 id="stats-heading" className="text-title-lg font-bold text-text">
         Made-to-measure, without the guesswork

--- a/web/src/components/home/WalkthroughSection.tsx
+++ b/web/src/components/home/WalkthroughSection.tsx
@@ -65,7 +65,7 @@ export function WalkthroughSection() {
   return (
     <section
       aria-labelledby="walkthrough-heading"
-      className="mx-auto w-full max-w-[1080px] px-6 py-12"
+      className="mx-auto w-full max-w-[1128px] px-6 py-12"
     >
       <h2 id="walkthrough-heading" className="text-title-lg font-bold text-text">
         How it works
@@ -78,9 +78,11 @@ export function WalkthroughSection() {
         onKeyDown={onKeyDown}
         onScroll={engage}
         data-testid="walkthrough-rail"
-        // xl:-mr-40 — the Figma walkthrough row runs 1192 wide, extending
-        // right past the 1080 heading grid; below xl the rail snap-scrolls
-        className="mt-6 flex snap-x snap-mandatory flex-col gap-8 overflow-x-auto pb-2 md:flex-row md:gap-6 xl:-mr-40"
+        // Canon walkthrough row = 4×252 + 3×24 = 1080: fits the content
+        // column exactly (the old 4×280 Figma row broke out of the grid via
+        // -mr-40 — W2.1 live-QA; frames 186:49/186:50 are now normalized).
+        // Below the full column width the rail snap-scrolls.
+        className="mt-6 flex snap-x snap-mandatory flex-col gap-8 overflow-x-auto pb-2 md:flex-row md:gap-6"
       >
         {STEPS.map((step, i) => (
           <WalkthroughStep

--- a/web/src/components/ui/Avatar.test.tsx
+++ b/web/src/components/ui/Avatar.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { Avatar } from "./Avatar";
 
 describe("Avatar (§8.2)", () => {
-  it.each([32, 44, 56, 96] as const)("renders size=%s", (size) => {
+  it.each([32, 44, 56, 64, 96] as const)("renders size=%s", (size) => {
     const { container } = render(<Avatar size={size} name="Kiki Adeyemi" />);
     expect(container.querySelector(`[data-size="${size}"]`)).not.toBeNull();
   });

--- a/web/src/components/ui/Avatar.tsx
+++ b/web/src/components/ui/Avatar.tsx
@@ -1,14 +1,20 @@
 "use client";
 
-// Avatar — design.md §8.2: size 32 / 44 / 56 / 96 · ring: none / gradient
-// (fresh) / amber / gray · badge: none / designer-verified. Ring semantics:
-// story ring (MI-8) and measurement-freshness ring (MI-11) share this atom.
-// Initials render when no image URL is provided.
+// Avatar — design.md §8.2: size 32 / 44 / 56 / 64 / 96 · ring: none /
+// gradient (fresh) / amber / gray · badge: none / designer-verified. Ring
+// semantics: story ring (MI-8) and measurement-freshness ring (MI-11) share
+// this atom. Initials render when no image URL is provided.
+//
+// Ring geometry (Figma master, design.md [Decided 2026-07-19]): the photo
+// is a square 1:1 box, radius 50%, object-fit cover — never stretched. The
+// ring is a SEPARATE circle stroke (2px; 3px at size 96) with a consistent
+// 2px clear gap between ring and photo: 32 → 24 photo · 56 → 48 · 64 → 56
+// (story rail) · 96 → 86.
 import clsx from "clsx";
 import Image from "next/image";
 import { Check } from "lucide-react";
 
-export type AvatarSize = 32 | 44 | 56 | 96;
+export type AvatarSize = 32 | 44 | 56 | 64 | 96;
 export type AvatarRing = "none" | "gradient" | "amber" | "gray";
 
 export interface AvatarProps {
@@ -38,7 +44,14 @@ export function Avatar({
   name,
   className,
 }: AvatarProps) {
-  const dimension = { width: size, height: size };
+  // Ring stroke: 2px (3px at 96). The photo box sits inside the stroke and
+  // wears a 2px bg border — the clear gap. border-box: photo = box − 4.
+  const stroke = size >= 96 ? 3 : 2;
+  const box = ring === "none" ? size : size - 2 * stroke;
+  // Explicit CSS dimensions — Tailwind preflight (`img { height: auto }`)
+  // otherwise overrides the height attribute and the avatar renders at the
+  // photo's natural aspect ratio: a lozenge, not a circle (W2.1 live-QA).
+  const dimension = { width: box, height: box };
   return (
     <span
       data-ring={ring}
@@ -46,20 +59,20 @@ export function Avatar({
       className={clsx("relative inline-block", className)}
     >
       <span
+        style={{ width: size, height: size }}
         className={clsx(
           "grid place-items-center rounded-pill",
-          ring !== "none" && "p-[2px]", // 2px ring (MI-8)
           ring === "gradient" && "bg-accent-gradient",
           ring === "amber" && "bg-warn",
           ring === "gray" && "bg-border",
         )}
-        style={ring === "none" ? undefined : undefined}
       >
         {src ? (
           <Image
             src={src}
             alt={name}
             {...dimension}
+            style={dimension}
             className={clsx(
               "rounded-pill object-cover",
               ring !== "none" && "border-2 border-bg",

--- a/web/src/components/ui/HomeFooter.tsx
+++ b/web/src/components/ui/HomeFooter.tsx
@@ -49,7 +49,9 @@ export interface HomeFooterProps {
 export function HomeFooter({ columns = DEFAULT_COLUMNS, className }: HomeFooterProps) {
   return (
     <footer className={clsx("border-t border-border px-6 py-12", className)}>
-      <div className="mx-auto grid max-w-5xl grid-cols-2 gap-8 md:grid-cols-4">
+      {/* Canonical 1080 content column (design.md container canon) —
+          max-w-5xl (1024) drifted off the section grid (W2.1 live-QA). */}
+      <div className="mx-auto grid max-w-[1080px] grid-cols-2 gap-8 md:grid-cols-4">
         <div>
           <span className="bg-accent-gradient bg-clip-text text-title font-bold text-transparent">
             Apparule
@@ -74,7 +76,7 @@ export function HomeFooter({ columns = DEFAULT_COLUMNS, className }: HomeFooterP
           </div>
         ))}
       </div>
-      <div className="mx-auto mt-10 flex max-w-5xl flex-wrap items-center gap-x-6 gap-y-2 border-t border-border pt-6 text-caption text-text-2">
+      <div className="mx-auto mt-10 flex max-w-[1080px] flex-wrap items-center gap-x-6 gap-y-2 border-t border-border pt-6 text-caption text-text-2">
         <span>© {new Date().getFullYear()} Cuesoft · CueLABS</span>
         <a href="/privacy" className="hover:text-text">
           Privacy

--- a/web/src/components/ui/HomeNav.tsx
+++ b/web/src/components/ui/HomeNav.tsx
@@ -62,7 +62,7 @@ export function HomeNav({
       data-state={stuck ? "stuck-blurred" : "top"}
       aria-label="Home"
       className={clsx(
-        "sticky top-0 z-10 flex h-16 items-center gap-6 px-6 transition-colors duration-200 ease-standard",
+        "sticky top-0 z-10 h-16 px-6 transition-colors duration-200 ease-standard",
         stuck
           ? "border-b border-border bg-bg/80 backdrop-blur-md"
           : "bg-transparent",
@@ -70,46 +70,51 @@ export function HomeNav({
         className,
       )}
     >
-      <Link href="/" className="bg-accent-gradient bg-clip-text text-title font-bold text-transparent">
-        Apparule
-      </Link>
-      <div className="hidden items-center gap-5 md:flex">
-        {links.map((link) => (
-          <a
-            key={link.label}
-            href={link.href}
-            className="text-body text-text-2 hover:text-text"
-          >
-            {link.label}
-          </a>
-        ))}
-      </div>
-      <div className="ml-auto flex items-center gap-3">
-        <a
-          href={githubHref}
-          target="_blank"
-          rel="noopener noreferrer"
-          data-testid="star-badge"
-          onClick={onGithubClick}
-          // hidden <sm: 375-width adaptation (Figma nav is 1440-only)
-          className="hidden h-9 items-center gap-2 rounded-pill border border-border px-3 text-body font-semibold text-text hover:bg-border/30 sm:flex"
-        >
-          <GitHubMark size={16} />
-          <Star size={14} className="text-warn" />
-          <span className="tnum">
-            {starCount === null ? "Star" : starCount.toLocaleString("en-NG")}
-          </span>
-        </a>
-        {trailing}
-        <Link
-          href="/signin"
-          className="whitespace-nowrap text-body font-semibold text-text hover:text-text-2"
-        >
-          Sign in
+      {/* Bar spans full-bleed; content sits on the canonical 1080 content
+          column (design.md container canon — x 180–1260 at 1440) so the
+          logo and CTAs line up with every section edge (W2.1 live-QA). */}
+      <div className="mx-auto flex h-full w-full max-w-[1080px] items-center gap-6">
+        <Link href="/" className="bg-accent-gradient bg-clip-text text-title font-bold text-transparent">
+          Apparule
         </Link>
-        <Button kind="gradient-primary" size="sm" onClick={onTryCloud}>
-          Try Cloud
-        </Button>
+        <div className="hidden items-center gap-5 md:flex">
+          {links.map((link) => (
+            <a
+              key={link.label}
+              href={link.href}
+              className="text-body text-text-2 hover:text-text"
+            >
+              {link.label}
+            </a>
+          ))}
+        </div>
+        <div className="ml-auto flex items-center gap-3">
+          <a
+            href={githubHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid="star-badge"
+            onClick={onGithubClick}
+            // hidden <sm: 375-width adaptation (Figma nav is 1440-only)
+            className="hidden h-9 items-center gap-2 rounded-pill border border-border px-3 text-body font-semibold text-text hover:bg-border/30 sm:flex"
+          >
+            <GitHubMark size={16} />
+            <Star size={14} className="text-warn" />
+            <span className="tnum">
+              {starCount === null ? "Star" : starCount.toLocaleString("en-NG")}
+            </span>
+          </a>
+          {trailing}
+          <Link
+            href="/signin"
+            className="whitespace-nowrap text-body font-semibold text-text hover:text-text-2"
+          >
+            Sign in
+          </Link>
+          <Button kind="gradient-primary" size="sm" onClick={onTryCloud}>
+            Try Cloud
+          </Button>
+        </div>
       </div>
     </nav>
   );

--- a/web/src/components/ui/NavRail.tsx
+++ b/web/src/components/ui/NavRail.tsx
@@ -139,6 +139,10 @@ export function NavRailItem({
   return (
     <Link
       href={item.href}
+      // Rails also render inside decorative home-page thumbs, where
+      // viewport prefetch 404s against unshipped /dashboard/* routes on
+      // the live landing (W2.1 live-QA).
+      prefetch={false}
       aria-current={active ? "page" : undefined}
       data-state={active ? "active" : "default"}
       className={itemClasses(active, expanded)}

--- a/web/src/components/ui/StoryRailItem.tsx
+++ b/web/src/components/ui/StoryRailItem.tsx
@@ -2,6 +2,8 @@
 
 // StoryRailItem — design.md §8.2: state unseen (gradient) / seen (gray) /
 // loading (rotating, MI-8: subtle 1.5s ring rotation while content loads).
+// Geometry (Figma master, design.md [Decided 2026-07-19]): 64px ring frame
+// wrapping a 56px photo — 2px stroke + 2px clear gap.
 import { useId } from "react";
 import clsx from "clsx";
 import { Avatar } from "./Avatar";
@@ -33,10 +35,11 @@ export function StoryRailItem({
     >
       {state === "loading" ? (
         // Figma master (46:88): dashed gradient ring, rotating while the
-        // story preloads (MI-8).
-        <span className="relative inline-grid place-items-center p-[2px]">
+        // story preloads (MI-8) — same 64px frame / 56px photo geometry as
+        // the solid rings.
+        <span className="relative grid size-16 place-items-center">
           <svg
-            viewBox="0 0 60 60"
+            viewBox="0 0 64 64"
             aria-hidden
             className="absolute inset-0 size-full animate-[spin_1.5s_linear_infinite] motion-reduce:animate-none"
           >
@@ -47,9 +50,9 @@ export function StoryRailItem({
               </linearGradient>
             </defs>
             <circle
-              cx="30"
-              cy="30"
-              r="29"
+              cx="32"
+              cy="32"
+              r="31"
               fill="none"
               stroke={`url(#${ringGradientId})`}
               strokeWidth="2"
@@ -61,7 +64,7 @@ export function StoryRailItem({
         </span>
       ) : (
         <Avatar
-          size={56}
+          size={64}
           name={username}
           src={avatarUrl}
           ring={state === "seen" ? "gray" : "gradient"}

--- a/web/src/components/ui/TabBar.tsx
+++ b/web/src/components/ui/TabBar.tsx
@@ -63,6 +63,9 @@ export function TabBar({
           <Link
             key={item.key}
             href={item.href}
+            // Same rationale as NavRail: decorative home-page thumbs must
+            // not viewport-prefetch /dashboard/* (W2.1 live-QA).
+            prefetch={false}
             aria-label={item.label}
             aria-current={active ? "page" : undefined}
             data-state={active ? "active" : "default"}

--- a/web/src/components/ui/WalkthroughStep.tsx
+++ b/web/src/components/ui/WalkthroughStep.tsx
@@ -36,12 +36,13 @@ export function WalkthroughStep({
   return (
     <figure
       data-step={step}
-      className={clsx("flex w-70 shrink-0 flex-col gap-4", className)}
+      // w-63 = 252px — canon walkthrough grid unit (4×252 + 3×24 = 1080).
+      className={clsx("flex w-63 shrink-0 flex-col gap-4", className)}
     >
       <span className="relative block h-45 w-full overflow-hidden rounded-card border border-border bg-bg-elev">
         {thumb ??
           (imageSrc ? (
-            <Image src={imageSrc} alt={imageAlt} fill sizes="280px" className="object-cover" />
+            <Image src={imageSrc} alt={imageAlt} fill sizes="252px" className="object-cover" />
           ) : null)}
       </span>
       <figcaption className="flex flex-col gap-1">


### PR DESCRIPTION
## W2.1 live-site QA sweep

Playwright sweep of https://apparule.cuesoft.io at 1440×900, 390×844 and 2400×1200 (`/` and `/signin`), measuring DOM rects rather than eyeballing, then fixed against the container canon (design.md [Decided 2026-07-19]: **1080 content column**, x 180–1260 at 1440, 24px gutters, grid units 528/344/252).

### Findings → fixes

**Avatar circles (user-reported, all live avatars affected)**
Tailwind preflight `img { height: auto }` overrides the Next `<Image>` height attribute, so every ringed avatar rendered at its photo's natural aspect ratio — lozenges from 1.45:1 to 0.68:1 measured live. `Avatar` now gives the photo an explicit square CSS box (`object-cover`, radius 50%) and draws the ring per the Figma master: separate 2px stroke (3px at 96) with a 2px clear gap (32→24 · 56→48 · 96→86). `StoryRailItem` uses the canonical 64px ring frame + 56px photo (new `64` size; loading ring redrawn on the 64 frame).

**Container alignment (user-reported: "main body should fit into a container")**
- All 11 home sections previously produced a 1032 content box (`max-w-[1080px]` *including* gutters); they now land the full canonical 1080 column (`max-w-[1128px] px-6`).
- `HomeNav` content was full-bleed (logo at x=24 vs sections at 180+) — now sits on the 1080 column inside the full-bleed sticky bar.
- `HomeFooter` columns used `max-w-5xl` (1024 → 4px+ drift, varies by viewport) — now the 1080 column.
- Walkthrough rail dropped its `xl:-mr-40` breakout (old Figma 1192 row escaped the grid by up to 160px, measured +75px past the container edge at 1440). Steps are now the canon 252 unit: 4×252 + 3×24 = 1080 exactly; below full width the rail snap-scrolls as before.
- Deep-dive panels split at canon 528 + 24 + 528.
- `FinalCtaBand` inner aligned to the same column.

**CSS hygiene**
- `body` and `:focus-visible` in `globals.css` were unlayered element-level selectors (beat every `@layer` rule — the class of bug that broke production on a sibling repo). Moved into `@layer base`.
- `PostCard`'s `100vw` audited: legitimate responsive `sizes` attr on a `fill` image inside an `aspect-square overflow-hidden` clip — no layout hazard.

**Console 404s on live**
The decorative `MiniScreen` dashboard thumbs render real `NavRail`/`TabBar` links, and viewport prefetch fired six `/dashboard/*` 404s for every landing visitor. Links are `prefetch={false}` now.

### Semantic audit (clean)
One `main`/`nav`/`footer`/`h1` per page, all sections labelled, heading hierarchy h1→h2→h3 with no skips, lists are `ul/li`, no href-less anchors or nested button/anchor — no violations found; locked in with e2e assertions.

### Verification
Local prod build (TEST_MODE), re-measured with the same sweep: sections + nav + footer + CTA inner all at x=180 w=1080; avatars 9/9 ratio 1.00 (desktop + mobile); 0 console errors; 0 horizontal overflow at all three widths. New e2e regression suite covers landmarks, the shared column, overflow at 1440/390, and avatar circularity.

Gates: lint ✅ · typecheck ✅ · unit 368/368 ✅ · e2e 13/13 ✅

### For the design fleet
The old walkthrough breakout was DESIGN-origin (Figma frames 186:49/186:50 drew a 1192-wide row escaping the 1080 grid); per the canon decision the frames are being normalized to 4×252 — code now matches the canon, not the old frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)