### PR TITLE
fix(web): system QA — final usability/accuracy/interaction pass

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -129,6 +129,44 @@ screenshot compares had missed:
   clean and is now locked in with e2e assertions rather than re-checked
   manually.
 
+**System-QA as-built notes (2026-07-19, PR #93):** the full-system QA pass
+(final web-phase gate) walked every §8.4 journey on the TEST_MODE prod
+build at 1440/390, light/dark/reduced-motion, and fixed what it found:
+
+- The quote sheet's due-date calendar was unusable — `DateInput`'s popover
+  sat on the z-20 dropdown layer under the z-40 Sheet. It now uses the
+  sheet layer, the same in-sheet fix `Select` received in W3; treat
+  "overlay opened from inside a Sheet" as z-40 by default.
+- Branded `not-found.tsx` / `error.tsx` (EmptyState anatomy) replace the
+  Next.js defaults.
+- `Button` and `Chip` carry `whitespace-nowrap` — pill labels never wrap
+  (the 390px comparison CTAs were the live repro).
+- `formatAgoPhrase` ("2d ago" / "just now" / "on 22 May") replaces
+  hand-appended " ago" templates (which produced "Updated 22 May ago").
+- MI-3's first-save "Saved to your looks" toast now exists (once per
+  browser, Toast gained an optional trailing link).
+- Seed coherence: designer `posts_count` is test-locked to the actually
+  seeded posts; payout-SLA copy aligned across PaymentBox/EarningsView.
+- 390px overflow fixes (order-detail grid, moderation actions, profile
+  stats) are e2e-gated across all dashboard routes.
+
+**Link-parity as-built notes (2026-07-19, PR #93):** the org "Marketing
+nav, footer & theme parity canon" (SKILL.md) applied — nav is Features ·
+For designers · Docs · GitHub (the star badge remains the GitHub
+affordance) + theme toggle + a single **Sign in** gradient CTA (the nav
+Try Cloud moved out; hero/A9c/comparison keep firing `try_cloud_click`).
+Footer is brand block + Product/Docs/Community/**Legal** columns (4/4/4/3
+links) + the verbatim legal bar ("© Cuesoft Inc. 2026. Apparule. CueLABS™
+Division. MIT License.") with the security-policy affordance and language
+selector. All external URLs are the verified-200 canon targets
+(`cuesoft.gitbook.io/apparule/*`, `discord.gg/CDfZxxrxbb`,
+`cuelabs.cuesoft.io`, `privacy/terms/status.cuesoft.io`); the old
+`docs.apparule.cuesoft.io` placeholders across A4b/A5/A7c/A9 were
+repointed to verified GitBook pages. Playwright asserts the exact hrefs
+on nav + footer and theme flip+persist on both surfaces. pages.md A1/A10
+still describe the pre-canon layout — deviation recorded here (design.md
+is owned by the design agent).
+
 **W3 as-built notes (2026-07-19, PR #91):**
 
 - Every Part B route (§4) is a fully working screen assembled from the W1

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -151,10 +151,12 @@ build at 1440/390, light/dark/reduced-motion, and fixed what it found:
   stats) are e2e-gated across all dashboard routes.
 
 **Link-parity as-built notes (2026-07-19, PR #93):** the org "Marketing
-nav, footer & theme parity canon" (SKILL.md) applied — nav is Features ·
-For designers · Docs · GitHub (the star badge remains the GitHub
-affordance) + theme toggle + a single **Sign in** gradient CTA (the nav
-Try Cloud moved out; hero/A9c/comparison keep firing `try_cloud_click`).
+nav, footer & theme parity canon" (SKILL.md) applied — nav is four plain
+text links, Features · For designers · Docs · GitHub (adjudicated
+2026-07-19: the nav star badge was dropped for cross-product parity —
+the live-count badge is A7b's alone) + theme toggle + a single **Sign
+in** gradient CTA (the nav Try Cloud moved out; hero/A9c/comparison keep
+firing `try_cloud_click`).
 Footer is brand block + Product/Docs/Community/**Legal** columns (4/4/4/3
 links) + the verbatim legal bar ("© Cuesoft Inc. 2026. Apparule. CueLABS™
 Division. MIT License.") with the security-policy affordance and language

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -319,3 +319,94 @@ test("designer side (actor seam): decline with reason; earnings itemize the rele
   await expect(page.getByTestId("transactions-list")).toContainText("APR-1044");
   await expect(page.getByTestId("payout-status-chip")).toBeVisible();
 });
+
+test("designer quote via the UI: the due-date calendar works inside the quote sheet", async ({
+  page,
+  request,
+}) => {
+  // Regression: the DateInput popover sat on the z-20 dropdown layer under
+  // the z-40 quote Sheet, so the calendar swallowed no clicks and a quote
+  // could never be sent from the UI. Close the seeded open order on this
+  // post first (no-op 409 when an earlier test already delivered it), then
+  // file a fresh request as kiki via the API.
+  const close = await request.post("/api/mock/v1/requests/req-apr-1044/confirm-delivery", {
+    headers: { "x-mock-actor": "kiki.adeyemi" },
+  });
+  expect([200, 409]).toContain(close.status());
+  const res = await request.post("/api/mock/v1/posts/post-print-brothers/requests", {
+    headers: { "x-mock-actor": "kiki.adeyemi" },
+    data: {
+      session_id: "sess-recent-scan",
+      notes: "Quote regression fixture",
+      delivery: {
+        recipient_name: "Kiki Adeyemi",
+        phone: "+2348012345678",
+        line1: "14 Adeola Odeku St",
+        city: "Lagos",
+        state: "Lagos",
+        country: "NG",
+      },
+    },
+  });
+  expect(res.status()).toBe(201);
+  const order = await res.json();
+
+  await page.addInitScript(() => {
+    window.sessionStorage.setItem("apparule.testmode.actor", "tunde.o");
+  });
+  await signIn(page);
+  await page.goto(`/dashboard/orders/${order.id}`);
+
+  await page.getByRole("button", { name: "Send quote" }).click();
+  const sheet = page.getByRole("dialog");
+  await sheet.getByLabel("Quote amount").fill("58000");
+  await sheet.getByLabel("Due date").click();
+  const picker = page.getByTestId("date-picker");
+  await expect(picker).toBeVisible();
+  // the calendar must actually receive the click (the z-layer regression)
+  await picker.getByRole("button", { name: "Next month" }).click();
+  await picker
+    .getByRole("button", { name: "15", exact: true })
+    .first()
+    .click();
+  await sheet.getByRole("button", { name: "Send quote" }).click();
+
+  await expect(page.getByText("Quoted", { exact: true }).first()).toBeVisible();
+  await expect(page.getByText(/₦58,000/).first()).toBeVisible();
+});
+
+test("no horizontal overflow on dashboard screens at 390 (system QA regression)", async ({
+  page,
+}) => {
+  // Regression: at 390 the order-detail grid (min-content sizing), the
+  // moderation action row and the profile stats row all pushed past the
+  // viewport (178/58/17px).
+  await page.setViewportSize({ width: 390, height: 844 });
+  await signIn(page);
+  for (const route of [
+    "/dashboard",
+    "/dashboard/explore",
+    "/dashboard/orders",
+    "/dashboard/orders/req-apr-1042",
+    "/dashboard/vault",
+    "/dashboard/create",
+    "/dashboard/kiki.adeyemi",
+    "/dashboard/amara.designs",
+    "/dashboard/settings",
+    "/dashboard/admin/moderation",
+    "/dashboard/designer/onboarding",
+    "/dashboard/earnings",
+  ]) {
+    await page.goto(route);
+    // networkidle never settles against the dev server (HMR socket) — wait
+    // for the screen's <main> content instead.
+    await expect(page.locator("main")).toBeVisible();
+    await page.waitForTimeout(400);
+    const overflow = await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth -
+        document.documentElement.clientWidth,
+    );
+    expect(overflow, `${route} horizontal overflow`).toBeLessThanOrEqual(2);
+  }
+});

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -1,8 +1,8 @@
 // "Marketing site" journey (design.md §8.4, web-implementation.md §7):
 // Part A scroll — every section renders — plus the FAQ accordion, the
 // Try Cloud / Sign in CTA handoff into /signin, and the theme toggle.
-// Runs in TEST_MODE: the star badge deterministically keeps its neutral
-// "Star" label (no third-party fetch in CI).
+// Runs in TEST_MODE: the A7b star badge deterministically keeps its
+// neutral "Star" label (no third-party fetch in CI).
 import { expect, test } from "@playwright/test";
 
 test.describe("Marketing site — home page", () => {
@@ -15,8 +15,10 @@ test.describe("Marketing site — home page", () => {
     ).toBeVisible();
     await expect(page.getByTestId("hero-phone")).toBeVisible();
 
-    // A1 nav — neutral star badge in TEST_MODE (accuracy standard)
-    await expect(page.getByTestId("star-badge")).toContainText("Star");
+    // A1 nav — plain GitHub text link (parity canon adjudication); the
+    // neutral star badge lives on A7b only (accuracy standard)
+    await expect(page.getByTestId("nav-github")).toHaveText("GitHub");
+    await expect(page.getByTestId("dev-star-badge")).toContainText("Star");
 
     // A3 stat band — the honest product claims
     await expect(page.getByText("±2 cm", { exact: true })).toBeVisible();
@@ -327,10 +329,11 @@ test.describe("nav/footer parity canon", () => {
       "href",
       "https://cuesoft.gitbook.io/apparule",
     );
-    await expect(nav.getByTestId("star-badge")).toHaveAttribute(
+    await expect(nav.getByTestId("nav-github")).toHaveAttribute(
       "href",
       "https://github.com/cuesoftinc/apparule",
     );
+    await expect(nav.getByTestId("star-badge")).toHaveCount(0);
     await expect(nav.getByRole("link", { name: "Sign in" })).toHaveAttribute(
       "href",
       "/signin",

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -275,3 +275,36 @@ test.describe("W2.1 live-QA — containers, landmarks, avatars", () => {
     }
   });
 });
+
+// System-QA regressions (2026-07-19).
+test.describe("system QA regressions", () => {
+  test("unknown routes render the branded 404, not the Next.js default", async ({
+    page,
+  }) => {
+    await page.goto("/definitely-not-a-page");
+    await expect(
+      page.getByRole("heading", { name: "This page doesn't exist" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Back to Apparule" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("This page could not be found"),
+    ).toHaveCount(0);
+  });
+
+  test("comparison-table CTAs keep to one line at 390 (no pill wrap)", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/");
+    const cta = page.getByRole("button", { name: "Start on Cloud" });
+    await cta.scrollIntoViewIfNeeded();
+    for (const name of ["Start on Cloud", "Self-host it"]) {
+      const box = await page.getByRole("button", { name }).boundingBox();
+      expect(box, `${name} rendered`).not.toBeNull();
+      // sm buttons are h-9 (36px) — a wrapped label pushes past the pill
+      expect(box!.height, `${name} single-line height`).toBeLessThanOrEqual(38);
+    }
+  });
+});

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -127,10 +127,9 @@ test.describe("Marketing site — home page", () => {
 
   test("Try Cloud CTA hands off to /signin", async ({ page }) => {
     await page.goto("/");
-    await page
-      .locator("nav")
-      .getByRole("button", { name: "Try Cloud" })
-      .click();
+    // Parity canon: the nav CTA is Sign in — Try Cloud hands off from the
+    // hero (and A9c/comparison) instead.
+    await page.getByRole("button", { name: "Try Cloud" }).first().click();
     await page.waitForURL("**/signin");
     await expect(
       page.getByRole("button", { name: /continue with google/i }),
@@ -306,5 +305,97 @@ test.describe("system QA regressions", () => {
       // sm buttons are h-9 (36px) — a wrapped label pushes past the pill
       expect(box!.height, `${name} single-line height`).toBeLessThanOrEqual(38);
     }
+  });
+});
+
+// Marketing nav/footer link-parity canon (SKILL.md, ratified 2026-07-19):
+// the exact link sets and verified URLs, asserted on the live DOM.
+test.describe("nav/footer parity canon", () => {
+  test("nav carries the four canon links + the Sign in CTA", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const nav = page.getByRole("navigation", { name: "Home" });
+    await expect(nav.getByRole("link", { name: "Features" })).toHaveAttribute(
+      "href",
+      "#product",
+    );
+    await expect(
+      nav.getByRole("link", { name: "For designers" }),
+    ).toHaveAttribute("href", "#designers");
+    await expect(nav.getByRole("link", { name: "Docs" })).toHaveAttribute(
+      "href",
+      "https://cuesoft.gitbook.io/apparule",
+    );
+    await expect(nav.getByTestId("star-badge")).toHaveAttribute(
+      "href",
+      "https://github.com/cuesoftinc/apparule",
+    );
+    await expect(nav.getByRole("link", { name: "Sign in" })).toHaveAttribute(
+      "href",
+      "/signin",
+    );
+    await expect(nav.getByText("Try Cloud")).toHaveCount(0);
+  });
+
+  test("footer carries the canon columns, URLs and legal bar", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const footer = page.locator("footer");
+    const canon: [string, string][] = [
+      ["Docs", "https://cuesoft.gitbook.io/apparule"],
+      ["Quickstart", "https://cuesoft.gitbook.io/apparule/setup"],
+      ["API reference", "https://cuesoft.gitbook.io/apparule/system/api-surface"],
+      ["Self-host guide", "https://cuesoft.gitbook.io/apparule/system/deployment"],
+      ["GitHub", "https://github.com/cuesoftinc/apparule"],
+      ["Discord", "https://discord.gg/CDfZxxrxbb"],
+      ["Roadmap", "https://cuesoft.gitbook.io/apparule/product/roadmap"],
+      ["CueLABS", "https://cuelabs.cuesoft.io"],
+      ["Privacy", "https://privacy.cuesoft.io"],
+      ["Terms", "https://terms.cuesoft.io"],
+      ["Status", "https://status.cuesoft.io"],
+      ["Cuesoft Inc.", "https://cuesoft.io"],
+      ["MIT License", "https://github.com/cuesoftinc/apparule/blob/main/LICENSE"],
+    ];
+    for (const [name, href] of canon) {
+      await expect(
+        footer.getByRole("link", { name, exact: true }),
+        `footer link ${name}`,
+      ).toHaveAttribute("href", href);
+    }
+    await expect(
+      footer.getByRole("link", { name: /Security policy/ }),
+    ).toHaveAttribute(
+      "href",
+      "https://github.com/cuesoftinc/apparule/blob/main/SECURITY.md",
+    );
+    await expect(
+      footer.getByText(/© Cuesoft Inc\. 2026\. Apparule\. CueLABS™ Division\./),
+    ).toBeVisible();
+    await expect(footer.getByLabel("Language")).toBeVisible();
+    await expect(footer.getByText("Contributing")).toHaveCount(0);
+    await expect(footer.getByText("Good first issues")).toHaveCount(0);
+  });
+
+  test("theme toggle flips and persists on home and dashboard", async ({
+    page,
+  }) => {
+    // marketing surface
+    await page.goto("/");
+    await page.getByRole("button", { name: /switch to dark theme/i }).click();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    await page.reload();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+
+    // dashboard surface (same apparule.theme key via NavRail toggle)
+    await page.goto("/signin");
+    await page.getByRole("button", { name: /continue with google/i }).click();
+    await page.waitForURL("**/dashboard");
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    await page.getByRole("button", { name: /switch to light theme/i }).click();
+    await expect(page.locator("html")).not.toHaveAttribute("data-theme", "dark");
+    await page.reload();
+    await expect(page.locator("html")).not.toHaveAttribute("data-theme", "dark");
   });
 });

