### PR TITLE
feat(web): nav star badge + Try Cloud CTA return, pointer-cursor base rule

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -84,6 +84,8 @@
 | Radii (product) | 8px cards/sheets, full-round avatars/pills |
 | Product note | haptics per MI-20 |
 
+- **Cursor affordance**: enabled interactive controls show `cursor: pointer` — one base-layer rule on `button:not(:disabled)`, `[role="button"]:not([aria-disabled="true"])`, `select:not(:disabled)`, `summary`, `label[for]`; links use the native pointer; disabled controls keep the default cursor. [Directive 2026-07-19]
+
 These rows are standardized in the org SKILL.md — a change here is an
 ecosystem change, PR'd to all three design.md files together.
 

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -150,22 +150,29 @@ build at 1440/390, light/dark/reduced-motion, and fixed what it found:
 - 390px overflow fixes (order-detail grid, moderation actions, profile
   stats) are e2e-gated across all dashboard routes.
 
-**Link-parity as-built notes (2026-07-19, PR #93):** the org "Marketing
-nav, footer & theme parity canon" (SKILL.md) applied — nav is four plain
-text links, Features · For designers · Docs · GitHub, + theme toggle + a
-single **Sign in** gradient CTA; the runtime star-count badge is A7b's
-alone; hero/A9c/comparison CTAs fire `try_cloud_click`.
+**Link-parity as-built notes (2026-07-19):** the org "Marketing nav,
+footer & theme parity canon" (SKILL.md) applied — nav is four links,
+Features · For designers · Docs · GitHub, with GitHub rendered as the
+compact star badge (live count from the cached fetch seam shared with
+A7b; TEST_MODE and failures keep the neutral "Star" label), + theme
+toggle + a **Sign in** text link + the **Try Cloud** gradient primary CTA
+(→ /signin); nav and hero/A9c/comparison CTAs fire `try_cloud_click`.
 Footer is brand block + Product/Docs/Community/**Legal** columns (4/4/4/3
 links) + the verbatim legal bar ("© Cuesoft Inc. 2026. Apparule. CueLABS™
-Division. MIT License.") with the security-policy affordance and language
+Division. MIT License." — Cuesoft Inc., CueLABS™ Division and MIT License
+are inline links) with the security-policy affordance and language
 selector. All external URLs are the verified-200 canon targets
 (`cuesoft.gitbook.io/apparule/*`, `discord.gg/CDfZxxrxbb`,
-`cuelabs.cuesoft.io`, `privacy/terms/status.cuesoft.io`). Below md the
-nav is a hamburger menu-button disclosure (aria-expanded trigger) whose
-panel carries the same four links + the theme toggle + the Sign in CTA.
-Playwright asserts the exact hrefs on nav + footer, walks every canonical
-href through the 390 disclosure, and covers theme flip+persist on both
-surfaces.
+`cuelabs.cuesoft.io`, `privacy/terms/status.cuesoft.io`); Discord channel
+copy is `#apparule-lab`. Below md the nav is a hamburger menu-button
+disclosure (aria-expanded trigger) whose panel carries the same four
+links + the theme toggle + Sign in + Try Cloud. Enabled interactive
+controls show `cursor: pointer` via one base-layer rule in `globals.css`
+(design.md §2 cursor-affordance foundation); removable Chips are a pill
+of two real buttons (label + keyboard-reachable ✕). Playwright asserts
+the exact hrefs on nav + footer, walks every canonical href through the
+390 disclosure, covers theme flip+persist on both surfaces, and pins the
+pointer cursor on controls.
 
 **W3 as-built notes (2026-07-19, PR #91):**
 

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -15,9 +15,9 @@ test.describe("Marketing site — home page", () => {
     ).toBeVisible();
     await expect(page.getByTestId("hero-phone")).toBeVisible();
 
-    // A1 nav — plain GitHub text link (parity canon adjudication); the
-    // neutral star badge lives on A7b only (accuracy standard)
-    await expect(page.getByTestId("nav-github")).toHaveText("GitHub");
+    // A1 nav — GitHub renders as the compact star badge, neutral in
+    // TEST_MODE (accuracy standard); A7b carries its own badge
+    await expect(page.getByTestId("star-badge")).toContainText("Star");
     await expect(page.getByTestId("dev-star-badge")).toContainText("Star");
 
     // A3 stat band — the honest product claims
@@ -329,16 +329,22 @@ test.describe("nav/footer parity canon", () => {
       "href",
       "https://cuesoft.gitbook.io/apparule",
     );
-    await expect(nav.getByTestId("nav-github")).toHaveAttribute(
+    // GitHub = compact star badge (canon revision)
+    const badge = nav.getByRole("link", {
+      name: "Star cuesoftinc/apparule on GitHub",
+    });
+    await expect(badge).toHaveAttribute(
       "href",
       "https://github.com/cuesoftinc/apparule",
     );
-    await expect(nav.getByTestId("star-badge")).toHaveCount(0);
+    await expect(badge).toContainText("Star");
     await expect(nav.getByRole("link", { name: "Sign in" })).toHaveAttribute(
       "href",
       "/signin",
     );
-    await expect(nav.getByText("Try Cloud")).toHaveCount(0);
+    // Try Cloud is the one primary CTA and hands off to /signin
+    await nav.getByRole("button", { name: "Try Cloud" }).click();
+    await page.waitForURL("**/signin");
   });
 
   test("footer carries the canon columns, URLs and legal bar", async ({
@@ -376,6 +382,9 @@ test.describe("nav/footer parity canon", () => {
     await expect(
       footer.getByText(/© Cuesoft Inc\. 2026\. Apparule\. CueLABS™ Division\./),
     ).toBeVisible();
+    await expect(
+      footer.getByRole("link", { name: "CueLABS™ Division" }),
+    ).toHaveAttribute("href", "https://cuelabs.cuesoft.io");
     await expect(footer.getByLabel("Language")).toBeVisible();
     await expect(footer.getByText("Contributing")).toHaveCount(0);
     await expect(footer.getByText("Good first issues")).toHaveCount(0);
@@ -413,6 +422,11 @@ test.describe("nav/footer parity canon", () => {
       ).toHaveAttribute("href", href);
     }
 
+    // Try Cloud rides along in the panel and hands off to /signin
+    await expect(
+      panel.getByRole("button", { name: "Try Cloud" }),
+    ).toBeVisible();
+
     // the theme toggle works from inside the panel
     await panel.getByRole("button", { name: /switch to dark theme/i }).click();
     await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
@@ -443,5 +457,23 @@ test.describe("nav/footer parity canon", () => {
     await expect(page.locator("html")).not.toHaveAttribute("data-theme", "dark");
     await page.reload();
     await expect(page.locator("html")).not.toHaveAttribute("data-theme", "dark");
+  });
+});
+
+// Cursor affordance [Directive 2026-07-19]: enabled interactive controls
+// show the pointer (Tailwind v4 defaults buttons to cursor:default).
+test.describe("cursor affordance", () => {
+  test("buttons and nav links show cursor: pointer", async ({ page }) => {
+    await page.goto("/");
+    const buttonCursor = await page
+      .getByRole("button", { name: "Try Cloud" })
+      .first()
+      .evaluate((el) => getComputedStyle(el).cursor);
+    expect(buttonCursor).toBe("pointer");
+    const linkCursor = await page
+      .getByRole("navigation", { name: "Home" })
+      .getByRole("link", { name: "Features" })
+      .evaluate((el) => getComputedStyle(el).cursor);
+    expect(linkCursor).toBe("pointer");
   });
 });

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -77,6 +77,17 @@
     outline: 2px solid var(--ap-accent-start);
     outline-offset: 2px;
   }
+
+  /* Cursor affordance [Directive 2026-07-19] — Tailwind v4 defaults buttons
+     to cursor:default; enabled interactive controls show the pointer.
+     Links keep the native pointer; disabled controls keep default. */
+  button:not(:disabled),
+  [role="button"]:not([aria-disabled="true"]),
+  select:not(:disabled),
+  summary,
+  label[for] {
+    cursor: pointer;
+  }
 }
 
 /* Tabular numerals for measurements and money (design.md §2 Type) */

--- a/web/src/components/home/DevelopersSection.tsx
+++ b/web/src/components/home/DevelopersSection.tsx
@@ -98,7 +98,7 @@ export function DevelopersSection() {
           className={LINK_CLASSES}
         >
           <DiscordMark size={18} />
-          #apparule-dev on Discord →
+          #apparule-lab on Discord →
         </a>
         <a
           href={GITHUB_REPO_URL}

--- a/web/src/components/home/HomeNavBar.tsx
+++ b/web/src/components/home/HomeNavBar.tsx
@@ -1,22 +1,31 @@
 "use client";
 
-// A1 nav wrapper — HomeNav instance wired to the controllers:
-// `github_click` and the theme toggle (parity canon: the nav CTA is Sign
-// in; the GitHub item is a plain text link — the live star badge is A7b's,
-// DevelopersSection keeps the runtime fetch).
+// A1 nav wrapper — HomeNav instance wired to the controllers: the live
+// star count (shared cached fetch seam with A7b, neutral "Star" fallback),
+// `github_click` / `try_cloud_click`, the Try Cloud → /signin handoff, and
+// the theme toggle.
+import { useRouter } from "next/navigation";
 import { Moon, Sun } from "lucide-react";
 import { HomeNav } from "@/components/ui/HomeNav";
 import { IconButton } from "@/components/ui/IconButton";
 import { useTheme } from "@/design/ThemeProvider";
 import { track } from "@/controllers/use-analytics";
+import { useGithubStars } from "@/controllers/use-github-stars";
 
 export function HomeNavBar() {
+  const router = useRouter();
+  const stars = useGithubStars();
   const { preference, setPreference } = useTheme();
   const nextTheme = preference === "dark" ? "light" : "dark";
 
   return (
     <HomeNav
+      starCount={stars}
       onGithubClick={() => track("github_click", { section: "nav" })}
+      onTryCloud={() => {
+        track("try_cloud_click", { section: "nav" });
+        router.push("/signin");
+      }}
       trailing={
         <IconButton
           size="sm"

--- a/web/src/components/home/interactive.test.tsx
+++ b/web/src/components/home/interactive.test.tsx
@@ -264,7 +264,7 @@ describe("HomeNavBar (A1)", () => {
     expect(document.documentElement).toHaveAttribute("data-theme", "light");
   });
 
-  it("the nav Sign in CTA links to /signin (parity canon)", () => {
+  it("nav: Sign in text link + Try Cloud CTA hands off with try_cloud_click", async () => {
     render(
       <ThemeProvider>
         <HomeNavBar />
@@ -274,21 +274,31 @@ describe("HomeNavBar (A1)", () => {
       "href",
       "/signin",
     );
-    expect(screen.queryByText("Try Cloud")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Try Cloud" }));
+    expect(names()).toContain("try_cloud_click");
+    expect(push).toHaveBeenCalledWith("/signin");
   });
 
-  it("nav GitHub is a plain text link that fires github_click", async () => {
+  it("nav star badge keeps the neutral label while no live count exists", () => {
     render(
       <ThemeProvider>
         <HomeNavBar />
       </ThemeProvider>,
     );
-    const github = screen.getByTestId("nav-github");
+    expect(screen.getByTestId("star-badge")).toHaveTextContent("Star");
+  });
+
+  it("nav GitHub star badge fires github_click", async () => {
+    render(
+      <ThemeProvider>
+        <HomeNavBar />
+      </ThemeProvider>,
+    );
+    const github = screen.getByTestId("star-badge");
     expect(github).toHaveAttribute(
       "href",
       "https://github.com/cuesoftinc/apparule",
     );
-    expect(screen.queryByTestId("star-badge")).not.toBeInTheDocument();
     await userEvent.click(github);
     expect(names()).toContain("github_click");
   });

--- a/web/src/components/ui/Chip.test.tsx
+++ b/web/src/components/ui/Chip.test.tsx
@@ -31,6 +31,13 @@ describe("Chip (§8.2)", () => {
     );
   });
 
+  it("the ✕ affordance is a real, keyboard-reachable button (semantic canon)", () => {
+    render(<Chip kind="removable" label="near me" onRemove={() => {}} />);
+    const remove = screen.getByRole("button", { name: "Remove near me" });
+    expect(remove.tagName).toBe("BUTTON");
+    expect(remove).not.toHaveAttribute("tabindex", "-1");
+  });
+
   it("removable chip fires onRemove from the ✕ affordance only", async () => {
     const onRemove = vi.fn();
     const onClick = vi.fn();

--- a/web/src/components/ui/Chip.tsx
+++ b/web/src/components/ui/Chip.tsx
@@ -16,6 +16,15 @@ export interface ChipProps
   onRemove?: () => void;
 }
 
+// Figma master (41:19): 13px semibold label; selected = solid text-token
+// fill (reads as active filter, not an action). whitespace-nowrap: a chip
+// is a fixed-height pill — wrapped labels clip out of it in constrained
+// rows (walkthrough mini-screens).
+const PILL_CLASSES = [
+  "inline-flex h-8 items-center gap-1.5 whitespace-nowrap rounded-pill border px-3 text-caption font-semibold",
+  "transition-colors duration-120 ease-standard motion-reduce:transition-none",
+];
+
 export function Chip({
   kind = "default",
   label,
@@ -23,18 +32,45 @@ export function Chip({
   className,
   ...rest
 }: ChipProps) {
+  if (kind === "removable") {
+    // Removable = two REAL buttons in a pill container — a button may not
+    // own interactive descendants, and the ✕ must be keyboard-reachable
+    // (semantic canon; formerly a tabIndex=-1 span[role=button] inside the
+    // chip button).
+    return (
+      <span
+        data-kind="removable"
+        className={clsx(PILL_CLASSES, "border-border bg-bg-elev text-text", className)}
+      >
+        <button
+          type="button"
+          data-kind={kind}
+          className="inline-flex items-center whitespace-nowrap"
+          {...rest}
+        >
+          {label}
+        </button>
+        <button
+          type="button"
+          aria-label={`Remove ${label}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove?.();
+          }}
+          className="-mr-1 grid size-4 place-items-center rounded-pill text-text-2 hover:text-text"
+        >
+          <X size={14} strokeWidth={2.5} />
+        </button>
+      </span>
+    );
+  }
   return (
     <button
       type="button"
       data-kind={kind}
       aria-pressed={kind === "selected" || undefined}
       className={clsx(
-        // Figma master (41:19): 13px semibold label; selected = solid
-        // text-token fill (reads as active filter, not an action).
-        // whitespace-nowrap: a chip is a fixed-height pill — wrapped labels
-        // clip out of it in constrained rows (walkthrough mini-screens).
-        "inline-flex h-8 items-center gap-1.5 whitespace-nowrap rounded-pill border px-3 text-caption font-semibold",
-        "transition-colors duration-120 ease-standard motion-reduce:transition-none",
+        PILL_CLASSES,
         kind === "selected"
           ? "border-transparent bg-text text-bg"
           : "border-border bg-bg-elev text-text",
@@ -43,20 +79,6 @@ export function Chip({
       {...rest}
     >
       <span>{label}</span>
-      {kind === "removable" ? (
-        <span
-          role="button"
-          aria-label={`Remove ${label}`}
-          tabIndex={-1}
-          onClick={(e) => {
-            e.stopPropagation();
-            onRemove?.();
-          }}
-          className="-mr-1 grid size-4 place-items-center rounded-pill text-text-2 hover:text-text"
-        >
-          <X size={14} strokeWidth={2.5} />
-        </span>
-      ) : null}
     </button>
   );
 }

--- a/web/src/components/ui/HomeFooter.test.tsx
+++ b/web/src/components/ui/HomeFooter.test.tsx
@@ -48,7 +48,9 @@ describe("HomeFooter (§8.2b marketing, parity canon 2026-07-19)", () => {
       "href",
       "https://cuesoft.io",
     );
-    expect(screen.getByText(/2026\. Apparule\. CueLABS™ Division\./)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "CueLABS™ Division" }),
+    ).toHaveAttribute("href", "https://cuelabs.cuesoft.io");
     expect(screen.getByRole("link", { name: "MIT License" })).toHaveAttribute(
       "href",
       "https://github.com/cuesoftinc/apparule/blob/main/LICENSE",

--- a/web/src/components/ui/HomeFooter.tsx
+++ b/web/src/components/ui/HomeFooter.tsx
@@ -98,7 +98,16 @@ export function HomeFooter({ columns = DEFAULT_COLUMNS, className }: HomeFooterP
           >
             Cuesoft Inc.
           </a>{" "}
-          2026. Apparule. CueLABS™ Division.{" "}
+          2026. Apparule.{" "}
+          <a
+            href="https://cuelabs.cuesoft.io"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-text"
+          >
+            CueLABS™ Division
+          </a>
+          .{" "}
           <a
             href="https://github.com/cuesoftinc/apparule/blob/main/LICENSE"
             target="_blank"

--- a/web/src/components/ui/HomeNav.test.tsx
+++ b/web/src/components/ui/HomeNav.test.tsx
@@ -21,17 +21,29 @@ describe("HomeNav (§8.2b marketing)", () => {
       "href",
       "https://cuesoft.gitbook.io/apparule",
     );
-    expect(screen.getByRole("link", { name: "GitHub" })).toHaveAttribute(
+    // canon revision: GitHub renders as the compact star badge
+    const badge = screen.getByRole("link", {
+      name: "Star cuesoftinc/apparule on GitHub",
+    });
+    expect(badge).toHaveAttribute(
       "href",
       "https://github.com/cuesoftinc/apparule",
     );
-    // adjudicated: plain text link — no star badge in the nav
-    expect(screen.queryByTestId("star-badge")).not.toBeInTheDocument();
+    expect(badge).toHaveTextContent("Star");
     expect(screen.getByRole("link", { name: "Sign in" })).toHaveAttribute(
       "href",
       "/signin",
     );
-    expect(screen.queryByText("Try Cloud")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Try Cloud" }),
+    ).toBeInTheDocument();
+  });
+
+  it("star badge is neutral until the live count arrives (never invented)", () => {
+    const { rerender } = render(<HomeNav starCount={null} />);
+    expect(screen.getByTestId("star-badge")).toHaveTextContent("Star");
+    rerender(<HomeNav starCount={1234} />);
+    expect(screen.getByTestId("star-badge")).toHaveTextContent("1,234");
   });
 
   it("collapses the links into a hamburger disclosure below md", async () => {
@@ -56,6 +68,7 @@ describe("HomeNav (§8.2b marketing)", () => {
       "https://github.com/cuesoftinc/apparule",
     );
     expect(within(panel).getByRole("link", { name: "Sign in" })).toHaveAttribute("href", "/signin");
+    expect(within(panel).getByRole("button", { name: "Try Cloud" })).toBeInTheDocument();
     expect(within(panel).getByRole("button", { name: "Toggle theme" })).toBeInTheDocument();
 
     // link click closes the disclosure

--- a/web/src/components/ui/HomeNav.tsx
+++ b/web/src/components/ui/HomeNav.tsx
@@ -1,18 +1,21 @@
 "use client";
 
-// HomeNav — design.md §8.2b marketing kit, links per the org "Marketing
-// nav, footer & theme parity canon" (SKILL.md, 2026-07-19, star-badge
-// adjudication): four PLAIN text links — Features · For designers · Docs ·
-// GitHub — + theme-toggle slot + the "Sign in" gradient CTA · state top /
-// stuck-blurred (blurs on scroll). The live star badge lives on A7b only
-// (DevelopersSection); a nav badge on one product is cross-repo drift.
-// Below md the four links collapse into a hamburger disclosure whose panel
-// carries the same links + the theme toggle + Sign in (canon extension,
-// 2026-07-19 — previously the links simply vanished on mobile).
+// HomeNav — design.md §8.2b marketing kit, per the org "Marketing nav,
+// footer & theme parity canon" (SKILL.md, revised 2026-07-19): four links
+// — Features · For designers · Docs · GitHub, with GitHub rendered as the
+// compact star badge (star glyph + "Star" + the live count from the shared
+// cached fetch seam; TEST_MODE/failure keep the neutral "Star" label,
+// never a hardcoded count) — + theme-toggle slot + the "Sign in" text link
+// + the "Try Cloud" gradient primary CTA (→ /signin) · state top /
+// stuck-blurred (blurs on scroll). Below md the links collapse into a
+// hamburger disclosure whose panel carries the same links + the theme
+// toggle + Sign in + Try Cloud.
 import { useEffect, useState, type ReactNode } from "react";
 import clsx from "clsx";
 import Link from "next/link";
-import { Menu, X } from "lucide-react";
+import { Menu, Star, X } from "lucide-react";
+import { Button } from "./Button";
+import { GitHubMark } from "@/components/icons/GitHubMark";
 
 export interface HomeNavLink {
   label: string;
@@ -22,8 +25,12 @@ export interface HomeNavLink {
 export interface HomeNavProps {
   links?: HomeNavLink[];
   githubHref?: string;
+  /** Live star count (shared cached fetch); null keeps the neutral badge. */
+  starCount?: number | null;
   /** Analytics seam: `github_click` fires here (pages.md A1). */
   onGithubClick?: () => void;
+  /** Try Cloud handoff (→ /signin) — `try_cloud_click` fires here. */
+  onTryCloud?: () => void;
   /**
    * Trailing slot before Sign in — the page mounts the theme toggle here
    * (W2 adaptation: light/dark QA + the §8.4 marketing journey need a
@@ -43,7 +50,9 @@ const DEFAULT_LINKS: HomeNavLink[] = [
 export function HomeNav({
   links = DEFAULT_LINKS,
   githubHref = "https://github.com/cuesoftinc/apparule",
+  starCount = null,
   onGithubClick,
+  onTryCloud,
   trailing,
   className,
 }: HomeNavProps) {
@@ -97,27 +106,35 @@ export function HomeNav({
               {link.label}
             </a>
           ))}
-          {/* canon link 4/4 — plain text like the rest (adjudicated) */}
+          {/* link 4/4 — GitHub as the compact star badge (canon revision) */}
           <a
             href={githubHref}
             target="_blank"
             rel="noopener noreferrer"
-            data-testid="nav-github"
+            data-testid="star-badge"
+            aria-label="Star cuesoftinc/apparule on GitHub"
             onClick={onGithubClick}
-            className="text-body text-text-2 hover:text-text"
+            className="flex h-9 items-center gap-2 rounded-pill border border-border px-3 text-caption font-semibold text-text hover:bg-border/30"
           >
-            GitHub
+            <GitHubMark size={14} />
+            <Star size={12} className="text-warn" />
+            <span className="tnum">
+              {starCount === null ? "Star" : starCount.toLocaleString("en-NG")}
+            </span>
           </a>
         </div>
         <div className="ml-auto hidden items-center gap-3 md:flex">
           {trailing}
-          {/* Parity canon: one nav CTA — Sign in, on apparule's gradient */}
           <Link
             href="/signin"
-            className="inline-flex h-9 items-center justify-center whitespace-nowrap rounded-card bg-accent-gradient px-3 text-caption font-semibold text-on-accent"
+            className="whitespace-nowrap text-body font-semibold text-text hover:text-text-2"
           >
             Sign in
           </Link>
+          {/* the one primary CTA — Try Cloud on apparule's gradient */}
+          <Button kind="gradient-primary" size="sm" onClick={onTryCloud}>
+            Try Cloud
+          </Button>
         </div>
         {/* <md: the canon links collapse into a hamburger disclosure */}
         <button
@@ -163,15 +180,27 @@ export function HomeNav({
           >
             GitHub
           </a>
-          <div className="mt-2 flex items-center justify-between border-t border-border pt-3">
+          <div className="mt-2 flex items-center justify-between gap-3 border-t border-border pt-3">
             {trailing}
-            <Link
-              href="/signin"
-              onClick={() => setMenuOpen(false)}
-              className="inline-flex h-9 items-center justify-center whitespace-nowrap rounded-card bg-accent-gradient px-3 text-caption font-semibold text-on-accent"
-            >
-              Sign in
-            </Link>
+            <div className="flex items-center gap-3">
+              <Link
+                href="/signin"
+                onClick={() => setMenuOpen(false)}
+                className="whitespace-nowrap text-body font-semibold text-text hover:text-text-2"
+              >
+                Sign in
+              </Link>
+              <Button
+                kind="gradient-primary"
+                size="sm"
+                onClick={() => {
+                  setMenuOpen(false);
+                  onTryCloud?.();
+                }}
+              >
+                Try Cloud
+              </Button>
+            </div>
           </div>
         </div>
       ) : null}

--- a/web/src/components/ui/PostCard.tsx
+++ b/web/src/components/ui/PostCard.tsx
@@ -94,7 +94,13 @@ export function PostCard({
         </IconButton>
       </header>
 
-      {/* media (full-bleed, 1:1 default / 4:5 max) */}
+      {/* media (full-bleed, 1:1 default / 4:5 max). The onClick here is the
+          MI-1 double-tap GESTURE zone, not a control: single click does
+          nothing, the accessible like path is the ActionRow heart, and a
+          role="button" would announce a control that ignores activation —
+          while a real <button> can't own the nested carousel buttons. It
+          stays a plain div (exempt from the cursor-affordance base rule by
+          design). */}
       <div
         className="relative aspect-square w-full select-none overflow-hidden bg-border/30"
         onClick={handleMediaTap}


### PR DESCRIPTION
## What

Follow-up to #96 applying three user decisions (canon revision + cursor directive + copy corrections). Branched off fresh `origin/main` containing the #96 squash.

### 1. Marketing-nav canon revision
- **GitHub renders as the compact star badge again**: star glyph + "Star" + live count via the **same cached fetch seam A7b uses** (`useGithubStars` — module-level cache, one fetch per session); TEST_MODE and failures keep the neutral "Star" label (never hardcoded); `aria-label="Star cuesoftinc/apparule on GitHub"`.
- Right cluster: theme toggle · **Sign in text link** · **Try Cloud gradient primary CTA** (→ `/signin`, fires `try_cloud_click`).
- Mobile disclosure panel gains **Try Cloud** alongside Sign in.
- e2e asserts the revised composition on desktop (badge href/label, Sign in link, Try Cloud handoff click) and through the 390 panel walk.

### 2. Cursor affordance (user directive)
- `@layer base` rule in `globals.css`: `button:not(:disabled), [role="button"]:not([aria-disabled="true"]), select:not(:disabled), summary, label[for] { cursor: pointer }` (Tailwind v4 defaults buttons to `cursor: default`).
- e2e asserts `getComputedStyle(...).cursor === "pointer"` on a button and a nav link.
- **onClick-on-non-interactive sweep**: `Chip`'s removable ✕ was a `tabIndex=-1` `span[role=button]` nested **inside** the chip `<button>` (invalid interactive nesting, not keyboard-reachable) — removable chips are now a pill container of **two real buttons** (label + ✕), unit-gated. `PostCard`'s media `div` is the MI-1 double-tap **gesture zone** (single click does nothing; accessible path is the ActionRow heart; a real button can't own the nested carousel buttons) — documented in code, intentionally left non-interactive.

### 3. Copy corrections
- Discord channel copy: `#apparule-dev` → **`#apparule-lab`** (canon: `#<product>-lab`, never invented; invite href unchanged). Swept web/src + docs — no other invented channel names.
- Footer legal bar: **"CueLABS™ Division" links to https://cuelabs.cuesoft.io**, styled like the bar's other inline links; e2e href assertion added.

### Docs
- `docs/design.md`: the verbatim cursor-affordance shared-foundations line (only that line).
- `docs/web-implementation.md`: link-parity note rewritten as current construction (nav badge + Sign in link + Try Cloud CTA, panel contents, cursor rule, chip semantics, channel copy).

## Gates

lint ✓ · typecheck ✓ · unit **428/428** ✓ · TEST_MODE build ✓ · Playwright **31/31** ✓ — screenshot-verified desktop nav + 390 panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)