### PR TITLE
fix(web): mobile-responsive pass — every route clean at 390/768, wide-element scroll containers

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -202,6 +202,28 @@ pointer cursor on controls.
 - Semantic-HTML landmarks (one `<main>`, one `nav[aria-label="Primary"]`)
   are enforced by e2e across all 15 dashboard screens, not spot-checked.
 
+**Mobile-responsiveness as-built notes (2026-07-19, PR #101):** the P1
+mobile pass **[Directive]** — home and every dashboard route render fully
+inside the mobile boundary at 390 (768 sanity); the document never
+side-scrolls, and wide elements scroll within their own containers:
+
+- `web/e2e/mobile-responsive.spec.ts` sweeps all 19 routes (public +
+  dashboard, settings sub-screens and order detail included) asserting
+  `document.scrollWidth <= viewport` at 390 AND 768, plus wide-element
+  containment: any `table`/`pre`/`code` wider than the viewport must sit
+  inside an `overflow-x: auto` container that itself fits. It supersedes
+  the old 12-route dashboard.spec sweep.
+- The A9 comparison table scrolls horizontally within its card below its
+  min-content width (the "Self-host it" CTA was clipped at 390).
+- One `@layer base` rule — `fieldset { min-inline-size: 0 }` — normalizes
+  the fieldset default that defeats child truncation (the request
+  stepper's snapshot picker overflowed the 390 viewport this way).
+- Thread image attachments carry `max-w-full` so a fixed-width bubble
+  image never crops at narrow widths.
+- Interactive overlays are part of the audited surface: stepper steps
+  1–3, quote sheet + due-date picker, decline/dispute/confirm-delivery,
+  capture and history sheets, explore post modal, followers sheet.
+
 Screen-state parity **[Directive 2026-07-18, carried from design.md §8.1]**:
 every data-driven screen ships default, empty, and loading states — the
 three-frame rule applies to the implementation exactly as it does to the

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -375,38 +375,5 @@ test("designer quote via the UI: the due-date calendar works inside the quote sh
   await expect(page.getByText(/₦58,000/).first()).toBeVisible();
 });
 
-test("no horizontal overflow on dashboard screens at 390 (system QA regression)", async ({
-  page,
-}) => {
-  // Regression: at 390 the order-detail grid (min-content sizing), the
-  // moderation action row and the profile stats row all pushed past the
-  // viewport (178/58/17px).
-  await page.setViewportSize({ width: 390, height: 844 });
-  await signIn(page);
-  for (const route of [
-    "/dashboard",
-    "/dashboard/explore",
-    "/dashboard/orders",
-    "/dashboard/orders/req-apr-1042",
-    "/dashboard/vault",
-    "/dashboard/create",
-    "/dashboard/kiki.adeyemi",
-    "/dashboard/amara.designs",
-    "/dashboard/settings",
-    "/dashboard/admin/moderation",
-    "/dashboard/designer/onboarding",
-    "/dashboard/earnings",
-  ]) {
-    await page.goto(route);
-    // networkidle never settles against the dev server (HMR socket) — wait
-    // for the screen's <main> content instead.
-    await expect(page.locator("main")).toBeVisible();
-    await page.waitForTimeout(400);
-    const overflow = await page.evaluate(
-      () =>
-        document.documentElement.scrollWidth -
-        document.documentElement.clientWidth,
-    );
-    expect(overflow, `${route} horizontal overflow`).toBeLessThanOrEqual(2);
-  }
-});
+// The 390 overflow sweep moved to e2e/mobile-responsive.spec.ts (P1
+// mobile pass): every route, 390 + 768, plus wide-element containment.

--- a/web/e2e/mobile-responsive.spec.ts
+++ b/web/e2e/mobile-responsive.spec.ts
@@ -1,0 +1,197 @@
+// Mobile-responsiveness sweep [Directive P1 2026-07-19]: home AND every
+// dashboard route render fully inside the mobile boundary at 390 (768
+// sanity) — the document itself never side-scrolls, and known-wide elements
+// (tables, code snippets, rails) sit in horizontal-scroll containers that
+// scroll WITHIN the viewport. Runs in TEST_MODE against the mock server.
+import { expect, test, type Page } from "@playwright/test";
+
+// Every route the web app serves (web-implementation.md §4 route map).
+const PUBLIC_ROUTES = [
+  "/",
+  "/signin",
+  "/p/post-ankara-gown",
+  "/definitely-not-a-route", // branded not-found
+];
+
+const DASHBOARD_ROUTES = [
+  "/dashboard",
+  "/dashboard/explore",
+  "/dashboard/orders",
+  "/dashboard/orders/req-apr-1042",
+  "/dashboard/vault",
+  "/dashboard/create",
+  "/dashboard/kiki.adeyemi",
+  "/dashboard/amara.designs",
+  "/dashboard/settings",
+  "/dashboard/settings/notifications",
+  "/dashboard/settings/privacy",
+  "/dashboard/settings/account",
+  "/dashboard/admin/moderation",
+  "/dashboard/designer/onboarding",
+  "/dashboard/earnings",
+];
+
+async function signIn(page: Page) {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: /continue with google/i }).click();
+  await page.waitForURL("**/dashboard");
+}
+
+async function settle(page: Page, route: string) {
+  await page.goto(route);
+  // networkidle never settles against the dev server (HMR socket) — wait
+  // for the screen's <main> content instead.
+  await expect(page.locator("main")).toBeVisible();
+  await page.waitForTimeout(400);
+}
+
+const docOverflow = (page: Page) =>
+  page.evaluate(
+    () =>
+      document.documentElement.scrollWidth -
+      document.documentElement.clientWidth,
+  );
+
+// Known-wide elements must be reachable by scrolling WITHIN a container:
+// each sits inside an ancestor with overflow-x auto/scroll whose own box
+// fits the viewport. Returns human-readable violations.
+const wideElementViolations = (page: Page) =>
+  page.evaluate(() => {
+    const vw = document.documentElement.clientWidth;
+    const violations: string[] = [];
+    const fitsViewport = (r: DOMRect) => r.right <= vw + 1 && r.left >= -1;
+    const scrollContainerOf = (el: Element): Element | null => {
+      for (let a = el.parentElement; a; a = a.parentElement) {
+        const s = getComputedStyle(a);
+        if (s.overflowX === "auto" || s.overflowX === "scroll") return a;
+      }
+      return null;
+    };
+    for (const el of document.querySelectorAll("table, pre, code")) {
+      const r = el.getBoundingClientRect();
+      if (!r.width || !r.height) continue;
+      if (fitsViewport(r)) continue; // narrow enough — nothing to prove
+      const container = scrollContainerOf(el);
+      if (!container) {
+        violations.push(
+          `<${el.tagName.toLowerCase()}> wider than viewport without a scroll container`,
+        );
+      } else if (!fitsViewport(container.getBoundingClientRect())) {
+        violations.push(
+          `<${el.tagName.toLowerCase()}> scroll container itself escapes the viewport`,
+        );
+      }
+    }
+    return violations;
+  });
+
+for (const width of [390, 768]) {
+  test(`no horizontal document overflow at ${width} — public + dashboard routes`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width, height: width === 390 ? 844 : 1024 });
+    for (const route of PUBLIC_ROUTES) {
+      await settle(page, route);
+      expect(
+        await docOverflow(page),
+        `${route} horizontal overflow at ${width}`,
+      ).toBeLessThanOrEqual(2);
+    }
+    await signIn(page);
+    for (const route of DASHBOARD_ROUTES) {
+      await settle(page, route);
+      expect(
+        await docOverflow(page),
+        `${route} horizontal overflow at ${width}`,
+      ).toBeLessThanOrEqual(2);
+    }
+  });
+}
+
+test("wide elements (tables, code) sit in horizontal-scroll containers at 390", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await signIn(page);
+  for (const route of [...PUBLIC_ROUTES, ...DASHBOARD_ROUTES]) {
+    await settle(page, route);
+    expect(
+      await wideElementViolations(page),
+      `${route} wide-element containment at 390`,
+    ).toEqual([]);
+  }
+});
+
+test("comparison table scrolls within its card at 390 — CTAs reachable", async ({
+  page,
+}) => {
+  // Regression: the A9 Cloud-vs-OSS table clipped its "Self-host it" CTA
+  // behind overflow-hidden at 390 (P1 mobile pass).
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/");
+  const table = page.locator("table").first();
+  await table.scrollIntoViewIfNeeded();
+  const selfHost = page.getByRole("button", { name: "Self-host it" });
+  await expect(selfHost).toBeVisible();
+  // scroll the container to the end — the CTA must land inside the viewport
+  const reachable = await selfHost.evaluate((el) => {
+    let scroller: HTMLElement | null = el.parentElement;
+    while (scroller && getComputedStyle(scroller).overflowX !== "auto") {
+      scroller = scroller.parentElement;
+    }
+    if (!scroller) return getComputedStyle(el).visibility === "visible";
+    scroller.scrollLeft = scroller.scrollWidth;
+    const r = el.getBoundingClientRect();
+    return r.right <= document.documentElement.clientWidth + 1;
+  });
+  expect(reachable, "Self-host CTA reachable by in-card scroll").toBe(true);
+});
+
+test("request stepper snapshot picker fits the 390 viewport", async ({
+  page,
+}) => {
+  // Regression: fieldset's default min-inline-size:min-content defeated
+  // SessionRow truncation and pushed step 1 content past the viewport.
+  await page.setViewportSize({ width: 390, height: 844 });
+  await signIn(page);
+  await page.goto("/dashboard");
+  const cta = page
+    .getByRole("button", { name: /request this outfit/i })
+    .first();
+  await cta.scrollIntoViewIfNeeded();
+  await cta.click();
+  const step1 = page.getByTestId("stepper-step-1");
+  await expect(step1).toBeVisible();
+  const pokes = await page.evaluate(() => {
+    const dlg = document.querySelector('[role="dialog"]');
+    if (!dlg) return -1;
+    const vw = document.documentElement.clientWidth;
+    let count = 0;
+    for (const el of dlg.querySelectorAll("*")) {
+      const r = el.getBoundingClientRect();
+      if (r.width && (r.right > vw + 1 || r.left < -1)) count++;
+    }
+    return count;
+  });
+  expect(pokes, "no stepper content outside the 390 viewport").toBe(0);
+});
+
+test("order-thread image attachments stay inside the bubble at 390", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await signIn(page);
+  await settle(page, "/dashboard/orders/req-apr-1042");
+  const images = page.locator("[data-content='image']");
+  const count = await images.count();
+  expect(count).toBeGreaterThan(0);
+  for (let i = 0; i < count; i++) {
+    const box = await images.nth(i).boundingBox();
+    expect(box, `attachment ${i} rendered`).not.toBeNull();
+    expect(box!.x, `attachment ${i} left edge`).toBeGreaterThanOrEqual(-1);
+    expect(
+      box!.x + box!.width,
+      `attachment ${i} right edge`,
+    ).toBeLessThanOrEqual(391);
+  }
+});

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -88,6 +88,14 @@
   label[for] {
     cursor: pointer;
   }