--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+// Branded error boundary — the token-styled counterpart to not-found.tsx
+// (system QA: an uncaught render error previously fell through to Next's
+// unstyled default). Retry re-renders the segment; the quiet link goes home.
+import Link from "next/link";
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+
+export default function ErrorPage({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-bg px-6 text-center">
+      <span className="bg-accent-gradient bg-clip-text text-title font-bold text-transparent">
+        Apparule
+      </span>
+      <span className="grid size-14 place-items-center rounded-pill border border-border text-warn">
+        <AlertTriangle size={28} aria-hidden />
+      </span>
+      <h1 className="text-body-lg font-semibold text-text">
+        Something went wrong
+      </h1>
+      <p className="max-w-sm text-body text-text-2">
+        An unexpected error interrupted this screen — your data is safe.
+      </p>
+      <div className="flex items-center gap-2">
+        <Button kind="gradient-primary" onClick={() => reset()}>
+          Try again
+        </Button>
+        <Link
+          href="/"
+          className="inline-flex h-11 items-center justify-center whitespace-nowrap rounded-card border border-border bg-bg-elev px-4 text-body font-semibold text-text"
+        >
+          Back home
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/web/src/app/not-found.tsx
+++ b/web/src/app/not-found.tsx
@@ -1,0 +1,30 @@
+// Branded 404 — before this the router fell through to Next's default
+// error shell (system QA finding: off-brand, no tokens, no way home).
+// Same anatomy as the EmptyState masters: icon · one-line · one CTA.
+import Link from "next/link";
+import { Compass } from "lucide-react";
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-bg px-6 text-center">
+      <span className="bg-accent-gradient bg-clip-text text-title font-bold text-transparent">
+        Apparule
+      </span>
+      <span className="grid size-14 place-items-center rounded-pill border border-border text-text-2">
+        <Compass size={28} aria-hidden />
+      </span>
+      <h1 className="text-body-lg font-semibold text-text">
+        This page doesn&apos;t exist
+      </h1>
+      <p className="max-w-sm text-body text-text-2">
+        The link may be old, or the outfit may have been taken down.
+      </p>
+      <Link
+        href="/"
+        className="inline-flex h-11 items-center justify-center whitespace-nowrap rounded-card bg-accent-gradient px-4 text-body font-semibold text-on-accent"
+      >
+        Back to Apparule
+      </Link>
+    </main>
+  );
+}

--- a/web/src/components/dashboard/earnings/EarningsView.tsx
+++ b/web/src/components/dashboard/earnings/EarningsView.tsx
@@ -91,7 +91,7 @@ export function EarningsView() {
                     </span>
                   </p>
                   <p className="text-caption text-text-2">
-                    Payouts arrive within 1 business day of release · fee 10%
+                    Payouts arrive within 2 business days of release · fee 10%
                     per order
                   </p>
                   <Link

--- a/web/src/components/dashboard/feed/FeedSidebar.tsx
+++ b/web/src/components/dashboard/feed/FeedSidebar.tsx
@@ -4,7 +4,7 @@
 // designers (Follow, MI-7). Renders from the vault + suggestions
 // controllers; hidden below xl by the feed view.
 import Link from "next/link";
-import { formatAgo } from "@/lib/format";
+import { formatAgoPhrase } from "@/lib/format";
 import { useVault } from "@/controllers/use-vault";
 import { useSuggestions } from "@/controllers/use-suggestions";
 import { useAuth } from "@/controllers/auth/AuthContext";
@@ -51,7 +51,7 @@ export function FeedSidebar({
             <Tooltip
               label={
                 latestComplete
-                  ? `Measured ${formatAgo(latestComplete.created_at)} ago — retake?`
+                  ? `Measured ${formatAgoPhrase(latestComplete.created_at)} — retake?`
                   : "No measurements yet"
               }
               placement="bottom"
@@ -70,7 +70,7 @@ export function FeedSidebar({
             <div className="min-w-0">
               <p className="text-body font-semibold text-text">
                 {latestComplete
-                  ? `Measured ${formatAgo(latestComplete.created_at)} ago`
+                  ? `Measured ${formatAgoPhrase(latestComplete.created_at)}`
                   : "No measurements yet"}
               </p>
               <Link href="/dashboard/vault" className="text-caption text-link">

--- a/web/src/components/dashboard/feed/FeedView.tsx
+++ b/web/src/components/dashboard/feed/FeedView.tsx
@@ -7,6 +7,7 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import type { Post } from "@/models";
+import { useAuth } from "@/controllers/auth/AuthContext";
 import { useFeed } from "@/controllers/use-feed";
 import { CaughtUpDivider } from "@/components/ui/CaughtUpDivider";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -16,6 +17,7 @@ import { UnfollowConfirmSheet, type UnfollowTarget } from "../UnfollowConfirmShe
 import { FeedSidebar } from "./FeedSidebar";
 import { PostOptionsSheet } from "./PostOptionsSheet";
 import { RequestStepperSheet } from "./RequestStepperSheet";
+import { maybeFirstSaveToast } from "../first-save";
 import { useToasts } from "../toast-context";
 
 const FRESH_MS = 48 * 60 * 60 * 1000; // story ring = outfits <48h (MI-8)
@@ -38,6 +40,7 @@ function storyDesignersOf(posts: Post[]): { username: string; fresh: boolean }[]
 
 export function FeedView() {
   const feed = useFeed("feed");
+  const { account } = useAuth();
   const { showToast } = useToasts();
   const [requestPost, setRequestPost] = useState<Post | null>(null);
   const [optionsPost, setOptionsPost] = useState<Post | null>(null);
@@ -61,13 +64,22 @@ export function FeedView() {
       }),
     );
   const save = (post: Post) =>
-    feed.toggleSave(post).catch(() =>
-      showToast({
-        kind: "error",
-        message: "Couldn't save the post",
-        onRetry: () => void feed.toggleSave(post),
-      }),
-    );
+    feed
+      .toggleSave(post)
+      .then(() => {
+        // MI-3: post.saved is the pre-toggle value — false means this
+        // toggle saved it.
+        if (!post.saved) {
+          maybeFirstSaveToast(showToast, account?.username ?? null);
+        }
+      })
+      .catch(() =>
+        showToast({
+          kind: "error",
+          message: "Couldn't save the post",
+          onRetry: () => void feed.toggleSave(post),
+        }),
+      );
 
   const copyShareLink = async (post: Post) => {
     try {

--- a/web/src/components/dashboard/feed/PostOptionsSheet.tsx
+++ b/web/src/components/dashboard/feed/PostOptionsSheet.tsx
@@ -116,14 +116,16 @@ export function PostOptionsSheet({
           </footer>
         </form>
       ) : (
-        <nav aria-label="Post options">
+        // role="menu": MenuItem renders role="menuitem", which ARIA
+        // requires to be owned by a menu container (system QA a11y fix).
+        <div role="menu" aria-label="Post options">
           <MenuItem label="Copy link" onSelect={() => void copyLink()} />
           <MenuItem
             label="Report post"
             destructive
             onSelect={() => setReporting(true)}
           />
-        </nav>
+        </div>
       )}
     </Sheet>
   );

--- a/web/src/components/dashboard/first-save.test.ts
+++ b/web/src/components/dashboard/first-save.test.ts
@@ -1,0 +1,37 @@
+// MI-3 first-save toast gate (system QA: the spec'd "Saved to your looks"
+// toast was missing from the product).
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { maybeFirstSaveToast } from "./first-save";
+
+describe("maybeFirstSaveToast (MI-3)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("toasts once with a link to the saver's looks", () => {
+    const showToast = vi.fn();
+    maybeFirstSaveToast(showToast, "kiki.adeyemi");
+    expect(showToast).toHaveBeenCalledWith({
+      kind: "success",
+      message: "Saved to your looks",
+      link: { href: "/dashboard/kiki.adeyemi", label: "View" },
+    });
+  });
+
+  it("never re-toasts after the first save", () => {
+    const showToast = vi.fn();
+    maybeFirstSaveToast(showToast, "kiki.adeyemi");
+    maybeFirstSaveToast(showToast, "kiki.adeyemi");
+    expect(showToast).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the profile redirect without a username", () => {
+    const showToast = vi.fn();
+    maybeFirstSaveToast(showToast, null);
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        link: { href: "/dashboard/profile", label: "View" },
+      }),
+    );
+  });
+});

--- a/web/src/components/dashboard/first-save.ts
+++ b/web/src/components/dashboard/first-save.ts
@@ -1,0 +1,26 @@
+// MI-3: the first-ever save shows a "Saved to your looks" toast with a link
+// (design.md §4). Once per browser — saved state itself lives server-side;
+// this only gates the one-time toast.
+import type { ToastInput } from "./toast-context";
+
+const KEY = "apparule.first-save-toast";
+
+export function maybeFirstSaveToast(
+  showToast: (input: ToastInput) => void,
+  username: string | null,
+): void {
+  try {
+    if (window.localStorage.getItem(KEY)) return;
+    window.localStorage.setItem(KEY, "1");
+  } catch {
+    return; // storage unavailable — skip rather than re-toast forever
+  }
+  showToast({
+    kind: "success",
+    message: "Saved to your looks",
+    link: {
+      href: username ? `/dashboard/${username}` : "/dashboard/profile",
+      label: "View",
+    },
+  });
+}

--- a/web/src/components/dashboard/orders/OrderDetailView.tsx
+++ b/web/src/components/dashboard/orders/OrderDetailView.tsx
@@ -212,7 +212,7 @@ export function OrderDetailView({ orderId }: { orderId: string }) {
 
       {/* Figma 179:536: two-column desktop — order content left, the thread
           as a right-rail card. Single column below lg. */}
-      <div className="grid gap-8 pt-4 lg:grid-cols-[minmax(0,1fr)_360px]">
+      <div className="grid grid-cols-[minmax(0,1fr)] gap-8 pt-4 lg:grid-cols-[minmax(0,1fr)_360px]">
       <div className="flex flex-col gap-6">
         <header
           aria-label="Order summary"

--- a/web/src/components/dashboard/post/PostDetailView.tsx
+++ b/web/src/components/dashboard/post/PostDetailView.tsx
@@ -10,6 +10,7 @@ import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react";
 import type { Post } from "@/models";
 import { formatAgo, formatNaira } from "@/lib/format";
 import { usePost } from "@/controllers/use-post";
+import { useAuth } from "@/controllers/auth/AuthContext";
 import { ActionRow } from "@/components/ui/ActionRow";
 import { Avatar } from "@/components/ui/Avatar";
 import { Button } from "@/components/ui/Button";
@@ -17,6 +18,7 @@ import { CommentRow } from "@/components/ui/CommentRow";
 import { IconButton } from "@/components/ui/IconButton";
 import { Input } from "@/components/ui/Input";
 import { Skeleton } from "@/components/ui/Skeleton";
+import { maybeFirstSaveToast } from "../first-save";
 import { useToasts } from "../toast-context";
 
 export interface PostDetailViewProps {
@@ -32,6 +34,7 @@ export function PostDetailView({
 }: PostDetailViewProps) {
   const { post, comments, loading, error, toggleLike, toggleSave, addComment } =
     usePost(postId);
+  const { account } = useAuth();
   const { showToast } = useToasts();
   const [slide, setSlide] = useState(0);
   const [draft, setDraft] = useState("");
@@ -184,11 +187,18 @@ export function PostDetailView({
                 }),
               )
             }
-            onToggleSave={() =>
-              toggleSave().catch(() =>
-                showToast({ kind: "error", message: "Couldn't save the post" }),
-              )
-            }
+            onToggleSave={() => {
+              const wasSaved = post.saved;
+              toggleSave()
+                .then(() => {
+                  if (!wasSaved) {
+                    maybeFirstSaveToast(showToast, account?.username ?? null);
+                  }
+                })
+                .catch(() =>
+                  showToast({ kind: "error", message: "Couldn't save the post" }),
+                );
+            }}
           />
           <p className="text-caption text-text-2">
             {formatAgo(post.created_at)}

--- a/web/src/components/dashboard/profile/ProfileView.tsx
+++ b/web/src/components/dashboard/profile/ProfileView.tsx
@@ -284,7 +284,7 @@ export function ProfileView({ username }: { username: string }) {
               </Link>
             )}
           </div>
-          <ul className="flex gap-6 text-body text-text">
+          <ul className="flex flex-wrap gap-x-6 gap-y-1 text-body text-text">
             <li>
               <span className="tnum font-semibold">{formatCount(d.posts_count)}</span> posts
             </li>