+
+  /* Fieldsets default to min-inline-size:min-content, which defeats child
+     truncation/wrapping — the request-stepper snapshot picker pushed past
+     the 390 viewport this way (P1 mobile pass). Normalize so flex children
+     can shrink like they do in any other container. */
+  fieldset {
+    min-inline-size: 0;
+  }
 }
 
 /* Tabular numerals for measurements and money (design.md §2 Type) */

--- a/web/src/components/ui/ComparisonTable.tsx
+++ b/web/src/components/ui/ComparisonTable.tsx
@@ -50,48 +50,53 @@ export function ComparisonTable({
         className,
       )}
     >
-      <table className="w-full border-collapse text-body">
-        <thead>
-          <tr className="border-b border-border text-left">
-            {/* Figma master: Feature reads Caption/13 Semi Bold in text-2 */}
-            <th className="h-25 px-6 text-caption font-semibold text-text-2">
-              Feature
-            </th>
-            <th className="h-25 w-35 text-center text-body-lg font-semibold text-text">
-              Cloud
-            </th>
-            <th className="h-25 w-35 px-6 pl-0 text-center text-body-lg font-semibold text-text">
-              Self-host
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row) => (
-            <tr key={row.feature} className="border-b border-border">
-              <td className="h-25 px-6 text-text">{row.feature}</td>
+      {/* Wide-table rule (P1 mobile pass): below the table's min-content
+          width the inner container scrolls horizontally within the card —
+          the document itself never side-scrolls. */}
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-body">
+          <thead>
+            <tr className="border-b border-border text-left">
+              {/* Figma master: Feature reads Caption/13 Semi Bold in text-2 */}
+              <th className="h-25 px-6 text-caption font-semibold text-text-2">
+                Feature
+              </th>
+              <th className="h-25 w-35 text-center text-body-lg font-semibold text-text">
+                Cloud
+              </th>
+              <th className="h-25 w-35 px-6 pl-0 text-center text-body-lg font-semibold text-text">
+                Self-host
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.feature} className="border-b border-border">
+                <td className="h-25 px-6 text-text">{row.feature}</td>
+                <td className="h-25 text-center">
+                  <Cell value={row.cloud} />
+                </td>
+                <td className="h-25 px-6 pl-0 text-center">
+                  <Cell value={row.oss} />
+                </td>
+              </tr>
+            ))}
+            <tr data-testid="cta-row">
+              <td className="h-25 px-6" />
               <td className="h-25 text-center">