--- a/web/src/components/dashboard/toast-context.tsx
+++ b/web/src/components/dashboard/toast-context.tsx
@@ -18,6 +18,8 @@ export interface ToastInput {
   kind?: ToastKind;
   message: string;
   onRetry?: () => void;
+  /** Trailing link action (MI-3 "Saved to your looks" → View). */
+  link?: { href: string; label: string };
 }
 
 interface ToastEntry extends ToastInput {
@@ -59,6 +61,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
               key={t.id}
               kind={t.kind}
               message={t.message}
+              link={t.link}
               onRetry={
                 t.onRetry
                   ? () => {

--- a/web/src/components/dashboard/vault/VaultView.tsx
+++ b/web/src/components/dashboard/vault/VaultView.tsx
@@ -7,7 +7,7 @@
 // data). Render-only over useVault.
 import { useMemo, useState } from "react";
 import Link from "next/link";
-import { formatAgo } from "@/lib/format";
+import { formatAgoPhrase } from "@/lib/format";
 import type { MeasurementSession } from "@/models";
 import { useAuth } from "@/controllers/auth/AuthContext";
 import { useVault } from "@/controllers/use-vault";
@@ -72,7 +72,7 @@ export function VaultView() {
         <div className="flex min-w-0 flex-1 flex-col gap-2 pt-1">
           <h1 className="text-title-lg font-bold text-text">
             {latestComplete
-              ? `Measured ${formatAgo(latestComplete.created_at)} ago`
+              ? `Measured ${formatAgoPhrase(latestComplete.created_at)}`
               : "No measurements yet"}
           </h1>
           <p className="text-body text-text-2">

--- a/web/src/components/home/CommunitySection.tsx
+++ b/web/src/components/home/CommunitySection.tsx
@@ -17,7 +17,7 @@ export function CommunitySection() {
         <CommunityCard />
         <div>
           <a
-            href="https://github.com/cuesoftinc/apparule#roadmap"
+            href="https://cuesoft.gitbook.io/apparule/product/roadmap"
             target="_blank"
             rel="noopener noreferrer"
             className="text-body font-semibold text-link hover:underline"

--- a/web/src/components/home/ComparisonSection.tsx
+++ b/web/src/components/home/ComparisonSection.tsx
@@ -27,7 +27,7 @@ export function ComparisonSection() {
           onSelfHost={() => {
             track("self_host_click", { section: "comparison" });
             window.open(
-              "https://docs.apparule.cuesoft.io/self-host",
+              "https://cuesoft.gitbook.io/apparule/system/deployment",
               "_blank",
               "noopener",
             );

--- a/web/src/components/home/DevelopersSection.tsx
+++ b/web/src/components/home/DevelopersSection.tsx
@@ -91,7 +91,7 @@ export function DevelopersSection() {
           CONTRIBUTING.md →
         </a>
         <a
-          href="https://discord.gg/cuesoft"
+          href="https://discord.gg/CDfZxxrxbb"
           target="_blank"
           rel="noopener noreferrer"
           onClick={() => track("contribute_click", { link: "discord" })}

--- a/web/src/components/home/FeatureDeepDives.tsx
+++ b/web/src/components/home/FeatureDeepDives.tsx
@@ -13,34 +13,36 @@ import {
   DashVaultThumb,
 } from "./dash-thumbs";
 
-const DOCS_BASE = "https://docs.apparule.cuesoft.io";
+// Verified GitBook target — per-feature sub-pages do not exist (404);
+// every A4b quiet link deep-dives into the features page.
+const DOCS_BASE = "https://cuesoft.gitbook.io/apparule/product/features";
 
 const PANELS = [
   {
     headline: "Capture once, keep it fresh",
     body: "Two photos become a full set of body measurements in a private vault only you can see. Freshness tracking nudges you when it's time to retake — no stale numbers on new orders.",
-    href: `${DOCS_BASE}/vault`,
+    href: `${DOCS_BASE}`,
     thumb: <DashVaultThumb />,
     mediaFirst: false,
   },
   {
     headline: "Find designers near you",
     body: "Follow Lagos designers and browse real commissioned work, filtered by style, budget and turnaround. Proximity ranking surfaces ateliers close to you, so fittings and delivery stay easy.",
-    href: `${DOCS_BASE}/discover`,
+    href: `${DOCS_BASE}`,
     thumb: <DashExploreThumb />,
     mediaFirst: true,
   },
   {
     headline: "Escrow-protected commissions",
     body: "Pay when you accept a quote — funds are held in escrow, not sent ahead. Money releases when the outfit is delivered, and a dispute freezes payout until it's resolved.",
-    href: `${DOCS_BASE}/orders`,
+    href: `${DOCS_BASE}`,
     thumb: <DashOrdersThumb />,
     mediaFirst: false,
   },
   {
     headline: "Your measurements ride with every order",
     body: "Each request carries a locked snapshot of exactly the values you chose to share. Your designer sews to those numbers — no more guessing sizes over chat.",
-    href: `${DOCS_BASE}/measurements`,
+    href: `${DOCS_BASE}`,
     thumb: <DashOrderDetailThumb />,
     mediaFirst: true,
   },

--- a/web/src/components/home/HomeNavBar.tsx
+++ b/web/src/components/home/HomeNavBar.tsx
@@ -1,24 +1,21 @@
 "use client";
 
-// A1 nav wrapper — HomeNav instance wired to the controllers: live star
-// count (count-up once, neutral "Star" fallback), `github_click`, and the
-// theme toggle (parity canon: the nav CTA is Sign in — a plain /signin
-// link; try_cloud_click keeps firing from the hero/A9c/comparison CTAs).
+// A1 nav wrapper — HomeNav instance wired to the controllers:
+// `github_click` and the theme toggle (parity canon: the nav CTA is Sign
+// in; the GitHub item is a plain text link — the live star badge is A7b's,
+// DevelopersSection keeps the runtime fetch).
 import { Moon, Sun } from "lucide-react";
 import { HomeNav } from "@/components/ui/HomeNav";
 import { IconButton } from "@/components/ui/IconButton";
 import { useTheme } from "@/design/ThemeProvider";
 import { track } from "@/controllers/use-analytics";
-import { useGithubStars } from "@/controllers/use-github-stars";
 
 export function HomeNavBar() {
-  const stars = useGithubStars();
   const { preference, setPreference } = useTheme();
   const nextTheme = preference === "dark" ? "light" : "dark";
 
   return (
     <HomeNav
-      starCount={stars}
       onGithubClick={() => track("github_click", { section: "nav" })}
       trailing={
         <IconButton

--- a/web/src/components/home/HomeNavBar.tsx
+++ b/web/src/components/home/HomeNavBar.tsx
@@ -1,11 +1,9 @@
 "use client";
 
 // A1 nav wrapper — HomeNav instance wired to the controllers: live star
-// count (count-up once, neutral "Star" fallback), Try Cloud → /signin
-// handoff, `github_click` / `try_cloud_click`, and the theme toggle
-// (W2 adaptation: the public surface needs light/dark switching for the
-// §8.4 journey; mirrors the NavRail footer toggle).
-import { useRouter } from "next/navigation";
+// count (count-up once, neutral "Star" fallback), `github_click`, and the
+// theme toggle (parity canon: the nav CTA is Sign in — a plain /signin
+// link; try_cloud_click keeps firing from the hero/A9c/comparison CTAs).
 import { Moon, Sun } from "lucide-react";
 import { HomeNav } from "@/components/ui/HomeNav";
 import { IconButton } from "@/components/ui/IconButton";
@@ -14,7 +12,6 @@ import { track } from "@/controllers/use-analytics";
 import { useGithubStars } from "@/controllers/use-github-stars";
 
 export function HomeNavBar() {
-  const router = useRouter();
   const stars = useGithubStars();
   const { preference, setPreference } = useTheme();
   const nextTheme = preference === "dark" ? "light" : "dark";
@@ -23,10 +20,6 @@ export function HomeNavBar() {
     <HomeNav
       starCount={stars}
       onGithubClick={() => track("github_click", { section: "nav" })}
-      onTryCloud={() => {
-        track("try_cloud_click", { section: "nav" });
-        router.push("/signin");
-      }}
       trailing={
         <IconButton
           size="sm"

--- a/web/src/components/home/SelfHostSection.tsx
+++ b/web/src/components/home/SelfHostSection.tsx
@@ -39,7 +39,7 @@ export function SelfHostSection() {
             <code className="font-mono">web</code>
           </p>
           <a
-            href="https://docs.apparule.cuesoft.io/self-host"
+            href="https://cuesoft.gitbook.io/apparule/system/deployment"
             target="_blank"
             rel="noopener noreferrer"
             onClick={() => track("self_host_click", { section: "self-host" })}

--- a/web/src/components/home/SmplSection.tsx
+++ b/web/src/components/home/SmplSection.tsx
@@ -20,7 +20,7 @@ export function SmplSection() {
             you see while it works is the real model output.
           </p>
           <a
-            href="https://docs.apparule.cuesoft.io/ai-modeling"
+            href="https://cuesoft.gitbook.io/apparule/system/architecture"
             target="_blank"
             rel="noopener noreferrer"
             className="mt-6 inline-block text-body font-semibold text-link hover:underline"

--- a/web/src/components/home/interactive.test.tsx
+++ b/web/src/components/home/interactive.test.tsx
@@ -277,12 +277,19 @@ describe("HomeNavBar (A1)", () => {
     expect(screen.queryByText("Try Cloud")).not.toBeInTheDocument();
   });
 
-  it("renders the neutral Star badge while no live count exists", () => {
+  it("nav GitHub is a plain text link that fires github_click", async () => {
     render(
       <ThemeProvider>
         <HomeNavBar />
       </ThemeProvider>,
     );
-    expect(screen.getByTestId("star-badge")).toHaveTextContent("Star");
+    const github = screen.getByTestId("nav-github");
+    expect(github).toHaveAttribute(
+      "href",
+      "https://github.com/cuesoftinc/apparule",
+    );
+    expect(screen.queryByTestId("star-badge")).not.toBeInTheDocument();
+    await userEvent.click(github);
+    expect(names()).toContain("github_click");
   });
 });

--- a/web/src/components/home/interactive.test.tsx
+++ b/web/src/components/home/interactive.test.tsx
@@ -196,7 +196,7 @@ describe("ComparisonSection (A9)", () => {
     await userEvent.click(screen.getByRole("button", { name: "Self-host it" }));
     expect(names()).toContain("self_host_click");
     expect(open).toHaveBeenCalledWith(
-      "https://docs.apparule.cuesoft.io/self-host",
+      "https://cuesoft.gitbook.io/apparule/system/deployment",
       "_blank",
       "noopener",
     );
@@ -264,15 +264,17 @@ describe("HomeNavBar (A1)", () => {
     expect(document.documentElement).toHaveAttribute("data-theme", "light");
   });
 
-  it("Try Cloud in the nav tracks and routes to /signin", async () => {
+  it("the nav Sign in CTA links to /signin (parity canon)", () => {
     render(
       <ThemeProvider>
         <HomeNavBar />
       </ThemeProvider>,
     );
-    await userEvent.click(screen.getByRole("button", { name: "Try Cloud" }));
-    expect(names()).toContain("try_cloud_click");
-    expect(push).toHaveBeenCalledWith("/signin");
+    expect(screen.getByRole("link", { name: "Sign in" })).toHaveAttribute(
+      "href",
+      "/signin",
+    );
+    expect(screen.queryByText("Try Cloud")).not.toBeInTheDocument();
   });
 
   it("renders the neutral Star badge while no live count exists", () => {

--- a/web/src/components/ui/Button.test.tsx
+++ b/web/src/components/ui/Button.test.tsx
@@ -4,6 +4,13 @@ import userEvent from "@testing-library/user-event";
 import { Button } from "./Button";
 
 describe("Button (§8.2)", () => {
+  it("never wraps its label (pill contract, system QA — 390px CTA wrap)", () => {
+    render(<Button>Start on Cloud</Button>);
+    expect(screen.getByRole("button", { name: "Start on Cloud" })).toHaveClass(
+      "whitespace-nowrap",
+    );
+  });
+
   it.each(["gradient-primary", "quiet", "destructive", "link"] as const)(
     "renders kind=%s",
     (kind) => {

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -41,7 +41,10 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         data-kind={kind}
         data-size={size}
         className={clsx(
-          "inline-flex items-center justify-center gap-2 rounded-card font-semibold",
+          // whitespace-nowrap: pill/button labels never wrap — at narrow
+          // widths a wrapped label overflows the fixed-height pill (the
+          // 390px comparison-table CTAs were the live repro).
+          "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-card font-semibold",
           "transition-transform duration-120 ease-standard enabled:active:scale-[0.98]",
           "motion-reduce:transition-none motion-reduce:active:scale-100",
           "disabled:opacity-40 disabled:cursor-not-allowed",

--- a/web/src/components/ui/Chip.test.tsx
+++ b/web/src/components/ui/Chip.test.tsx
@@ -16,6 +16,13 @@ describe("Chip (§8.2)", () => {
     },
   );
 
+  it("never wraps its label (pill contract, system QA)", () => {
+    render(<Chip label="2-week turnaround" />);
+    expect(screen.getByRole("button", { name: "2-week turnaround" })).toHaveClass(
+      "whitespace-nowrap",
+    );
+  });
+
   it("selected chip exposes aria-pressed", () => {
     render(<Chip kind="selected" label="aso-oke" />);
     expect(screen.getByRole("button", { name: "aso-oke" })).toHaveAttribute(

--- a/web/src/components/ui/Chip.tsx
+++ b/web/src/components/ui/Chip.tsx
@@ -31,7 +31,9 @@ export function Chip({
       className={clsx(
         // Figma master (41:19): 13px semibold label; selected = solid
         // text-token fill (reads as active filter, not an action).
-        "inline-flex h-8 items-center gap-1.5 rounded-pill border px-3 text-caption font-semibold",
+        // whitespace-nowrap: a chip is a fixed-height pill — wrapped labels
+        // clip out of it in constrained rows (walkthrough mini-screens).
+        "inline-flex h-8 items-center gap-1.5 whitespace-nowrap rounded-pill border px-3 text-caption font-semibold",
         "transition-colors duration-120 ease-standard motion-reduce:transition-none",
         kind === "selected"
           ? "border-transparent bg-text text-bg"

--- a/web/src/components/ui/CommunityCard.tsx
+++ b/web/src/components/ui/CommunityCard.tsx
@@ -18,7 +18,7 @@ export interface CommunityCardProps {
 
 export function CommunityCard({
   memberCount = null,
-  discordHref = "https://discord.gg/cuesoft",
+  discordHref = "https://discord.gg/CDfZxxrxbb",
   className,
 }: CommunityCardProps) {
   return (

--- a/web/src/components/ui/DateInput.tsx
+++ b/web/src/components/ui/DateInput.tsx
@@ -83,7 +83,12 @@ export function DateInput({
         <RadixPopover.Portal>
           <RadixPopover.Content
             sideOffset={4}
-            className="z-20 rounded-card border border-border bg-bg-elev p-3 shadow-lg"
+            // z-40 (sheet layer): the calendar opens from inside the quote
+            // Sheet (z-40 dialog) — at the z-20 dropdown layer the dialog
+            // paints over it and swallows every click, so the due date could
+            // never be picked. Same layer as the sheet, later in portal
+            // order wins (the same class of fix as Select, W3).
+            className="z-40 rounded-card border border-border bg-bg-elev p-3 shadow-lg"
           >
             <DatePickerPopover
               value={value}

--- a/web/src/components/ui/HomeFooter.test.tsx
+++ b/web/src/components/ui/HomeFooter.test.tsx
@@ -2,21 +2,63 @@ import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { HomeFooter } from "./HomeFooter";
 
-describe("HomeFooter (§8.2b marketing, pages.md A10)", () => {
-  it("renders the three link columns", () => {
+describe("HomeFooter (§8.2b marketing, parity canon 2026-07-19)", () => {
+  it("renders the four canon link columns", () => {
     render(<HomeFooter />);
-    for (const heading of ["Product", "Docs", "Community"]) {
+    for (const heading of ["Product", "Docs", "Community", "Legal"]) {
       expect(screen.getByRole("heading", { name: heading })).toBeInTheDocument();
     }
   });
 
-  it("renders legal links incl. the privacy.cuesoft.io clause link", () => {
+  it("Docs and Community columns hit the verified canonical URLs", () => {
     render(<HomeFooter />);
-    expect(screen.getByRole("link", { name: "Privacy" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Terms" })).toBeInTheDocument();
+    const canon: [string, string][] = [
+      ["Docs", "https://cuesoft.gitbook.io/apparule"],
+      ["Quickstart", "https://cuesoft.gitbook.io/apparule/setup"],
+      ["API reference", "https://cuesoft.gitbook.io/apparule/system/api-surface"],
+      ["Self-host guide", "https://cuesoft.gitbook.io/apparule/system/deployment"],
+      ["GitHub", "https://github.com/cuesoftinc/apparule"],
+      ["Discord", "https://discord.gg/CDfZxxrxbb"],
+      ["Roadmap", "https://cuesoft.gitbook.io/apparule/product/roadmap"],
+      ["CueLABS", "https://cuelabs.cuesoft.io"],
+    ];
+    for (const [name, href] of canon) {
+      expect(screen.getByRole("link", { name })).toHaveAttribute("href", href);
+    }
+    expect(screen.queryByText("Contributing")).not.toBeInTheDocument();
+    expect(screen.queryByText("Good first issues")).not.toBeInTheDocument();
+  });
+
+  it("renders the Legal column and the verbatim legal bar", () => {
+    render(<HomeFooter />);
+    expect(screen.getByRole("link", { name: "Privacy" })).toHaveAttribute(
+      "href",
+      "https://privacy.cuesoft.io",
+    );
+    expect(screen.getByRole("link", { name: "Terms" })).toHaveAttribute(
+      "href",
+      "https://terms.cuesoft.io",
+    );
+    expect(screen.getByRole("link", { name: "Status" })).toHaveAttribute(
+      "href",
+      "https://status.cuesoft.io",
+    );
+    // verbatim: © Cuesoft Inc. 2026. Apparule. CueLABS™ Division. MIT License.
+    expect(screen.getByRole("link", { name: "Cuesoft Inc." })).toHaveAttribute(
+      "href",
+      "https://cuesoft.io",
+    );
+    expect(screen.getByText(/2026\. Apparule\. CueLABS™ Division\./)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "MIT License" })).toHaveAttribute(
+      "href",
+      "https://github.com/cuesoftinc/apparule/blob/main/LICENSE",
+    );
     expect(
-      screen.getByRole("link", { name: "privacy.cuesoft.io" }),
-    ).toHaveAttribute("href", "https://privacy.cuesoft.io");
+      screen.getByRole("link", { name: /Security policy/ }),
+    ).toHaveAttribute(
+      "href",
+      "https://github.com/cuesoftinc/apparule/blob/main/SECURITY.md",
+    );
   });
 
   it("renders the language selector", () => {

--- a/web/src/components/ui/HomeFooter.tsx
+++ b/web/src/components/ui/HomeFooter.tsx
@@ -1,14 +1,17 @@
-// HomeFooter — design.md §8.2b: 3 link columns + legal + language
-// (pages.md A10: product/docs/community columns · privacy (APP-005) ·
-// terms · privacy.cuesoft.io clause link · language).
+// HomeFooter — design.md §8.2b marketing kit, laid out to the org
+// "Marketing nav, footer & theme parity canon" (SKILL.md, ratified
+// 2026-07-19): brand block + 4 link columns (Product · Docs · Community ·
+// Legal) + legal bar (verbatim © line · security policy · language).
+// pages.md A10's privacy/terms/clause links live in the Legal column now.
 import clsx from "clsx";
+import { ShieldCheck } from "lucide-react";
 
 export interface FooterColumn {
   heading: string;
   links: { label: string; href: string }[];
 }
 
-// Canvas footer content (Home instance 186:272, enriched landing).
+// Canonical link set — URLs are the ratified, verified-200 targets.
 const DEFAULT_COLUMNS: FooterColumn[] = [
   {
     heading: "Product",
@@ -22,21 +25,27 @@ const DEFAULT_COLUMNS: FooterColumn[] = [
   {
     heading: "Docs",
     links: [
-      { label: "Quickstart", href: "https://docs.apparule.cuesoft.io" },
-      { label: "API reference", href: "/docs/api" },
-      { label: "GitBook", href: "https://docs.apparule.cuesoft.io" },
-      { label: "Self-host guide", href: "https://docs.apparule.cuesoft.io/self-host" },
-      { label: "Contributing", href: "https://github.com/cuesoftinc/apparule/blob/main/CONTRIBUTING.md" },
+      { label: "Docs", href: "https://cuesoft.gitbook.io/apparule" },
+      { label: "Quickstart", href: "https://cuesoft.gitbook.io/apparule/setup" },
+      { label: "API reference", href: "https://cuesoft.gitbook.io/apparule/system/api-surface" },
+      { label: "Self-host guide", href: "https://cuesoft.gitbook.io/apparule/system/deployment" },
     ],
   },
   {
     heading: "Community",
     links: [
       { label: "GitHub", href: "https://github.com/cuesoftinc/apparule" },
-      { label: "Discord", href: "https://discord.gg/cuesoft" },
-      { label: "Roadmap", href: "https://github.com/cuesoftinc/apparule#roadmap" },
-      { label: "Good first issues", href: "https://github.com/cuesoftinc/apparule/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22" },
-      { label: "CueLABS", href: "https://cuesoft.io" },
+      { label: "Discord", href: "https://discord.gg/CDfZxxrxbb" },
+      { label: "Roadmap", href: "https://cuesoft.gitbook.io/apparule/product/roadmap" },
+      { label: "CueLABS", href: "https://cuelabs.cuesoft.io" },
+    ],
+  },
+  {
+    heading: "Legal",
+    links: [
+      { label: "Privacy", href: "https://privacy.cuesoft.io" },
+      { label: "Terms", href: "https://terms.cuesoft.io" },
+      { label: "Status", href: "https://status.cuesoft.io" },
     ],
   },
 ];
@@ -51,8 +60,8 @@ export function HomeFooter({ columns = DEFAULT_COLUMNS, className }: HomeFooterP
     <footer className={clsx("border-t border-border px-6 py-12", className)}>
       {/* Canonical 1080 content column (design.md container canon) —
           max-w-5xl (1024) drifted off the section grid (W2.1 live-QA). */}
-      <div className="mx-auto grid max-w-[1080px] grid-cols-2 gap-8 md:grid-cols-4">
-        <div>
+      <div className="mx-auto grid max-w-[1080px] grid-cols-2 gap-8 md:grid-cols-5">
+        <div className="col-span-2 md:col-span-1">
           <span className="bg-accent-gradient bg-clip-text text-title font-bold text-transparent">
             Apparule
           </span>
@@ -77,20 +86,37 @@ export function HomeFooter({ columns = DEFAULT_COLUMNS, className }: HomeFooterP
         ))}
       </div>
       <div className="mx-auto mt-10 flex max-w-[1080px] flex-wrap items-center gap-x-6 gap-y-2 border-t border-border pt-6 text-caption text-text-2">
-        <span>© {new Date().getFullYear()} Cuesoft · CueLABS</span>
-        <a href="/privacy" className="hover:text-text">
-          Privacy
-        </a>
-        <a href="/terms" className="hover:text-text">
-          Terms
-        </a>
+        {/* Verbatim legal line (parity canon): © Cuesoft Inc. 2026.
+            Apparule. CueLABS™ Division. MIT License. */}
+        <span>
+          ©{" "}
+          <a
+            href="https://cuesoft.io"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-text"
+          >
+            Cuesoft Inc.
+          </a>{" "}
+          2026. Apparule. CueLABS™ Division.{" "}
+          <a
+            href="https://github.com/cuesoftinc/apparule/blob/main/LICENSE"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-text"
+          >
+            MIT License
+          </a>
+          .
+        </span>
         <a
-          href="https://privacy.cuesoft.io"
+          href="https://github.com/cuesoftinc/apparule/blob/main/SECURITY.md"
           target="_blank"
           rel="noopener noreferrer"
-          className="hover:text-text"
+          className="flex items-center gap-1 hover:text-text"
         >
-          privacy.cuesoft.io
+          <ShieldCheck size={14} aria-hidden />
+          Security policy
         </a>
         <label className="ml-auto flex items-center gap-2">
           <span className="sr-only">Language</span>

--- a/web/src/components/ui/HomeNav.test.tsx
+++ b/web/src/components/ui/HomeNav.test.tsx
@@ -3,12 +3,32 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { HomeNav } from "./HomeNav";
 
 describe("HomeNav (§8.2b marketing)", () => {
-  it("renders logo, links, star badge, Sign in, Try Cloud", () => {
+  it("renders logo, canon links, star badge and the Sign in CTA", () => {
     render(<HomeNav />);
     expect(screen.getByText("Apparule")).toBeInTheDocument();
-    expect(screen.getByTestId("star-badge")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Sign in" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Try Cloud" })).toBeInTheDocument();
+    // Parity canon (SKILL.md 2026-07-19): Features · For designers · Docs ·
+    // GitHub (star badge) + the single Sign in CTA — no nav Try Cloud.
+    expect(screen.getByRole("link", { name: "Features" })).toHaveAttribute(
+      "href",
+      "#product",
+    );
+    expect(screen.getByRole("link", { name: "For designers" })).toHaveAttribute(
+      "href",
+      "#designers",
+    );
+    expect(screen.getByRole("link", { name: "Docs" })).toHaveAttribute(
+      "href",
+      "https://cuesoft.gitbook.io/apparule",
+    );
+    expect(screen.getByTestId("star-badge")).toHaveAttribute(
+      "href",
+      "https://github.com/cuesoftinc/apparule",
+    );
+    expect(screen.getByRole("link", { name: "Sign in" })).toHaveAttribute(
+      "href",
+      "/signin",
+    );
+    expect(screen.queryByText("Try Cloud")).not.toBeInTheDocument();
   });
 
   it("star badge is neutral (no invented number) until the live count arrives", () => {

--- a/web/src/components/ui/HomeNav.test.tsx
+++ b/web/src/components/ui/HomeNav.test.tsx
@@ -20,22 +20,17 @@ describe("HomeNav (§8.2b marketing)", () => {
       "href",
       "https://cuesoft.gitbook.io/apparule",
     );
-    expect(screen.getByTestId("star-badge")).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "GitHub" })).toHaveAttribute(
       "href",
       "https://github.com/cuesoftinc/apparule",
     );
+    // adjudicated: plain text link — no star badge in the nav
+    expect(screen.queryByTestId("star-badge")).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Sign in" })).toHaveAttribute(
       "href",
       "/signin",
     );
     expect(screen.queryByText("Try Cloud")).not.toBeInTheDocument();
-  });
-
-  it("star badge is neutral (no invented number) until the live count arrives", () => {
-    const { rerender } = render(<HomeNav starCount={null} />);
-    expect(screen.getByTestId("star-badge")).toHaveTextContent("Star");
-    rerender(<HomeNav starCount={1234} />);
-    expect(screen.getByTestId("star-badge")).toHaveTextContent("1,234");
   });
 
   it("blurs when stuck (scroll state)", () => {

--- a/web/src/components/ui/HomeNav.tsx
+++ b/web/src/components/ui/HomeNav.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-// HomeNav — design.md §8.2b marketing kit: logo + links + GitHub star badge
-// + Sign in + Try Cloud (gradient) · state top / stuck-blurred (blurs on
-// scroll). Accuracy standard: the badge renders "Star" with no number until
-// the live count arrives at runtime (fetched client-side by the page, A1).
+// HomeNav — design.md §8.2b marketing kit, links per the org "Marketing
+// nav, footer & theme parity canon" (SKILL.md, 2026-07-19): Features ·
+// For designers · Docs · GitHub (the star badge is the GitHub affordance)
+// + theme-toggle slot + the "Sign in" gradient CTA · state top /
+// stuck-blurred (blurs on scroll). Accuracy standard: the badge renders
+// "Star" with no number until the live count arrives at runtime (A1).
 import { useEffect, useState, type ReactNode } from "react";
 import clsx from "clsx";
 import Link from "next/link";
 import { Star } from "lucide-react";
-import { Button } from "./Button";
 import { GitHubMark } from "@/components/icons/GitHubMark";
 
 export interface HomeNavLink {
@@ -21,7 +22,6 @@ export interface HomeNavProps {
   /** Live star count (fetched at runtime); null renders the neutral badge. */
   starCount?: number | null;
   githubHref?: string;
-  onTryCloud?: () => void;
   /** Analytics seam: `github_click` fires here (pages.md A1). */
   onGithubClick?: () => void;
   /**
@@ -34,16 +34,15 @@ export interface HomeNavProps {
 }
 
 const DEFAULT_LINKS: HomeNavLink[] = [
-  { label: "Product", href: "#product" },
-  { label: "Docs", href: "https://docs.apparule.cuesoft.io" },
-  { label: "Community", href: "#community" },
+  { label: "Features", href: "#product" },
+  { label: "For designers", href: "#designers" },
+  { label: "Docs", href: "https://cuesoft.gitbook.io/apparule" },
 ];
 
 export function HomeNav({
   links = DEFAULT_LINKS,
   starCount = null,
   githubHref = "https://github.com/cuesoftinc/apparule",
-  onTryCloud,
   onGithubClick,
   trailing,
   className,
@@ -105,15 +104,13 @@ export function HomeNav({
             </span>
           </a>
           {trailing}
+          {/* Parity canon: one nav CTA — Sign in, on apparule's gradient */}
           <Link
             href="/signin"
-            className="whitespace-nowrap text-body font-semibold text-text hover:text-text-2"
+            className="inline-flex h-9 items-center justify-center whitespace-nowrap rounded-card bg-accent-gradient px-3 text-caption font-semibold text-on-accent"
           >
             Sign in
           </Link>
-          <Button kind="gradient-primary" size="sm" onClick={onTryCloud}>
-            Try Cloud
-          </Button>
         </div>
       </div>
     </nav>

--- a/web/src/components/ui/HomeNav.tsx
+++ b/web/src/components/ui/HomeNav.tsx
@@ -1,16 +1,14 @@
 "use client";
 
 // HomeNav — design.md §8.2b marketing kit, links per the org "Marketing
-// nav, footer & theme parity canon" (SKILL.md, 2026-07-19): Features ·
-// For designers · Docs · GitHub (the star badge is the GitHub affordance)
-// + theme-toggle slot + the "Sign in" gradient CTA · state top /
-// stuck-blurred (blurs on scroll). Accuracy standard: the badge renders
-// "Star" with no number until the live count arrives at runtime (A1).
+// nav, footer & theme parity canon" (SKILL.md, 2026-07-19, star-badge
+// adjudication): four PLAIN text links — Features · For designers · Docs ·
+// GitHub — + theme-toggle slot + the "Sign in" gradient CTA · state top /
+// stuck-blurred (blurs on scroll). The live star badge lives on A7b only
+// (DevelopersSection); a nav badge on one product is cross-repo drift.
 import { useEffect, useState, type ReactNode } from "react";
 import clsx from "clsx";
 import Link from "next/link";
-import { Star } from "lucide-react";
-import { GitHubMark } from "@/components/icons/GitHubMark";
 
 export interface HomeNavLink {
   label: string;
@@ -19,8 +17,6 @@ export interface HomeNavLink {
 
 export interface HomeNavProps {
   links?: HomeNavLink[];
-  /** Live star count (fetched at runtime); null renders the neutral badge. */
-  starCount?: number | null;
   githubHref?: string;
   /** Analytics seam: `github_click` fires here (pages.md A1). */
   onGithubClick?: () => void;
@@ -41,7 +37,6 @@ const DEFAULT_LINKS: HomeNavLink[] = [
 
 export function HomeNav({
   links = DEFAULT_LINKS,
-  starCount = null,
   githubHref = "https://github.com/cuesoftinc/apparule",
   onGithubClick,
   trailing,
@@ -86,23 +81,19 @@ export function HomeNav({
               {link.label}
             </a>
           ))}
-        </div>
-        <div className="ml-auto flex items-center gap-3">
+          {/* canon link 4/4 — plain text like the rest (adjudicated) */}
           <a
             href={githubHref}
             target="_blank"
             rel="noopener noreferrer"
-            data-testid="star-badge"
+            data-testid="nav-github"
             onClick={onGithubClick}
-            // hidden <sm: 375-width adaptation (Figma nav is 1440-only)
-            className="hidden h-9 items-center gap-2 rounded-pill border border-border px-3 text-body font-semibold text-text hover:bg-border/30 sm:flex"
+            className="text-body text-text-2 hover:text-text"
           >
-            <GitHubMark size={16} />
-            <Star size={14} className="text-warn" />
-            <span className="tnum">
-              {starCount === null ? "Star" : starCount.toLocaleString("en-NG")}
-            </span>
+            GitHub
           </a>
+        </div>
+        <div className="ml-auto flex items-center gap-3">
           {trailing}
           {/* Parity canon: one nav CTA — Sign in, on apparule's gradient */}
           <Link

--- a/web/src/components/ui/MeasurementCard.tsx
+++ b/web/src/components/ui/MeasurementCard.tsx
@@ -6,7 +6,7 @@
 // policy). Tap → history sheet (wired by the vault view).
 import clsx from "clsx";
 import { Camera, Pencil } from "lucide-react";
-import { formatAgo, formatCm } from "@/lib/format";
+import { formatAgoPhrase, formatCm } from "@/lib/format";
 import { humanizeMeasureName } from "./ManualMeasureRow";
 import type { MeasureUnit } from "./Input";
 
@@ -75,7 +75,7 @@ export function MeasurementCard({
       ) : null}
       {updatedAt ? (
         <span className="text-micro text-text-2">
-          Updated {formatAgo(updatedAt)} ago
+          Updated {formatAgoPhrase(updatedAt)}
         </span>
       ) : null}
     </button>

--- a/web/src/components/ui/ModerationQueueRow.tsx
+++ b/web/src/components/ui/ModerationQueueRow.tsx
@@ -6,7 +6,7 @@
 import clsx from "clsx";
 import Image from "next/image";
 import type { ModerationAction, Report } from "@/models";
-import { formatAgo } from "@/lib/format";
+import { formatAgoPhrase } from "@/lib/format";
 import { Button } from "./Button";
 
 export interface ModerationQueueRowProps {
@@ -50,7 +50,7 @@ export function ModerationQueueRow({
           </p>
           <p className="mt-0.5 line-clamp-2 text-caption text-text-2">
             “{report.subject_preview.text}” · Reported by{" "}
-            {report.reporter.username} · {formatAgo(report.created_at)} ago
+            {report.reporter.username} · {formatAgoPhrase(report.created_at)}
           </p>
         </div>
         <span className="shrink-0 rounded-pill bg-warn/14 px-2 py-0.5 text-micro font-semibold capitalize text-warn">
@@ -58,7 +58,7 @@ export function ModerationQueueRow({
         </span>
       </div>
       {open ? (
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
           <Button
             kind="quiet"
             size="sm"

--- a/web/src/components/ui/RequestCard.tsx
+++ b/web/src/components/ui/RequestCard.tsx
@@ -62,7 +62,16 @@ export function RequestCard({
 }: RequestCardProps) {
   const counterparty =
     role === "customer" ? order.designer.username : order.customer.username;
-  const action = NEXT_ACTION[role][order.status];
+  let action = NEXT_ACTION[role][order.status];
+  // "Add tracking" only makes sense while tracking is missing — once the
+  // shipment carries a ref the row's shortcut is just "View order".
+  if (
+    role === "designer" &&
+    order.status === "shipped" &&
+    order.tracking !== null
+  ) {
+    action = { label: "View order" };
+  }
   const amount = order.quote_cents ?? order.budget_cents;
   const price = amount !== null ? formatNaira(amount, order.currency) : null;
 

--- a/web/src/components/ui/Toast.test.tsx
+++ b/web/src/components/ui/Toast.test.tsx
@@ -18,6 +18,21 @@ describe("Toast (§8.2)", () => {
     expect(onRetry).toHaveBeenCalledOnce();
   });
 
+  it("renders a trailing link action (MI-3 first save)", () => {
+    render(
+      <Toast
+        kind="success"
+        message="Saved to your looks"
+        link={{ href: "/dashboard/kiki.adeyemi", label: "View" }}
+        autoDismissMs={0}
+      />,
+    );
+    expect(screen.getByRole("link", { name: "View" })).toHaveAttribute(
+      "href",
+      "/dashboard/kiki.adeyemi",
+    );
+  });
+
   it("auto-dismisses after 3s by default", () => {
     vi.useFakeTimers();
     const onDismiss = vi.fn();

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -4,6 +4,7 @@
 // variants success / error+retry / neutral. Optimistic-action failures
 // re-toast with Retry (MI-18). Entrance/exit use entrance/exit tokens.
 import { useEffect } from "react";
+import Link from "next/link";
 import clsx from "clsx";
 import { Check, X } from "lucide-react";
 
@@ -14,6 +15,8 @@ export interface ToastProps {
   message: string;
   /** error toasts render a Retry action when provided (MI-18 rollback). */
   onRetry?: () => void;
+  /** Trailing link action ("Saved to your looks" → View, MI-3). */
+  link?: { href: string; label: string };
   onDismiss?: () => void;
   /** Auto-dismiss delay; 0 disables (design default 3s). */
   autoDismissMs?: number;
@@ -30,6 +33,7 @@ export function Toast({
   kind = "neutral",
   message,
   onRetry,
+  link,
   onDismiss,
   autoDismissMs = 3000,
   className,
@@ -67,6 +71,14 @@ export function Toast({
         >
           Retry
         </button>
+      ) : null}
+      {link ? (
+        <Link
+          href={link.href}
+          className="font-semibold text-accent-start underline-offset-2 hover:underline"
+        >
+          {link.label}
+        </Link>
       ) : null}
     </div>
   );

--- a/web/src/controllers/use-profile.ts
+++ b/web/src/controllers/use-profile.ts
@@ -63,10 +63,17 @@ export function useProfile() {
 
 export function useEarnings(ownUsername: string | null = null) {
   const [earnings, setEarnings] = useState<Earnings | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  // Non-designers (ownUsername null) never hit the endpoint — it would be a
+  // guaranteed 403 (console noise on every visit); the hook boots straight
+  // into the B9 upsell state instead.
+  const [loading, setLoading] = useState(ownUsername !== null);
+  const [error, setError] = useState<string | null>(
+    ownUsername ? null : "Earnings are available to designer profiles only",
+  );
   /** Taxonomy code (e.g. designer_profile_required → B9 upsell state). */
-  const [errorCode, setErrorCode] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<string | null>(
+    ownUsername ? null : "designer_profile_required",
+  );
   /** Payout-account card data (Figma 210:3) — own designer profile. */
   const [payoutAccount, setPayoutAccount] = useState<
     DesignerProfile["payout_account"] | null
@@ -108,8 +115,9 @@ export function useEarnings(ownUsername: string | null = null) {
   );
 
   useEffect(() => {
+    if (!ownUsername) return; // upsell state set at init — nothing to fetch
     void load();
-  }, [load]);
+  }, [load, ownUsername]);
 
   const reload = useCallback(() => {
     setLoading(true);

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatAgo, formatCm, formatNaira } from "./format";
+import { formatAgo, formatAgoPhrase, formatCm, formatNaira } from "./format";
 
 describe("format utilities", () => {
   it("formats kobo to naira", () => {
@@ -19,5 +19,15 @@ describe("format utilities", () => {
     expect(formatAgo("2026-07-18T11:00:00Z", now)).toBe("1h");
     expect(formatAgo("2026-07-16T12:00:00Z", now)).toBe("2d");
     expect(formatAgo("2026-07-04T12:00:00Z", now)).toBe("2w");
+  });
+
+  it("phrases relative ages for prose meta lines (system QA: no '22 May ago')", () => {
+    const now = new Date("2026-07-18T12:00:00Z");
+    expect(formatAgoPhrase("2026-07-18T11:59:59Z", now)).toBe("just now");
+    expect(formatAgoPhrase("2026-07-16T12:00:00Z", now)).toBe("2d ago");
+    expect(formatAgoPhrase("2026-07-04T12:00:00Z", now)).toBe("2w ago");
+    // ≥30d switches to an absolute date — prefixed, never suffixed with "ago"
+    expect(formatAgoPhrase("2026-05-22T12:00:00Z", now)).toBe("on 22 May");
+    expect(formatAgoPhrase("2026-05-22T12:00:00Z", now)).not.toMatch(/ago/);
   });
 });

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -31,6 +31,20 @@ export function formatCount(value: number): string {
   return `${Math.round(m * 10) / 10}m`;
 }
 
+/**
+ * Full relative phrase for prose meta lines ("2d ago", "just now",
+ * "on 22 May"). formatAgo alone switches to an absolute date after 30d, so
+ * templates that append " ago" produced "Updated 22 May ago" (system QA).
+ */
+export function formatAgoPhrase(iso: string, now: Date = new Date()): string {
+  const days = Math.floor(
+    (now.getTime() - new Date(iso).getTime()) / (24 * 60 * 60 * 1000),
+  );
+  if (days >= 30) return `on ${formatAgo(iso, now)}`;
+  const label = formatAgo(iso, now);
+  return label === "now" ? "just now" : `${label} ago`;
+}
+
 /** Relative day label for meta lines ("today", "3d", "2w"). */
 export function formatAgo(iso: string, now: Date = new Date()): string {
   const ms = now.getTime() - new Date(iso).getTime();

--- a/web/src/mocks/seed.ts
+++ b/web/src/mocks/seed.ts
@@ -132,7 +132,9 @@ export const seedDesigners: DesignerProfile[] = [
     location: { city: "Lagos", state: "Lagos", country: "NG" },
     followers_count: 1284,
     following_count: 87,
-    posts_count: 4,
+    // posts_count mirrors the actual seeded posts (system QA: the profile
+    // header said "4 posts" over a 3-tile grid).
+    posts_count: 3,
   },
   {
     id: "des-tunde",

--- a/web/src/mocks/store.test.ts
+++ b/web/src/mocks/store.test.ts
@@ -47,6 +47,15 @@ describe("seed narrative", () => {
     expect(shoulder?.value_cm).toBe(42.5);
   });
 
+  it("designer posts_count matches the actually seeded posts (system QA)", () => {
+    for (const designer of store.designers) {
+      const actual = store.posts.filter(
+        (p) => p.designer.username === designer.username,
+      ).length;
+      expect(designer.posts_count, designer.username).toBe(actual);
+    }
+  });
+
   it("feed contains only followed designers (amara + bisi, not tunde)", () => {
     const feed = store.feed("kiki.adeyemi");
     expect(feed.length).toBeGreaterThan(0);


### PR DESCRIPTION
## What

The web-phase final gate: a full-system QA of the TEST_MODE prod build — every design.md §8.4 journey walked end-to-end as a skeptical user (Playwright-driven at 1440×900 and 390×844, light + dark + reduced-motion), data accuracy audited against the §6 seed narrative, the MI catalog spot-verified, and a live-site (apparule.cuesoft.io) spot check. Everything found is fixed here with regression tests.

## Journeys walked (all pass after fixes)

- Marketing site → CTA handoff → /signin → dashboard
- Feed: MI-1 double-click heart burst, MI-2 like + count tick, MI-3 save, MI-7 follow morph + unfollow confirm, MI-9 copy-link flash + toast, overflow → report (reason enum → moderation queue), caught-up divider, story rail, freshness card
- Request stepper (MI-10): snapshot picker w/ freshness states → prefilled delivery → review → confetti → order appears
- Explore: masonry, price-band + tag chips, search (Designers + Posts sections, per-section empty copy), recent searches, hover stats, tile → post modal w/ request CTA
- Orders: all ten lifecycle states from seed; per-state actions — pay (₦40,000 quote → escrow-held), cancel, dispute-freeze, confirm-delivery release, decline-with-reason; thread MI-17 typing → scripted reply
- Vault: QC-failure fixture → retake → capture → stagger results (low-confidence chip) → save; manual entry (height gate, cm/in); history sheet CRUD; export; rights links
- Designer: upsell → onboarding (short-number gate, mismatch fixture, resolve, KYC-lapse fixture incl. banner) → composer publish → explore/profile grid; **quote via UI with the due-date calendar (was the blocker)**; earnings math (₦55,800 released, −₦6,200 fee lines, provider refs, pending escrow)
- Settings ×3 sub-screens: pref/location persistence, consent history, export download, delete-all confirm, sign out; theme toggle + persistence
- Moderation: dismiss + hide actions, audit note, queue-clear state

## Findings → fixes (by severity)

| Sev | Lens | Finding | Fix |
|---|---|---|---|
| blocker | usability | Quote sheet's due-date calendar unusable — DateInput popover on z-20 under the z-40 Sheet swallowed every click; no quote could ever be sent via UI | popover raised to the sheet layer (same class as the W3 Select fix) + e2e that walks the calendar inside the sheet |
| major | polish | Default Next.js 404 + unstyled error boundary (off-brand) | token-branded `not-found.tsx` + `error.tsx`, e2e-gated |
| major | polish | Pill-label wrap: 390px comparison CTAs ("Start on / Cloud"), walkthrough mini-screen chips | `whitespace-nowrap` in the Button + Chip atoms; unit + e2e gates |
| major | polish | 390px horizontal overflow: order detail 178px (grid min-content), moderation 58px, profile 17px | grid clamped to `minmax(0,1fr)`, action/stats rows wrap; e2e sweeps every dashboard route at 390 |
| major | accuracy | amara.designs profile said "4 posts" over a 3-tile grid (seed drift) | seed count fixed; store test locks every designer's `posts_count` to the seeded posts |
| minor | polish | "Updated 22 May ago" (absolute date + "ago" suffix) on vault/sidebar/moderation | `formatAgoPhrase` ("2d ago" / "just now" / "on 22 May") + unit tests |
| minor | interactions | MI-3 first-save toast ("Saved to your looks" + link) missing entirely | implemented once-per-browser; Toast gains an optional trailing link |
| minor | accuracy | Payout SLA copy conflict (earnings "1 business day" vs PaymentBox "2 business days") | aligned to the PaymentBox master |
| minor | polish | Non-designer /dashboard/earnings always logged a 403 (fetch fired before the upsell gate) | hook boots straight into the B9 upsell state |
| nit | a11y | `role="menuitem"` inside `<nav>` (PostOptionsSheet) | wrapped in `role="menu"` |
| nit | accuracy | Designer shipped-row shortcut said "Add tracking" when tracking exists | reads "View order" once tracked |

## Accuracy checks that passed as-is

Escrow math everywhere (₦45,000 held, 10% fee, ₦55,800 released + itemized −₦6,200 + `PSTK-TRF-*` refs, ₦76,500 pending), all ten state pills + role-correct actions, snapshot freezing (vault edits never mutate orders), freshness ring states (fresh/aging/stale) coherent across vault/sidebar/stepper, follow-state coherence in followers sheets, KYC-lapse behavior (B8 banner, Lapsed chip), notification amounts (₦40,000 quote, ₦55,800 payout), Orders badge = 2 unread order-kind notifications and clears on visit (MI-16).

## Notes for maintainers

- `web/probe.tmp.mjs` is committed leftover QA-probe debris from the W3 pass — flagged, not removed (no-deletion policy). Recommend deleting in a follow-up chore PR.
- Live site: healthy (auth guard redirects /dashboard → /signin; star badge renders its neutral fallback — GitHub API count didn't resolve from this network). The branded 404 ships with this PR.
- The seeded follower **counts** (e.g. 1,284) are narrative vanity numbers; the followers **sheets** enumerate the few real seeded edges — per web-implementation.md §6, left as designed.

## Gates

lint ✓ · typecheck ✓ · unit 424/424 ✓ · TEST_MODE build ✓ · Playwright e2e 26/26 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)