-                <Cell value={row.cloud} />
+                <Button kind="gradient-primary" size="sm" onClick={onTryCloud}>
+                  Start on Cloud
+                </Button>
               </td>
               <td className="h-25 px-6 pl-0 text-center">
-                <Cell value={row.oss} />
+                <Button kind="quiet" size="sm" onClick={onSelfHost}>
+                  Self-host it
+                </Button>
               </td>
             </tr>
-          ))}
-          <tr data-testid="cta-row">
-            <td className="h-25 px-6" />
-            <td className="h-25 text-center">
-              <Button kind="gradient-primary" size="sm" onClick={onTryCloud}>
-                Start on Cloud
-              </Button>
-            </td>
-            <td className="h-25 px-6 pl-0 text-center">
-              <Button kind="quiet" size="sm" onClick={onSelfHost}>
-                Self-host it
-              </Button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/web/src/components/ui/ThreadBubble.tsx
+++ b/web/src/components/ui/ThreadBubble.tsx
@@ -67,7 +67,7 @@ export function ThreadBubble({
             ))}
           </span>
         ) : content === "image" && imageUrl ? (
-          <span className="relative block h-48 w-56">
+          <span className="relative block h-48 w-56 max-w-full">
             <Image src={imageUrl} alt="" fill sizes="224px" className="object-cover" />
           </span>
         ) : (


### PR DESCRIPTION
## Summary

P1 mobile-responsiveness pass **[Directive]**: home AND every dashboard route fully mobile responsive at 390 (768 sanity) — the document never side-scrolls; wide tables/charts sit in horizontal-scroll containers that scroll within the viewport.

### Fixes
- **ComparisonTable (A9)**: the Cloud-vs-OSS table clipped its "Self-host it" CTA behind `overflow-hidden` at 390 — the table now scrolls horizontally **within its card** (`overflow-x-auto` inner wrapper), per the wide-table rule.
- **Request stepper step 1**: `fieldset`'s default `min-inline-size: min-content` defeated SessionRow truncation and pushed snapshot rows past the 390 viewport (intro copy + freshness lines ran off-screen; the Continue CTA's row card clipped). Normalized with one `@layer base` rule — `fieldset { min-inline-size: 0 }` — fixing the class of bug for all fieldsets (AddressFieldset, manual-entry sheet included).
- **ThreadBubble image attachments**: fixed `w-56` cropped inside the 75% bubble at 390 — now `max-w-full`.

### e2e sweep (new `e2e/mobile-responsive.spec.ts`)
- Every public + dashboard route (19 routes: home, signin, post permalink, branded 404, and all 15 dashboard screens incl. settings sub-screens, order detail, onboarding, earnings, moderation) asserts `document.scrollWidth <= viewport` at **390 and 768**.
- Known-wide elements (`table`, `pre`, `code`) must sit inside an `overflow-x: auto|scroll` container whose own box fits the viewport — asserted on every route at 390.
- Regression tests: comparison-table CTA reachable by in-card scroll; stepper step-1 dialog has zero descendants outside the 390 viewport; order-thread attachments stay inside the bubble.
- Folds in and supersedes the old `dashboard.spec.ts` 390 sweep (12 routes → 19, adds 768 + containment).

### Verification
- 19 routes × {390, 768} × {light, dark} sweep clean on the TEST_MODE prod build (screenshots per route at 390 in both themes captured).
- Interactive overlays audited at 390: stepper steps 1–3, quote sheet + due-date picker, decline, dispute, confirm-delivery, capture options/webcam/manual/history sheets, explore post modal, followers sheet — all fit.
- Gates: lint ✓ typecheck ✓ unit (434) ✓ TEST_MODE build ✓ Playwright e2e (38) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)