### PR TITLE
feat(web): demo completeness — PR #102 review fixes, B2 filter chips, MI-6 infinite scroll, F2-9 exports

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -115,13 +115,22 @@ All under `/api/v1`, workspace/account auth as §2. Deltas only:
 
 | Group | Endpoints |
 | --- | --- |
-| Posts | `POST /posts` (designer) · `GET /posts/{id}` · `GET /feed` (followed + ranked) · `GET /explore?q&tags&price_band` (bands: `budget` <25k, `mid` 25–100k, `premium` >100k NGN **[Decided defaults]**) · `DELETE /posts/{id}` |
+| Posts | `POST /posts` (designer) · `GET /posts/{id}` · `GET /feed` (followed + ranked) · `GET /explore?q&tags&price_band&max_turnaround_days&near_me` (bands: `budget` <25k, `mid` 25–100k, `premium` >100k NGN **[Decided defaults]**; filter-chip params below) · `DELETE /posts/{id}` |
 | Social graph | `POST/DELETE /follows/{designer}` · `POST/DELETE /posts/{id}/like` · `POST/DELETE /posts/{id}/save` · `POST /posts/{id}/comments` (body ≤500 chars) · `GET /posts/{id}/comments` |
 | Trust & safety | `POST /reports` `{subject_kind, subject_id, reason}` · `POST/DELETE /blocks/{account}` · moderator: `GET /moderation/queue` · `POST /moderation/reports/{id}/action` `{action: hide_post\|suspend_account\|dismiss}` (A-6; semantics in data-model §6.2) |
 | Requests | `POST /posts/{id}/requests` (body: vault snapshot selector, notes, budget) · `GET /requests?role=customer\|designer` · `GET /requests/{id}` · `POST /requests/{id}/quote` · `POST /requests/{id}/decline` · `POST /requests/{id}/status` (in_progress/shipped — `delivered` is customer-confirm or system auto-confirm only, order-lifecycle §2) · `POST /requests/{id}/messages` |
 | Payments | `POST /requests/{id}/pay` (provider session) · `POST /webhooks/payments` (unversioned by design; **auth = provider signature only**, never bearer; unauthenticated-but-verified, engineering §2) · `POST /requests/{id}/confirm-delivery` (releases escrow) · `POST /requests/{id}/dispute` |
 | Designer | `POST /designer-profile` (enable + KYC start) · `GET /designer/earnings` · `POST /designer/payout-account` |
 | Notifications | `GET /notifications` · `POST /notifications/read` |
+
+Explore filter-chip params (pages.md B2) **[Proposed 2026-07-19 — mock
+implements]**: `max_turnaround_days` (positive integer) keeps only posts
+with `turnaround_days` within the bound; `near_me` (`1`) proximity-ranks
+results by the designer's `profile_location` against the caller's (X-10
+tier 1) — same city, then same state, then same country, with recency
+preserved within each tier. Proximity is a **ranking, never a hard gate**:
+locationless designers simply sort last, and callers without a profile
+location get plain recency order.
 
 Feed/explore are the only ranked endpoints (recency + follow affinity v1; no
 ML ranking until data exists). Ranked pagination **[Decided]**: cursors encode

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -249,6 +249,46 @@ realism pass **[Directive]** — the seed simulates actual user interaction:
 - Brand copy: "open-source" is hyphenated in prose; the community
   attribution reads "An open-source product by CueLABS™".
 
+**Demo-completeness as-built notes (2026-07-19):** the P1 completeness
+pass **[Directive]** — the review-fix set from the realism pass plus the
+approved gap implementations:
+
+- The post-detail modal (feed, explore, profile grids) opens on the
+  Sheet's `wide` size axis — a real desktop width (896px,
+  viewport-clamped), not a max-width fighting the base `md:w-*` utility —
+  and the owning list re-syncs that post from the server on modal close
+  (`useFeed.syncPost`), so cards never show stale like/save/comment state
+  after in-modal interactions.
+- Explore carries the full pages.md B2 chip set: style tags, price bands,
+  turnaround time (≤ 1 week / ≤ 2 weeks / ≤ 1 month →
+  `max_turnaround_days`), and "Near me" — proximity RANKING by designer
+  `profile_location` vs the caller's (api.md §5 param extension; city >
+  state > country, recency within tiers, locationless designers sort
+  last, no hard gate). The seed carries one non-Lagos designer
+  (`eniola.stitches`, Abuja, newest post) so the ranking is visible from
+  boot; unit + e2e gate both chips.
+- MI-6 feed infinite scroll is live: `/feed` pages through the api.md §4
+  cursor contract at page size 4, prefetches when the viewer is 3 cards
+  from the end (an IntersectionObserver over the last three cards),
+  renders skeleton ×2 while the page is in flight, and lands the
+  caught-up divider on cursor exhaustion.
+- F2-9 session exports: the vault history sheet exports any session as
+  CSV or PDF per row through `POST /sessions/{id}/exports` (the mock
+  returns inline data URLs — a real minimal PDF for `pdf` — where the
+  backend will return signed URLs); e2e asserts real browser downloads.
+- Seed coherence: #APR-1058 ("Little senator") is a gift order freezing
+  child-scale manual measurements entered at request time; #APR-1042's
+  note asks for a skirt-appropriate alteration.
+- The dashboard rail's two states are e2e-pinned
+  (`e2e/nav-rail-states.spec.ts`): expansion is viewport-driven
+  (collapsed 72px below 1264, expanded 244px at ≥1264; no user toggle,
+  no persisted state), so an expanded rail can never squeeze the mobile
+  content column; every dashboard route reflows cleanly at 1264/1440
+  with content contained in the column.
+- F0-8 Scalar embed at `/docs/api`: **[Proposed — deferred pending
+  ratification vs the GitBook links canon]** — the docs surface stays
+  the GitBook links inventory (§ nav/footer canon) until adjudicated.
+
 Screen-state parity **[Directive 2026-07-18, carried from design.md §8.1]**:
 every data-driven screen ships default, empty, and loading states — the
 three-frame rule applies to the implementation exactly as it does to the
@@ -340,7 +380,7 @@ with full CRUD; contract types shared with `src/models/`.
 | --- | --- |
 | Auth & consent | `GET/PATCH /me` · `GET/POST /consent` |
 | Vault (self-customer alias, data-model.md §6.1) | `GET/POST /me/sessions` · `GET /sessions/{id}` · `PATCH /sessions/{id}/measurements` · `POST /sessions/{id}/exports` |
-| Posts | `POST /posts` · `GET /posts/{id}` · `GET /feed` · `GET /explore?q&tags&price_band` · `DELETE /posts/{id}` |
+| Posts | `POST /posts` · `GET /posts/{id}` · `GET /feed` · `GET /explore?q&tags&price_band&max_turnaround_days&near_me` · `DELETE /posts/{id}` |
 | Social graph | `POST/DELETE /follows/{designer}` · `POST/DELETE /posts/{id}/like` · `/save` · `GET/POST /posts/{id}/comments` |
 | Trust & safety | `POST /reports` · `POST/DELETE /blocks/{account}` · `GET /moderation/queue` · `POST /moderation/reports/{id}/action` |
 | Requests | `POST /posts/{id}/requests` · `GET /requests?role=` · `GET /requests/{id}` · `/quote` · `/decline` · `/status` · `/messages` |

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -151,6 +151,38 @@ test("B3: the seeded list covers all ten lifecycle states", async ({ page }) => 
   }
 });
 
+test("B2 explore: turnaround chip filters; near-me proximity-ranks without dropping posts", async ({
+  page,
+}) => {
+  await signIn(page);
+  await page.goto("/dashboard/explore");
+  const tiles = page.getByLabel("Posts").locator("li");
+  const tileImgs = page.getByLabel("Posts").locator("li img");
+
+  // Default recency order leads with the newest post — the Abuja atelier.
+  await expect(tileImgs.first()).toHaveAttribute("alt", /atelier/);
+  const total = await tiles.count();
+
+  // "Near me" (kiki is Lagos-based): every Lagos designer's post ranks
+  // above the Abuja designer's; the Abuja post still renders — proximity
+  // is a ranking, never a hard gate (pages.md B2).
+  await page.getByRole("button", { name: "Near me" }).click();
+  await expect(tileImgs.first()).not.toHaveAttribute("alt", /atelier/);
+  await expect(tileImgs.last()).toHaveAttribute("alt", /atelier/);
+  await expect(tiles).toHaveCount(total);
+  await page.getByRole("button", { name: "Near me" }).click();
+
+  // Turnaround "≤ 1 week" keeps only the 7-day posts (both tunde's).
+  await page.getByRole("button", { name: "≤ 1 week" }).click();
+  await expect(tiles).toHaveCount(2);
+  await expect(tileImgs.first()).toHaveAttribute(
+    "alt",
+    "Two men in matching African print shirts",
+  );
+  await page.getByRole("button", { name: "≤ 1 week" }).click();
+  await expect(tiles).toHaveCount(total);
+});
+
 test("B4 vault: webcam QC failure → retake → capture → save; history delete", async ({
   page,
 }) => {

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -247,6 +247,23 @@ test("B4 vault: webcam QC failure → retake → capture → save; history delet
   await page.getByTestId("vault-grid").getByRole("button").first().click();
   const history = page.getByTestId("history-list");
   await expect(history).toBeVisible();
+
+  // F2-9: per-session export hands the browser a real download.
+  const csvDownload = page.waitForEvent("download");
+  await history
+    .getByRole("button", { name: "Export session as CSV" })
+    .first()
+    .click();
+  expect((await csvDownload).suggestedFilename()).toMatch(
+    /^apparule-session-\d{4}-\d{2}-\d{2}\.csv$/,
+  );
+  const pdfDownload = page.waitForEvent("download");
+  await history
+    .getByRole("button", { name: "Export session as PDF" })
+    .first()
+    .click();
+  expect((await pdfDownload).suggestedFilename()).toMatch(/\.pdf$/);
+
   const before = await history.locator("li").count();
   await history.getByRole("button", { name: "Delete session" }).first().click();
   await expect(history.locator("li")).toHaveCount(before - 1);

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -58,6 +58,39 @@ test("semantic landmarks: every dashboard screen renders one <main> and the prim
   }
 });
 
+// Runs BEFORE the B1 journey (serial file): the journey follows tunde,
+// which grows the feed past the canonical 7-post seed this test paginates.
+test("B1 MI-6: infinite scroll — cursor page prefetched near the end, skeleton ×2, caught-up", async ({
+  page,
+}) => {
+  // Slow the cursor page down so the MI-6 skeletons are observable.
+  await page.route(
+    (url) =>
+      url.pathname.endsWith("/api/mock/v1/feed") &&
+      url.searchParams.has("cursor"),
+    async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 700));
+      await route.continue();
+    },
+  );
+  await signIn(page);
+
+  const cards = page.getByTestId("feed-list").locator("> li");
+  // First ranked page (MI-6 page size 4 over the 7-post seeded feed).
+  await expect(cards).toHaveCount(4);
+
+  // Walking toward the end crosses the 3-from-end observer → prefetch;
+  // skeleton ×2 renders while the cursor page is in flight.
+  await cards.last().scrollIntoViewIfNeeded();
+  await expect(page.getByTestId("feed-loading-more")).toBeVisible();
+  await expect(cards).toHaveCount(7);
+  await expect(page.getByTestId("feed-loading-more")).toHaveCount(0);
+
+  // Cursor exhausted → the MI-6 caught-up divider.
+  await cards.last().scrollIntoViewIfNeeded();
+  await expect(page.getByText(/all caught up/i)).toBeVisible();
+});
+
 test("B1 journey: like/save/follow → request stepper → order → quote → pay → escrow-held → thread MI-17", async ({
   page,
   request,

--- a/web/e2e/nav-rail-states.spec.ts
+++ b/web/e2e/nav-rail-states.spec.ts
@@ -1,0 +1,178 @@
+// NavRail state sweep [Directive 2026-07-19]: the dashboard chrome is a
+// viewport-driven rail — collapsed 72px below 1264, expanded 244px at
+// ≥1264 — with NO user toggle and NO persisted expanded state. Two duties:
+//
+// 1. Mobile (<md): an expanded rail must NEVER squeeze the main content.
+//    Apparule's shape makes that structurally impossible (the expanded
+//    rail is display-hidden below 1264 and nothing can re-enable it);
+//    this spec pins the shape so a future toggle/persistence change that
+//    leaks an expanded rail into mobile fails CI.
+// 2. Desktop ≥1264: the expanded rail squeezes the content column hardest
+//    at 1264 — every dashboard route must reflow cleanly in BOTH states
+//    (no document side-scroll, no element escaping the viewport outside a
+//    fitting scroll container).
+import { expect, test, type Page } from "@playwright/test";
+
+const DASHBOARD_ROUTES = [
+  "/dashboard",
+  "/dashboard/explore",
+  "/dashboard/orders",
+  "/dashboard/orders/req-apr-1042",
+  "/dashboard/vault",
+  "/dashboard/create",
+  "/dashboard/kiki.adeyemi",
+  "/dashboard/amara.designs",
+  "/dashboard/settings",
+  "/dashboard/settings/notifications",
+  "/dashboard/settings/privacy",
+  "/dashboard/settings/account",
+  "/dashboard/admin/moderation",
+  "/dashboard/designer/onboarding",
+  "/dashboard/earnings",
+];
+
+// The widest screens — screenshotted in both rail states for the report.
+const WORST_OFFENDERS = [
+  "/dashboard/orders/req-apr-1042",
+  "/dashboard/explore",
+  "/dashboard/admin/moderation",
+  "/dashboard/earnings",
+];
+
+async function signIn(page: Page) {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: /continue with google/i }).click();
+  await page.waitForURL("**/dashboard");
+}
+
+async function settle(page: Page, route: string) {
+  await page.goto(route);
+  await expect(page.locator("main")).toBeVisible();
+  await page.waitForTimeout(400);
+}
+
+const visibleRail = (page: Page) =>
+  page.locator('nav[aria-label="Primary"]:visible');
+
+const docOverflow = (page: Page) =>
+  page.evaluate(
+    () =>
+      document.documentElement.scrollWidth -
+      document.documentElement.clientWidth,
+  );
+
+// Every rendered element inside <main> must either fit the viewport
+// horizontally or sit inside an overflow-x scroll container that itself
+// fits (the mobile-sweep containment rule, applied to the squeezed
+// desktop content column).
+const contentColumnViolations = (page: Page) =>
+  page.evaluate(() => {
+    const vw = document.documentElement.clientWidth;
+    const violations: string[] = [];
+    const fits = (r: DOMRect) => r.right <= vw + 1 && r.left >= -1;
+    const scrollContainerOf = (el: Element): Element | null => {
+      for (let a = el.parentElement; a; a = a.parentElement) {
+        const s = getComputedStyle(a);
+        if (s.overflowX === "auto" || s.overflowX === "scroll") return a;
+      }
+      return null;
+    };
+    const main = document.querySelector("main");
+    if (!main) return ["no <main> landmark"];
+    for (const el of main.querySelectorAll("*")) {
+      const r = el.getBoundingClientRect();
+      if (!r.width || !r.height) continue;
+      if (fits(r)) continue;
+      const container = scrollContainerOf(el);
+      if (!container) {
+        violations.push(
+          `<${el.tagName.toLowerCase()} class="${el.className
+            .toString()
+            .slice(0, 60)}"> escapes the viewport without a scroll container`,
+        );
+      } else if (!fits(container.getBoundingClientRect())) {
+        violations.push(
+          `<${el.tagName.toLowerCase()}> scroll container itself escapes the viewport`,
+        );
+      }
+      if (violations.length >= 5) break;
+    }
+    return violations;
+  });
+
+test("mobile 390: only the collapsed 72px rail exists — an expanded rail cannot squeeze content", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await signIn(page);
+  for (const route of ["/dashboard", "/dashboard/orders", "/dashboard/vault"]) {
+    await settle(page, route);
+    const rail = visibleRail(page);
+    await expect(rail, `${route}: one visible rail`).toHaveCount(1);
+    await expect(rail).toHaveAttribute("data-expanded", "false");
+    const railBox = (await rail.boundingBox())!;
+    expect(railBox.width, `${route}: collapsed rail width`).toBeLessThanOrEqual(
+      72,
+    );
+    // the expanded (244px) rail is display-hidden, not merely offscreen
+    await expect(
+      page.locator('nav[aria-label="Primary"][data-expanded="true"]'),
+    ).toBeHidden();
+    // main takes the rest of the viewport — content is never squeezed
+    const mainBox = (await page.locator("main").boundingBox())!;
+    expect(mainBox.width, `${route}: content column width`).toBeGreaterThanOrEqual(
+      390 - 72 - 2,
+    );
+    expect(await docOverflow(page), `${route}: no side-scroll`).toBeLessThanOrEqual(
+      2,
+    );
+  }
+});
+
+for (const width of [1264, 1440]) {
+  test(`expanded rail at ${width}: every dashboard route reflows inside the squeezed content column`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width, height: 900 });
+    await signIn(page);
+    for (const route of DASHBOARD_ROUTES) {
+      await settle(page, route);
+      const rail = visibleRail(page);
+      await expect(rail, `${route}: one visible rail`).toHaveCount(1);
+      await expect(rail).toHaveAttribute("data-expanded", "true");
+      expect(
+        (await rail.boundingBox())!.width,
+        `${route}: expanded rail width`,
+      ).toBeGreaterThanOrEqual(243);
+      expect(
+        await docOverflow(page),
+        `${route}: no horizontal document scroll at ${width}`,
+      ).toBeLessThanOrEqual(2);
+      expect(
+        await contentColumnViolations(page),
+        `${route}: content containment at ${width}`,
+      ).toEqual([]);
+    }
+  });
+}
+
+test("worst offenders screenshot in both rail states (1263 collapsed / 1264 expanded)", async ({
+  page,
+}, testInfo) => {
+  await signIn(page);
+  for (const route of WORST_OFFENDERS) {
+    for (const width of [1263, 1264]) {
+      await page.setViewportSize({ width, height: 900 });
+      await settle(page, route);
+      const state = width >= 1264 ? "expanded" : "collapsed";
+      await expect(visibleRail(page)).toHaveAttribute(
+        "data-expanded",
+        String(width >= 1264),
+      );
+      await testInfo.attach(
+        `${route.replaceAll("/", "_")}@${width}-${state}`,
+        { body: await page.screenshot({ fullPage: true }), contentType: "image/png" },
+      );
+    }
+  }
+});

--- a/web/src/app/api/mock/v1/explore/route.ts
+++ b/web/src/app/api/mock/v1/explore/route.ts
@@ -2,7 +2,7 @@
 // (api.md §5 — bands: budget <25k, mid 25–100k, premium >100k NGN;
 // max_turnaround_days + near_me are the 2026-07-19 filter-chip extension —
 // near_me proximity-ranks by designer profile_location vs the caller's).
-import { actorUsername, handle, jsonResponse, paginate } from "@/mocks/http";
+import { actorUsername, handle, jsonResponse, parseLimit } from "@/mocks/http";
 import { getStore } from "@/mocks/store";
 
 export async function GET(request: Request) {
@@ -24,14 +24,17 @@ export async function GET(request: Request) {
         : undefined;
     const nearRaw = url.searchParams.get("near_me");
     const nearMe = nearRaw === "1" || nearRaw === "true";
-    const posts = getStore().explore(
-      actorUsername(request),
-      q,
-      tags,
-      priceBand,
-      maxTurnaroundDays,
-      nearMe,
+    const actor = actorUsername(request);
+    const store = getStore();
+    // Ranked endpoint — cursor pages come from a frozen rank snapshot
+    // ([Decided] ranked pagination), same as /feed.
+    return jsonResponse(
+      store.rankedPage(
+        actor,
+        () => store.explore(actor, q, tags, priceBand, maxTurnaroundDays, nearMe),
+        url.searchParams.get("cursor"),
+        parseLimit(url),
+      ),
     );
-    return jsonResponse(paginate(posts, url));
   });
 }

--- a/web/src/app/api/mock/v1/explore/route.ts
+++ b/web/src/app/api/mock/v1/explore/route.ts
@@ -1,5 +1,7 @@
-// Mock: GET /api/v1/explore?q&tags&price_band (api.md §5 — bands: budget
-// <25k, mid 25–100k, premium >100k NGN).
+// Mock: GET /api/v1/explore?q&tags&price_band&max_turnaround_days&near_me
+// (api.md §5 — bands: budget <25k, mid 25–100k, premium >100k NGN;
+// max_turnaround_days + near_me are the 2026-07-19 filter-chip extension —
+// near_me proximity-ranks by designer profile_location vs the caller's).
 import { actorUsername, handle, jsonResponse, paginate } from "@/mocks/http";
 import { getStore } from "@/mocks/store";
 
@@ -13,7 +15,23 @@ export async function GET(request: Request) {
       bandRaw === "budget" || bandRaw === "mid" || bandRaw === "premium"
         ? bandRaw
         : undefined;
-    const posts = getStore().explore(actorUsername(request), q, tags, priceBand);
+    const turnaroundRaw = Number(
+      url.searchParams.get("max_turnaround_days") ?? "",
+    );
+    const maxTurnaroundDays =
+      Number.isFinite(turnaroundRaw) && turnaroundRaw > 0
+        ? Math.floor(turnaroundRaw)
+        : undefined;
+    const nearRaw = url.searchParams.get("near_me");
+    const nearMe = nearRaw === "1" || nearRaw === "true";
+    const posts = getStore().explore(
+      actorUsername(request),
+      q,
+      tags,
+      priceBand,
+      maxTurnaroundDays,
+      nearMe,
+    );
     return jsonResponse(paginate(posts, url));
   });
 }

--- a/web/src/app/api/mock/v1/feed/route.ts
+++ b/web/src/app/api/mock/v1/feed/route.ts
@@ -1,10 +1,21 @@
-// Mock: GET /api/v1/feed — followed + recency-ranked (api.md §5).
-import { actorUsername, handle, jsonResponse, paginate } from "@/mocks/http";
+// Mock: GET /api/v1/feed — followed + recency-ranked (api.md §5), cursor
+// pages served from a rank snapshot frozen per scroll session ([Decided]
+// ranked pagination — never duplicates or skips mid-scroll).
+import { actorUsername, handle, jsonResponse, parseLimit } from "@/mocks/http";
 import { getStore } from "@/mocks/store";
 
 export async function GET(request: Request) {
   return handle(() => {
-    const posts = getStore().feed(actorUsername(request));
-    return jsonResponse(paginate(posts, new URL(request.url)));
+    const url = new URL(request.url);
+    const actor = actorUsername(request);
+    const store = getStore();
+    return jsonResponse(
+      store.rankedPage(
+        actor,
+        () => store.feed(actor),
+        url.searchParams.get("cursor"),
+        parseLimit(url),
+      ),
+    );
   });
 }

--- a/web/src/app/api/mock/v1/sessions/[id]/exports/route.ts
+++ b/web/src/app/api/mock/v1/sessions/[id]/exports/route.ts
@@ -4,6 +4,7 @@ import {
   actorUsername,
   handle,
   jsonResponse,
+  MockApiError,
   readJson,
 } from "@/mocks/http";
 import { getStore } from "@/mocks/store";
@@ -13,9 +14,17 @@ type Params = { params: Promise<{ id: string }> };
 export async function POST(request: Request, { params }: Params) {
   return handle(async () => {
     const { id } = await params;
-    const body = await readJson<{ format?: "csv" | "pdf" }>(request);
+    const body = await readJson<{ format?: string }>(request);
+    const format = body.format ?? "csv";
+    if (format !== "csv" && format !== "pdf") {
+      throw new MockApiError(
+        "validation_failed",
+        "format must be csv or pdf",
+        422,
+      );
+    }
     return jsonResponse(
-      getStore().sessionExport(id, actorUsername(request), body.format ?? "csv"),
+      getStore().sessionExport(id, actorUsername(request), format),
       201,
     );
   });

--- a/web/src/components/dashboard/explore/ExploreView.tsx
+++ b/web/src/components/dashboard/explore/ExploreView.tsx
@@ -225,10 +225,15 @@ export function ExploreView() {
       <Sheet
         open={openPostId !== null}
         onOpenChange={(open) => {
-          if (!open) setOpenPostId(null);
+          if (!open) {
+            // Sync the grid tile's counts back on close — the modal's
+            // usePost mutations don't touch this list (PR #102 review).
+            if (openPostId) void explore.syncPost(openPostId);
+            setOpenPostId(null);
+          }
         }}
         title="Post"
-        className="max-w-4xl"
+        size="wide"
       >
         {openPostId ? (
           <PostDetailView

--- a/web/src/components/dashboard/explore/ExploreView.tsx
+++ b/web/src/components/dashboard/explore/ExploreView.tsx
@@ -30,6 +30,13 @@ const PRICE_BANDS = [
   { value: "premium", label: "Over ₦100k" },
 ] as const;
 
+// Turnaround-time chips (pages.md B2) — single-select max-days buckets.
+const TURNAROUNDS = [
+  { value: 7, label: "≤ 1 week" },
+  { value: 14, label: "≤ 2 weeks" },
+  { value: 30, label: "≤ 1 month" },
+] as const;
+
 export function ExploreView() {
   const explore = useExplore();
   const { showToast } = useToasts();
@@ -117,6 +124,30 @@ export function ExploreView() {
               />
             </li>
           ))}
+          {TURNAROUNDS.map((t) => (
+            <li key={t.value}>
+              <Chip
+                label={t.label}
+                kind={
+                  explore.maxTurnaround === t.value ? "selected" : "default"
+                }
+                onClick={() =>
+                  explore.setMaxTurnaround(
+                    explore.maxTurnaround === t.value ? undefined : t.value,
+                  )
+                }
+              />
+            </li>
+          ))}
+          <li>
+            {/* Proximity ranking (designer location vs your profile
+                location) — re-orders, never excludes (pages.md B2). */}
+            <Chip
+              label="Near me"
+              kind={explore.nearMe ? "selected" : "default"}
+              onClick={() => explore.setNearMe(!explore.nearMe)}
+            />
+          </li>
           {tagOptions.map((tag) => (
             <li key={tag}>
               <Chip

--- a/web/src/components/dashboard/feed/FeedView.tsx
+++ b/web/src/components/dashboard/feed/FeedView.tsx
@@ -188,10 +188,15 @@ export function FeedView() {
       <Sheet
         open={openPostId !== null}
         onOpenChange={(open) => {
-          if (!open) setOpenPostId(null);
+          if (!open) {
+            // Modal mutations live in PostDetailView's own usePost — sync
+            // the rendered feed item back on close (PR #102 review).
+            if (openPostId) void feed.syncPost(openPostId);
+            setOpenPostId(null);
+          }
         }}
         title="Post"
-        className="max-w-4xl"
+        size="wide"
       >
         {openPostId ? (
           <PostDetailView

--- a/web/src/components/dashboard/feed/FeedView.tsx
+++ b/web/src/components/dashboard/feed/FeedView.tsx
@@ -4,7 +4,7 @@
 // column with MI-1/2/3/4/9 + the request stepper CTA (MI-10) · right column
 // (freshness MI-11 + suggestions MI-7) · skeleton / empty / caught-up
 // states (MI-19, MI-6). Render-only over useFeed.
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import type { Post } from "@/models";
 import { useAuth } from "@/controllers/auth/AuthContext";
@@ -59,6 +59,25 @@ export function FeedView() {
     () => storyDesignersOf(feed.posts),
     [feed.posts],
   );
+
+  // MI-6 infinite scroll: prefetch the next ranked page when the viewer is
+  // 3 cards from the end — any of the last 3 cards entering the viewport
+  // fires (robust to jump-scrolls, not just smooth ones). The observed set
+  // moves as pages append; loadMore self-gates (cursor + in-flight ref).
+  const listRef = useRef<HTMLUListElement | null>(null);
+  const { loadMore, caughtUp } = feed;
+  const postCount = feed.posts.length;
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list || caughtUp || postCount === 0) return;
+    const cards = [...list.querySelectorAll(":scope > li")].slice(-3);
+    if (cards.length === 0) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) void loadMore();
+    });
+    for (const card of cards) observer.observe(card);
+    return () => observer.disconnect();
+  }, [loadMore, caughtUp, postCount]);
 
   const like = (post: Post) =>
     feed.toggleLike(post).catch(() =>
@@ -147,7 +166,7 @@ export function FeedView() {
           />
         ) : (
           <>
-            <ul className="flex flex-col gap-6" data-testid="feed-list">
+            <ul ref={listRef} className="flex flex-col gap-6" data-testid="feed-list">
               {feed.posts.map((post) => (
                 <li
                   key={post.id}
@@ -172,6 +191,18 @@ export function FeedView() {
                 </li>
               ))}
             </ul>
+            {feed.loadingMore ? (
+              // MI-6: skeleton ×2 while the next page is in flight (MI-19
+              // shimmer comes from the PostCard skeleton anatomy).
+              <div
+                aria-busy="true"
+                className="flex flex-col gap-6 pt-6"
+                data-testid="feed-loading-more"
+              >
+                <PostCard skeleton />
+                <PostCard skeleton />
+              </div>
+            ) : null}
             {feed.caughtUp ? <CaughtUpDivider className="py-6" /> : null}
           </>
         )}

--- a/web/src/components/dashboard/profile/ProfileView.tsx
+++ b/web/src/components/dashboard/profile/ProfileView.tsx
@@ -201,7 +201,7 @@ export function ProfileView({ username }: { username: string }) {
             if (!open) setOpenPostId(null);
           }}
           title="Post"
-          className="max-w-4xl"
+          size="wide"
         >
           {openPostId ? (
             <PostDetailView
@@ -383,7 +383,7 @@ export function ProfileView({ username }: { username: string }) {
           if (!open) setOpenPostId(null);
         }}
         title="Post"
-        className="max-w-4xl"
+        size="wide"
       >
         {openPostId ? (
           <PostDetailView

--- a/web/src/components/dashboard/profile/ProfileView.tsx
+++ b/web/src/components/dashboard/profile/ProfileView.tsx
@@ -101,7 +101,7 @@ function FollowListSheet({
 
 export function ProfileView({ username }: { username: string }) {
   const { account } = useAuth();
-  const { profile, posts, saved, loading, error, toggleFollow } =
+  const { profile, posts, saved, loading, error, toggleFollow, syncPost } =
     usePublicProfile(username);
   const { showToast } = useToasts();
   const [tab, setTab] = useState<"first" | "second">("first");
@@ -198,7 +198,12 @@ export function ProfileView({ username }: { username: string }) {
         <Sheet
           open={openPostId !== null}
           onOpenChange={(open) => {
-            if (!open) setOpenPostId(null);
+            if (!open) {
+              // Sync the grid tile(s) back on close — modal mutations live in
+              // the modal's own usePost (PR #103 review).
+              if (openPostId) void syncPost(openPostId);
+              setOpenPostId(null);
+            }
           }}
           title="Post"
           size="wide"
@@ -380,7 +385,12 @@ export function ProfileView({ username }: { username: string }) {
       <Sheet
         open={openPostId !== null}
         onOpenChange={(open) => {
-          if (!open) setOpenPostId(null);
+          if (!open) {
+            // Sync the grid tile(s) back on close — modal mutations live in
+            // the modal's own usePost (PR #103 review).
+            if (openPostId) void syncPost(openPostId);
+            setOpenPostId(null);
+          }
         }}
         title="Post"
         size="wide"

--- a/web/src/components/dashboard/vault/VaultView.tsx
+++ b/web/src/components/dashboard/vault/VaultView.tsx
@@ -45,6 +45,31 @@ export function VaultView() {
     return map;
   }, [vault.sessions]);
 
+  /** F2-9: fetch the export URL, then hand it to the browser as a save. */
+  const exportSession = (session: MeasurementSession, format: "csv" | "pdf") =>
+    vault.exportSession(session.id, format).then(
+      ({ url }) => {
+        const anchor = document.createElement("a");
+        anchor.href = url;
+        anchor.download = `apparule-session-${new Date(session.created_at)
+          .toISOString()
+          .slice(0, 10)}.${format}`;
+        document.body.appendChild(anchor);
+        anchor.click();
+        anchor.remove();
+        showToast({
+          kind: "success",
+          message: `Exporting session as ${format.toUpperCase()}`,
+        });
+      },
+      () =>
+        showToast({
+          kind: "error",
+          message: "Couldn't export the session",
+          onRetry: () => void exportSession(session, format),
+        }),
+    );
+
   /** Oldest → newest values per metric for the sparkline. */
   const historyFor = (name: string): number[] =>
     [...vault.sessions]
@@ -196,6 +221,7 @@ export function VaultView() {
               <li key={session.id}>
                 <SessionRow
                   session={session}
+                  onExport={(format) => void exportSession(session, format)}
                   onDelete={() =>
                     vault.deleteSession(session.id).then(
                       () =>

--- a/web/src/components/ui/SessionRow.test.tsx
+++ b/web/src/components/ui/SessionRow.test.tsx
@@ -17,6 +17,26 @@ describe("SessionRow (§8.2b)", () => {
     expect(onDelete).toHaveBeenCalledOnce();
   });
 
+  it("history context: F2-9 export affordances fire per format", async () => {
+    const onExport = vi.fn();
+    render(<SessionRow session={fixtureSession} onExport={onExport} />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Export session as CSV" }),
+    );
+    expect(onExport).toHaveBeenCalledWith("csv");
+    await userEvent.click(
+      screen.getByRole("button", { name: "Export session as PDF" }),
+    );
+    expect(onExport).toHaveBeenCalledWith("pdf");
+  });
+
+  it("omits the export affordance when no handler is wired (picker rows)", () => {
+    render(<SessionRow session={fixtureSession} />);
+    expect(
+      screen.queryByRole("button", { name: /Export session/ }),
+    ).not.toBeInTheDocument();
+  });
+
   it("picker context: radio + freshness pill, selected state", () => {
     render(
       <SessionRow session={fixtureSession} context="picker" selected />,

--- a/web/src/components/ui/SessionRow.tsx
+++ b/web/src/components/ui/SessionRow.tsx
@@ -4,7 +4,7 @@
 // values + delete) / picker (radio select + freshness warning fresh /
 // aging / stale) · state default / selected.
 import clsx from "clsx";
-import { Trash2 } from "lucide-react";
+import { FileDown, Trash2 } from "lucide-react";
 import type { MeasurementSession } from "@/models";
 import { freshnessOf } from "@/models";
 import { formatCm } from "@/lib/format";
@@ -19,6 +19,8 @@ export interface SessionRowProps {
   selected?: boolean;
   onSelect?: () => void;
   onDelete?: () => void;
+  /** F2-9 per-session export (history context only): pdf/csv → signed URL. */
+  onExport?: (format: "csv" | "pdf") => void;
   className?: string;
 }
 
@@ -36,6 +38,7 @@ export function SessionRow({
   selected = false,
   onSelect,
   onDelete,
+  onExport,
   className,
 }: SessionRowProps) {
   const freshness = freshnessOf(session.created_at);
@@ -117,6 +120,31 @@ export function SessionRow({
       )}
     >
       {body}
+      {onExport ? (
+        // F2-9: per-session export, both documented formats (api.md §2).
+        <span className="flex shrink-0 items-center gap-1">
+          <FileDown size={16} aria-hidden className="text-text-2" />
+          <button
+            type="button"
+            aria-label="Export session as CSV"
+            onClick={() => onExport("csv")}
+            className="text-caption font-semibold text-link"
+          >
+            CSV
+          </button>
+          <span aria-hidden className="text-caption text-text-2">
+            ·
+          </span>
+          <button
+            type="button"
+            aria-label="Export session as PDF"
+            onClick={() => onExport("pdf")}
+            className="text-caption font-semibold text-link"
+          >
+            PDF
+          </button>
+        </span>
+      ) : null}
       <button
         type="button"
         aria-label="Delete session"

--- a/web/src/components/ui/Sheet.test.tsx
+++ b/web/src/components/ui/Sheet.test.tsx
@@ -44,6 +44,26 @@ describe("Sheet (§8.2)", () => {
     ).toHaveAttribute("aria-current", "step");
   });
 
+  it("desktop width follows the size axis (default 480px modal, wide post-detail)", () => {
+    const { rerender } = render(
+      <Sheet open onOpenChange={() => {}} title="Post">
+        <p>Body</p>
+      </Sheet>,
+    );
+    // default: the 480px secondary-flow modal
+    expect(screen.getByRole("dialog").className).toContain("md:w-[480px]");
+    rerender(
+      <Sheet open onOpenChange={() => {}} title="Post" size="wide">
+        <p>Body</p>
+      </Sheet>,
+    );
+    // wide: a real md width (not a max-width fighting the base md:w-*),
+    // viewport-clamped — the two-column PostDetailView needs the room
+    const wide = screen.getByRole("dialog").className;
+    expect(wide).not.toContain("md:w-[480px]");
+    expect(wide).toContain("md:w-[min(56rem,calc(100vw-4rem))]");
+  });
+
   it("close affordance fires onOpenChange(false)", async () => {
     const onOpenChange = vi.fn();
     render(

--- a/web/src/components/ui/Sheet.tsx
+++ b/web/src/components/ui/Sheet.tsx
@@ -15,21 +15,39 @@ export interface SheetStepper {
   current: number;
 }
 
+export type SheetSize = "default" | "wide";
+
 export interface SheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   title: string;
   /** Optional MI-10 stepper header (Measurements → Notes/Budget → Review). */
   stepper?: SheetStepper;
+  /**
+   * Desktop width: `default` is the 480px secondary-flow modal; `wide` is
+   * the two-column post-detail modal (B2's IG desktop pattern) — a real
+   * width, not a max-width, because same-property Tailwind utilities
+   * resolve by stylesheet order (layout canon), so callers must never
+   * try to out-class the base `md:w-*`.
+   */
+  size?: SheetSize;
   children: ReactNode;
   className?: string;
 }
+
+// Wide clamps to the viewport (floating-layer canon) below its 896px
+// (max-w-4xl-equivalent) desktop width.
+const SIZE_CLASSES: Record<SheetSize, string> = {
+  default: "md:w-[480px]",
+  wide: "md:w-[min(56rem,calc(100vw-4rem))]",
+};
 
 export function Sheet({
   open,
   onOpenChange,
   title,
   stepper,
+  size = "default",
   children,
   className,
 }: SheetProps) {
@@ -42,7 +60,8 @@ export function Sheet({
             // z-40 sheet/modal layer; bottom sheet <md, centered modal ≥md
             "fixed z-40 flex max-h-[85vh] w-full flex-col overflow-hidden bg-bg-elev",
             "inset-x-0 bottom-0 rounded-t-card shadow-[0_-4px_8px_rgba(0,0,0,0.2)]",
-            "md:inset-x-auto md:bottom-auto md:left-1/2 md:top-1/2 md:w-[480px] md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-card md:shadow-lg",
+            "md:inset-x-auto md:bottom-auto md:left-1/2 md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-card md:shadow-lg",
+            SIZE_CLASSES[size],
             className,
           )}
         >

--- a/web/src/controllers/use-explore.ts
+++ b/web/src/controllers/use-explore.ts
@@ -33,6 +33,12 @@ export function useExplore() {
   const [priceBand, setPriceBand] = useState<
     "budget" | "mid" | "premium" | undefined
   >(undefined);
+  /** Turnaround-time chip — max days, single-select like the price bands. */
+  const [maxTurnaround, setMaxTurnaround] = useState<number | undefined>(
+    undefined,
+  );
+  /** "Near me" chip — proximity ranking, never a hard gate (pages.md B2). */
+  const [nearMe, setNearMe] = useState(false);
   // Lazy init: reads localStorage once; hydration-safe because the recent
   // dropdown only renders after a client-side focus interaction.
   const [recent, setRecent] = useState<string[]>(readRecent);
@@ -44,8 +50,10 @@ export function useExplore() {
       q: submitted ?? undefined,
       tags: tags.length > 0 ? tags : undefined,
       price_band: priceBand,
+      max_turnaround_days: maxTurnaround,
+      near_me: nearMe || undefined,
     }),
-    [submitted, tags, priceBand],
+    [submitted, tags, priceBand, maxTurnaround, nearMe],
   );
 
   const feed = useFeed("explore", filters);
@@ -139,6 +147,10 @@ export function useExplore() {
     toggleTag,
     priceBand,
     setPriceBand,
+    maxTurnaround,
+    setMaxTurnaround,
+    nearMe,
+    setNearMe,
     designers,
     designersLoading,
     toggleDesignerFollow,

--- a/web/src/controllers/use-feed.test.ts
+++ b/web/src/controllers/use-feed.test.ts
@@ -1,0 +1,115 @@
+// Feed controller — optimistic toggles (MI-18) and the post-modal sync
+// seam: PostDetailView mutates its own usePost state, so the owning list
+// re-syncs the item on modal close (PR #102 review).
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { Post } from "@/models";
+
+const feed = vi.fn();
+const explore = vi.fn();
+vi.mock("@/models/repositories/feed-repo", () => ({
+  feedRepo: {
+    feed: (...a: unknown[]) => feed(...a),
+    explore: (...a: unknown[]) => explore(...a),
+  },
+}));
+
+const get = vi.fn();
+const like = vi.fn();
+const unlike = vi.fn();
+const save = vi.fn();
+const unsave = vi.fn();
+vi.mock("@/models/repositories/posts-repo", () => ({
+  postsRepo: {
+    get: (...a: unknown[]) => get(...a),
+    like: (...a: unknown[]) => like(...a),
+    unlike: (...a: unknown[]) => unlike(...a),
+    save: (...a: unknown[]) => save(...a),
+    unsave: (...a: unknown[]) => unsave(...a),
+  },
+}));
+
+import { useFeed } from "./use-feed";
+
+function post(id: string, overrides: Partial<Post> = {}): Post {
+  return {
+    id,
+    designer: {
+      id: "des-1",
+      username: "amara.designs",
+      display_name: "Amara Designs",
+      avatar_url: null,
+      verified: true,
+    },
+    caption: `caption-${id}`,
+    style_tags: ["ankara"],
+    base_price_cents: 4_500_000,
+    currency: "NGN",
+    turnaround_days: 14,
+    media: [],
+    like_count: 3,
+    comment_count: 1,
+    liked: false,
+    saved: false,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  feed.mockReset();
+  get.mockReset();
+  like.mockReset();
+  unlike.mockReset();
+  save.mockReset();
+  unsave.mockReset();
+});
+
+describe("useFeed", () => {
+  it("syncPost replaces the rendered item with the server copy", async () => {
+    const stale = post("p1");
+    feed.mockResolvedValue({ items: [stale, post("p2")], next_cursor: null });
+    // The modal liked + commented: server state moved on without the list.
+    get.mockResolvedValue(
+      post("p1", { liked: true, like_count: 4, comment_count: 2 }),
+    );
+
+    const { result } = renderHook(() => useFeed("feed"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await act(() => result.current.syncPost("p1"));
+
+    const synced = result.current.posts.find((p) => p.id === "p1")!;
+    expect(synced.liked).toBe(true);
+    expect(synced.like_count).toBe(4);
+    expect(synced.comment_count).toBe(2);
+    // untouched siblings keep their identity
+    expect(result.current.posts.map((p) => p.id)).toEqual(["p1", "p2"]);
+  });
+
+  it("syncPost keeps the rendered item when the refetch fails", async () => {
+    feed.mockResolvedValue({ items: [post("p1")], next_cursor: null });
+    get.mockRejectedValue(new Error("offline"));
+
+    const { result } = renderHook(() => useFeed("feed"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await act(() => result.current.syncPost("p1"));
+
+    expect(result.current.posts).toHaveLength(1);
+    expect(result.current.posts[0].like_count).toBe(3);
+  });
+
+  it("toggleLike is optimistic and rolls back on failure (MI-18)", async () => {
+    const p = post("p1");
+    feed.mockResolvedValue({ items: [p], next_cursor: null });
+    like.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useFeed("feed"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await expect(
+      act(() => result.current.toggleLike(result.current.posts[0])),
+    ).rejects.toThrow("like_failed");
+
+    expect(result.current.posts[0].liked).toBe(false);
+    expect(result.current.posts[0].like_count).toBe(3);
+  });
+});

--- a/web/src/controllers/use-feed.test.ts
+++ b/web/src/controllers/use-feed.test.ts
@@ -98,6 +98,56 @@ describe("useFeed", () => {
     expect(result.current.posts[0].like_count).toBe(3);
   });
 
+  it("paginates the feed: MI-6 loadMore appends the cursor page, then caught-up", async () => {
+    feed.mockResolvedValueOnce({
+      items: [post("p1"), post("p2"), post("p3"), post("p4")],
+      next_cursor: "c2",
+    });
+    feed.mockResolvedValueOnce({
+      items: [post("p5"), post("p6"), post("p7")],
+      next_cursor: null,
+    });
+
+    const { result } = renderHook(() => useFeed("feed"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    // The feed requests the MI-6 page size, not the api.md default 50.
+    expect(feed).toHaveBeenCalledWith(undefined, 4);
+    expect(result.current.posts).toHaveLength(4);
+    expect(result.current.caughtUp).toBe(false);
+
+    await act(() => result.current.loadMore());
+    expect(feed).toHaveBeenLastCalledWith("c2", 4);
+    expect(result.current.posts.map((p) => p.id)).toEqual([
+      "p1", "p2", "p3", "p4", "p5", "p6", "p7",
+    ]);
+    expect(result.current.caughtUp).toBe(true);
+
+    // exhausted cursor → further loadMore calls are no-ops
+    await act(() => result.current.loadMore());
+    expect(feed).toHaveBeenCalledTimes(2);
+  });
+
+  it("gates concurrent loadMore calls to one in-flight page request", async () => {
+    feed.mockResolvedValueOnce({ items: [post("p1")], next_cursor: "c2" });
+    let release!: (v: { items: Post[]; next_cursor: null }) => void;
+    feed.mockImplementationOnce(
+      () => new Promise((resolve) => { release = resolve; }),
+    );
+
+    const { result } = renderHook(() => useFeed("feed"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      // the MI-6 observer can re-fire while the page is in flight
+      const first = result.current.loadMore();
+      const second = result.current.loadMore();
+      release({ items: [post("p2")], next_cursor: null });
+      await Promise.all([first, second]);
+    });
+    expect(feed).toHaveBeenCalledTimes(2); // initial load + ONE page fetch
+    expect(result.current.posts).toHaveLength(2);
+  });
+
   it("toggleLike is optimistic and rolls back on failure (MI-18)", async () => {
     const p = post("p1");
     feed.mockResolvedValue({ items: [p], next_cursor: null });

--- a/web/src/controllers/use-feed.ts
+++ b/web/src/controllers/use-feed.ts
@@ -25,6 +25,13 @@ function togglePost(
   return posts.map((p) => (p.id === id ? mutate(p) : p));
 }
 
+/**
+ * MI-6 feed page size: small enough that the seeded 7-post feed exercises
+ * cursor pagination from boot (prefetch at 3 cards from the end, skeleton
+ * ×2 during the fetch). Explore keeps the api.md §4 default (50).
+ */
+export const FEED_PAGE_SIZE = 4;
+
 export function useFeed(mode: "feed" | "explore" = "feed", filters?: ExploreFilters) {
   const [state, setState] = useState<FeedState>({
     posts: [],
@@ -34,6 +41,7 @@ export function useFeed(mode: "feed" | "explore" = "feed", filters?: ExploreFilt
     caughtUp: false,
   });
   const cursorRef = useRef<string | null>(null);
+  const loadingMoreRef = useRef(false);
   const filtersKey = JSON.stringify(filters ?? {});
 
   // Effect-safe fetch (react-hooks/set-state-in-effect): setState only in
@@ -42,7 +50,7 @@ export function useFeed(mode: "feed" | "explore" = "feed", filters?: ExploreFilt
   const load = useCallback(() => {
     const request =
       mode === "feed"
-        ? feedRepo.feed()
+        ? feedRepo.feed(undefined, FEED_PAGE_SIZE)
         : feedRepo.explore(JSON.parse(filtersKey));
     return request.then(
       (page) => {
@@ -77,12 +85,15 @@ export function useFeed(mode: "feed" | "explore" = "feed", filters?: ExploreFilt
 
   const loadMore = useCallback(async () => {
     const cursor = cursorRef.current;
-    if (!cursor) return;
+    // The MI-6 intersection prefetch can re-fire while a page is in
+    // flight — the ref gate keeps one request per cursor.
+    if (!cursor || loadingMoreRef.current) return;
+    loadingMoreRef.current = true;
     setState((s) => ({ ...s, loadingMore: true }));
     try {
       const page =
         mode === "feed"
-          ? await feedRepo.feed(cursor)
+          ? await feedRepo.feed(cursor, FEED_PAGE_SIZE)
           : await feedRepo.explore(JSON.parse(filtersKey), cursor);
       cursorRef.current = page.next_cursor;
       setState((s) => ({
@@ -93,6 +104,8 @@ export function useFeed(mode: "feed" | "explore" = "feed", filters?: ExploreFilt
       }));
     } catch {
       setState((s) => ({ ...s, loadingMore: false }));
+    } finally {
+      loadingMoreRef.current = false;
     }
   }, [mode, filtersKey]);
 

--- a/web/src/controllers/use-feed.ts
+++ b/web/src/controllers/use-feed.ts
@@ -96,6 +96,24 @@ export function useFeed(mode: "feed" | "explore" = "feed", filters?: ExploreFilt
     }
   }, [mode, filtersKey]);
 
+  /**
+   * Re-sync one rendered item from the server — the in-app post modal
+   * (PostDetailView over its own usePost) mutates likes/saves/comments
+   * independently, so the owning list refreshes that post when the modal
+   * closes; the feed card never shows stale counts (PR #102 review).
+   */
+  const syncPost = useCallback(async (id: string) => {
+    try {
+      const fresh = await postsRepo.get(id);
+      setState((s) => ({
+        ...s,
+        posts: togglePost(s.posts, id, () => fresh),
+      }));
+    } catch {
+      // keep the rendered item; the next reload converges it
+    }
+  }, []);
+
   /** Optimistic like toggle (MI-1/MI-2 + MI-18 rollback). */
   const toggleLike = useCallback(async (post: Post) => {
     const liked = !post.liked;
@@ -141,5 +159,5 @@ export function useFeed(mode: "feed" | "explore" = "feed", filters?: ExploreFilt
     }
   }, []);
 
-  return { ...state, reload, loadMore, toggleLike, toggleSave };
+  return { ...state, reload, loadMore, syncPost, toggleLike, toggleSave };
 }

--- a/web/src/controllers/use-public-profile.test.ts
+++ b/web/src/controllers/use-public-profile.test.ts
@@ -1,0 +1,110 @@
+// Public-profile controller — the post-modal sync seam (PR #103 review):
+// modal mutations live in the modal's own usePost, so the profile grids
+// re-sync the post (and the self-only saved grid) on modal close.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { Post } from "@/models";
+
+const profileGet = vi.fn();
+const profilePosts = vi.fn();
+const profileSaved = vi.fn();
+vi.mock("@/models/repositories/profiles-repo", () => ({
+  profilesRepo: {
+    get: (...a: unknown[]) => profileGet(...a),
+    posts: (...a: unknown[]) => profilePosts(...a),
+    saved: (...a: unknown[]) => profileSaved(...a),
+    followers: vi.fn(),
+    following: vi.fn(),
+  },
+}));
+
+const postGet = vi.fn();
+vi.mock("@/models/repositories/posts-repo", () => ({
+  postsRepo: {
+    get: (...a: unknown[]) => postGet(...a),
+    follow: vi.fn(),
+    unfollow: vi.fn(),
+  },
+}));
+
+import { usePublicProfile } from "./use-public-profile";
+
+function post(id: string, overrides: Partial<Post> = {}): Post {
+  return {
+    id,
+    designer: {
+      id: "des-1",
+      username: "amara.designs",
+      display_name: "Amara Designs",
+      avatar_url: null,
+      verified: true,
+    },
+    caption: `caption-${id}`,
+    style_tags: [],
+    base_price_cents: null,
+    currency: "NGN",
+    turnaround_days: 14,
+    media: [],
+    like_count: 3,
+    comment_count: 1,
+    liked: false,
+    saved: true,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  } as Post;
+}
+
+beforeEach(() => {
+  profileGet.mockReset();
+  profilePosts.mockReset();
+  profileSaved.mockReset();
+  postGet.mockReset();
+});
+
+describe("usePublicProfile.syncPost", () => {
+  it("re-syncs the grid tile and refreshes the self saved grid on modal close", async () => {
+    profileGet.mockResolvedValue({
+      kind: "designer",
+      designer: { username: "amara.designs" },
+      viewer_follows: true,
+      viewer_is_self: true,
+    });
+    profilePosts.mockResolvedValue({ items: [post("p1")], next_cursor: null });
+    profileSaved.mockResolvedValueOnce({
+      items: [post("p1")],
+      next_cursor: null,
+    });
+    // In the modal: liked + commented + UNSAVED.
+    postGet.mockResolvedValue(
+      post("p1", { liked: true, like_count: 4, comment_count: 2, saved: false }),
+    );
+    profileSaved.mockResolvedValueOnce({ items: [], next_cursor: null });
+
+    const { result } = renderHook(() => usePublicProfile("amara.designs"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.saved).toHaveLength(1);
+
+    await act(() => result.current.syncPost("p1"));
+    expect(result.current.posts[0].like_count).toBe(4);
+    expect(result.current.posts[0].comment_count).toBe(2);
+    // the unsaved tile leaves the saved grid without a manual reload
+    expect(result.current.saved).toHaveLength(0);
+  });
+
+  it("keeps the rendered tiles when the refetch fails", async () => {
+    profileGet.mockResolvedValue({
+      kind: "designer",
+      designer: { username: "amara.designs" },
+      viewer_follows: false,
+      viewer_is_self: false,
+    });
+    profilePosts.mockResolvedValue({ items: [post("p1")], next_cursor: null });
+    postGet.mockRejectedValue(new Error("offline"));
+
+    const { result } = renderHook(() => usePublicProfile("amara.designs"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await act(() => result.current.syncPost("p1"));
+    expect(result.current.posts[0].like_count).toBe(3);
+    expect(profileSaved).not.toHaveBeenCalled(); // not self — saved untouched
+  });
+});

--- a/web/src/controllers/use-public-profile.ts
+++ b/web/src/controllers/use-public-profile.ts
@@ -76,7 +76,37 @@ export function usePublicProfile(username: string) {
     setSaved(page.items);
   }, []);
 
-  return { profile, posts, saved, loading, error, toggleFollow, reloadSaved };
+  /**
+   * Re-sync one grid tile from the server when the post modal closes —
+   * modal like/save/comment mutations live in the modal's own usePost
+   * (PR #103 review; same seam as useFeed.syncPost). Saved membership can
+   * flip in the modal, so the self-only saved grid refreshes wholesale.
+   */
+  const syncPost = useCallback(
+    async (id: string) => {
+      try {
+        const fresh = await postsRepo.get(id);
+        setPosts((prev) => prev.map((p) => (p.id === id ? fresh : p)));
+        if (profile?.viewer_is_self) {
+          await reloadSaved();
+        }
+      } catch {
+        // keep the rendered tiles; the next load converges them
+      }
+    },
+    [profile, reloadSaved],
+  );
+
+  return {
+    profile,
+    posts,
+    saved,
+    loading,
+    error,
+    toggleFollow,
+    reloadSaved,
+    syncPost,
+  };
 }
 
 /** Followers/following sheet lists — fetched when the sheet opens. */

--- a/web/src/controllers/use-vault.ts
+++ b/web/src/controllers/use-vault.ts
@@ -78,6 +78,15 @@ export function useVault() {
     setSessions((prev) => prev.filter((s) => s.id !== id));
   }, []);
 
+  /**
+   * F2-9 session export: POST /sessions/{id}/exports → the signed URL
+   * (an inline data URL in TEST_MODE) the view hands to the browser.
+   */
+  const exportSession = useCallback(
+    (id: string, format: "csv" | "pdf") => vaultRepo.exportSession(id, format),
+    [],
+  );
+
   return {
     sessions,
     latest,
@@ -87,5 +96,6 @@ export function useVault() {
     reload,
     addManualSession,
     deleteSession,
+    exportSession,
   };
 }

--- a/web/src/mocks/http.ts
+++ b/web/src/mocks/http.ts
@@ -70,16 +70,21 @@ export async function readJson<T>(request: Request): Promise<T> {
   }
 }
 
+/** `?limit=` parsing (api.md §4): default 50, max 100. */
+export function parseLimit(url: URL): number {
+  const limitRaw = Number(url.searchParams.get("limit") ?? "50");
+  return Math.min(
+    Number.isFinite(limitRaw) && limitRaw > 0 ? Math.floor(limitRaw) : 50,
+    100,
+  );
+}
+
 /** Cursor pagination (api.md §4): `?cursor=` + `limit` default 50, max 100. */
 export function paginate<T>(
   items: T[],
   url: URL,
 ): { items: T[]; next_cursor: string | null } {
-  const limitRaw = Number(url.searchParams.get("limit") ?? "50");
-  const limit = Math.min(
-    Number.isFinite(limitRaw) && limitRaw > 0 ? Math.floor(limitRaw) : 50,
-    100,
-  );
+  const limit = parseLimit(url);
   const cursorRaw = url.searchParams.get("cursor");
   let offset = 0;
   if (cursorRaw) {

--- a/web/src/mocks/seed.ts
+++ b/web/src/mocks/seed.ts
@@ -910,7 +910,8 @@ export const seedOrders: CommissionRequest[] = [
     customer: { id: "acc-kiki", username: "kiki.adeyemi", avatar_url: null },
     designer: { id: "des-amara", username: "amara.designs", avatar_url: null },
     status: "in_progress",
-    notes: "Slightly longer sleeves than the sample, please. Event is July 26.",
+    notes:
+      "Ankle length please, with a small side slit — easier to dance in. Event is July 26.",
     budget_cents: 5_000_000,
     quote_cents: 4_500_000, // ₦45,000
     currency: "NGN",
@@ -968,7 +969,8 @@ export const seedOrders: CommissionRequest[] = [
     customer: { id: "acc-kiki", username: "kiki.adeyemi", avatar_url: null },
     designer: { id: "des-bisi", username: "maisonbisi", avatar_url: null },
     status: "delivered",
-    notes: "For a family wedding — colour scheme attached in thread.",
+    notes:
+      "Gift for my nephew Tobi (age 6) — family wedding. Colour scheme in thread; his measurements are tape-measured, entered by hand.",
     budget_cents: null,
     quote_cents: 6_200_000, // ₦62,000
     currency: "NGN",
@@ -985,17 +987,23 @@ export const seedOrders: CommissionRequest[] = [
       state: "Lagos",
       country: "NG",
     },
+    // The child outfit is a GIFT: kiki tape-measured her nephew and entered
+    // the values as a manual vault session just before requesting, then
+    // deleted that session after the order was placed — snapshots freeze at
+    // request time, so the order keeps the child's numbers while her own
+    // vault (adult sessions above) is untouched (PR #102 review: an adult
+    // 42 cm-shoulder snapshot can't dress a six-year-old).
     snapshot: {
       id: "snap-1058",
       request_id: "req-apr-1058",
       values: {
         method: "manual",
-        measured_at: daysAgo(58),
+        measured_at: daysAgo(41),
         measurements: [
-          { name: "shoulder_width", value_cm: 42.0 },
-          { name: "hip_width", value_cm: 37.2 },
-          { name: "chest_girth", value_cm: 92.0 },
-          { name: "waist_girth", value_cm: 78.5 },
+          { name: "shoulder_width", value_cm: 28.0 },
+          { name: "hip_width", value_cm: 25.5 },
+          { name: "chest_girth", value_cm: 60.5 },
+          { name: "waist_girth", value_cm: 55.0 },
         ],
       },
       created_at: daysAgo(40),

--- a/web/src/mocks/seed.ts
+++ b/web/src/mocks/seed.ts
@@ -1,7 +1,9 @@
 // Seed data — the canonical Figma narrative (docs/design.md §8.3 sourced
 // photography; the mock narratives the designs boot with):
 //   kiki.adeyemi (customer) · amara.designs / tunde.o / maisonbisi
-//   (designers, Lagos) · orders #APR-1042 (ankara, ₦45,000, in_progress) and
+//   (designers, Lagos) · eniola.stitches (designer, Abuja — the non-Lagos
+//   contrast that makes the explore "near me" proximity ranking visible)
+//   · orders #APR-1042 (ankara, ₦45,000, in_progress) and
 //   #APR-1058 (little senator, ₦62,000, delivered/paid-out) · measurements
 //   (shoulder 42.5 cm etc. with freshness) · feed posts referencing the
 //   CC-licensed photos in web/public/demo (see ATTRIBUTIONS.md there).
@@ -112,6 +114,26 @@ export const seedAccounts: Account[] = [
     ],
     created_at: daysAgo(400),
   },
+  {
+    id: "acc-eniola",
+    firebase_uid: "test-uid-eniola",
+    email: "eniola@example.com",
+    username: "eniola.stitches",
+    display_name: "Eniola Stitches",
+    avatar_url: null,
+    // The one non-Lagos designer: kiki (Lagos) ranks her LAST under the
+    // explore "near me" proximity ordering — the visible contrast case.
+    profile_location: { city: "Abuja", state: "FCT", country: "NG" },
+    deletion_state: "active",
+    designer: { enabled: true, kyc_complete: true },
+    is_staff: false,
+    notification_prefs: defaultPrefs(),
+    consent: [
+      { document: "tos", version: "1.0", accepted_at: daysAgo(160) },
+      { document: "privacy", version: "1.0", accepted_at: daysAgo(160) },
+    ],
+    created_at: daysAgo(160),
+  },
 ];
 
 // Community members — the wider Lagos-scene audience around the four core
@@ -173,7 +195,7 @@ export const seedDesigners: DesignerProfile[] = [
     // Counts mirror the seeded graph exactly (P1 realism pass: the
     // followers sheet lists every follower, so count == list; posts_count
     // == the seeded grid).
-    followers_count: 7,
+    followers_count: 8,
     following_count: 2,
     posts_count: 3,
   },
@@ -214,6 +236,25 @@ export const seedDesigners: DesignerProfile[] = [
     followers_count: 6,
     following_count: 1,
     posts_count: 4,
+  },
+  {
+    id: "des-eniola",
+    account_id: "acc-eniola",
+    username: "eniola.stitches",
+    display_name: "Eniola Stitches",
+    bio: "Bespoke womenswear from the Abuja atelier — corporate and occasion.",
+    avatar_url: null,
+    payout_account: {
+      provider_ref: "PSTK-RCP-55492",
+      bank_name: "UBA",
+      account_last4: "7305",
+      kyc_state: "verified",
+    },
+    verified: true,
+    location: { city: "Abuja", state: "FCT", country: "NG" },
+    followers_count: 1,
+    following_count: 1,
+    posts_count: 1,
   },
 ];
 
@@ -270,6 +311,27 @@ function makePost(input: SeedPostInput): Post {
 }
 
 export const seedPosts: Post[] = [
+  makePost({
+    // Newest post overall: explore's default recency order leads with the
+    // Abuja atelier, and switching "near me" on visibly re-ranks it below
+    // every Lagos designer for the Lagos-based test user.
+    id: "post-atelier-abuja",
+    designerId: "des-eniola",
+    caption:
+      "Cutting for the September calendar at the Abuja atelier — corporate and occasion pieces, made to your vault numbers.",
+    tags: ["bespoke", "workwear"],
+    priceCents: 3_800_000,
+    turnaround: 10,
+    media: [
+      {
+        file: "outfit-w10.jpg",
+        alt: "Designer at a work table making clothes in the atelier",
+      },
+    ],
+    likes: 9,
+    comments: 1,
+    createdDaysAgo: 0.3,
+  }),
   makePost({
     id: "post-ankara-gown",
     designerId: "des-amara",
@@ -403,6 +465,16 @@ export const seedPosts: Post[] = [
 ];
 
 export const seedComments: Comment[] = [
+  {
+    id: "cmt-33",
+    post_id: "post-atelier-abuja",
+    author: { id: "acc-zainab", username: "zainab.k", avatar_url: null },
+    body: "An atelier this side of Abuja at last — booking for December.",
+    like_count: 1,
+    liked: false,
+    hidden_by_moderation: false,
+    created_at: daysAgo(0.15),
+  },
   {
     id: "cmt-1",
     post_id: "post-ankara-gown",
@@ -1400,8 +1472,12 @@ export const seedFollows: [string, string][] = [
   ["acc-amara", "maisonbisi"],
   ["acc-tunde", "amara.designs"],
   ["acc-bisi", "amara.designs"],
+  // The Abuja designer follows the Lagos scene; zainab (Abuja) follows her
+  // hometown atelier.
+  ["acc-eniola", "amara.designs"],
+  ["acc-zainab", "eniola.stitches"],
   // Community edges — the designers' followers_count mirrors this graph
-  // exactly (amara 7 · tunde 4 · bisi 6).
+  // exactly (amara 8 · tunde 4 · bisi 6 · eniola 1).
   ["acc-ada", "amara.designs"],
   ["acc-ada", "maisonbisi"],
   ["acc-funmi", "amara.designs"],

--- a/web/src/mocks/store.test.ts
+++ b/web/src/mocks/store.test.ts
@@ -223,6 +223,53 @@ describe("engagement", () => {
     const premium = store.explore("kiki.adeyemi", undefined, undefined, "premium");
     expect(premium.map((p) => p.id)).toEqual(["post-bridal-gown"]);
   });
+
+  it("explore max_turnaround_days keeps only posts deliverable in time", () => {
+    const week = store.explore(
+      "kiki.adeyemi",
+      undefined,
+      undefined,
+      undefined,
+      7,
+    );
+    expect(week.map((p) => p.id)).toEqual([
+      "post-print-brothers",
+      "post-dance-troupe",
+    ]);
+    for (const p of week) expect(p.turnaround_days).toBeLessThanOrEqual(7);
+  });
+
+  it("explore near_me proximity-ranks by designer location — no hard gate", () => {
+    // Default recency order leads with the newest post: the Abuja atelier.
+    const recency = store.explore("kiki.adeyemi");
+    expect(recency[0].id).toBe("post-atelier-abuja");
+    // near_me for Lagos-based kiki: every Lagos designer's post ranks above
+    // the Abuja designer's, which still APPEARS (ranking, not filtering).
+    const near = store.explore(
+      "kiki.adeyemi",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+    expect(near).toHaveLength(recency.length);
+    expect(near[0].id).toBe("post-print-couple"); // newest Lagos post
+    expect(near[near.length - 1].id).toBe("post-atelier-abuja");
+  });
+
+  it("explore near_me is a no-op for callers without a profile location", () => {
+    store.updateMe("kiki.adeyemi", { profile_location: null });
+    const near = store.explore(
+      "kiki.adeyemi",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+    expect(near[0].id).toBe("post-atelier-abuja"); // recency order holds
+  });
 });
 
 describe("earnings (designer view)", () => {
@@ -335,10 +382,10 @@ describe("profiles & social lists", () => {
     expect(following.map((f) => f.username)).toEqual(
       expect.arrayContaining(["tunde.o", "maisonbisi"]),
     );
-    // tunde is the seeded suggestion (not followed by kiki)
+    // tunde + the Abuja atelier are the seeded suggestions (not followed)
     expect(
       store.suggestedDesigners("kiki.adeyemi").map((d) => d.username),
-    ).toEqual(["tunde.o"]);
+    ).toEqual(["tunde.o", "eniola.stitches"]);
   });
 
   it("saved posts round-trip through engagement", () => {

--- a/web/src/mocks/store.test.ts
+++ b/web/src/mocks/store.test.ts
@@ -258,6 +258,25 @@ describe("engagement", () => {
     expect(near[near.length - 1].id).toBe("post-atelier-abuja");
   });
 
+  it("explore near_me ranks against the designer's CURRENT profile location", () => {
+    // PR #103 review: settings B7 writes Account.profile_location — the
+    // cached DesignerProfile.location must follow, or near-me keeps
+    // ranking on stale onboarding data.
+    store.updateMe("eniola.stitches", {
+      profile_location: { city: "Lagos", state: "Lagos", country: "NG" },
+    });
+    const near = store.explore(
+      "kiki.adeyemi",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+    // her newest-overall post now leads the same-city tier
+    expect(near[0].id).toBe("post-atelier-abuja");
+  });
+
   it("explore near_me is a no-op for callers without a profile location", () => {
     store.updateMe("kiki.adeyemi", { profile_location: null });
     const near = store.explore(
@@ -421,6 +440,65 @@ describe("capture path (webcam, B4)", () => {
     expect(() => store.saveSession(session.id, "kiki.adeyemi")).toThrowError(
       expect.objectContaining({ code: "invalid_transition" }),
     );
+  });
+});
+
+describe("ranked pagination (api.md §5 — snapshot cursors)", () => {
+  const feedPage = (cursor: string | null, limit: number) =>
+    store.rankedPage(
+      "kiki.adeyemi",
+      () => store.feed("kiki.adeyemi"),
+      cursor,
+      limit,
+    );
+
+  it("freezes the rank per scroll session — no duplicates or skips mid-scroll", () => {
+    const page1 = feedPage(null, 4);
+    expect(page1.items).toHaveLength(4);
+    expect(page1.next_cursor).not.toBeNull();
+    // A followed designer publishes mid-scroll — a fresh rank would lead
+    // with it and shift every offset (PR #103 review).
+    const fresh = store.createPost("amara.designs", {
+      caption: "Mid-scroll drop",
+      style_tags: ["ankara"],
+      base_price_cents: null,
+      turnaround_days: 7,
+      media: [{ url: "/demo/outfit-w14.jpg", alt_text: "Fabric drop" }],
+    });
+    const page2 = feedPage(page1.next_cursor, 4);
+    const ids = [...page1.items, ...page2.items].map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length); // never duplicates
+    expect(ids).not.toContain(fresh.id); // new posts land on refresh only
+    expect(page2.next_cursor).toBeNull();
+    // …and a NEW scroll session (no cursor) does lead with it
+    expect(feedPage(null, 4).items[0].id).toBe(fresh.id);
+  });
+
+  it("posts deleted mid-scroll drop out without duplicating", () => {
+    const page1 = feedPage(null, 2);
+    store.deletePost("post-asooke-set", "maisonbisi"); // would be page 2
+    const page2 = feedPage(page1.next_cursor, 2);
+    const ids = [...page1.items, ...page2.items].map((p) => p.id);
+    expect(ids).not.toContain("post-asooke-set");
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("freezes only the RANK — engagement state stays live", () => {
+    const page1 = feedPage(null, 4);
+    store.setEngagement("post-fabric-drop", "kiki.adeyemi", "like", true);
+    const page2 = feedPage(page1.next_cursor, 4);
+    expect(page2.items.find((p) => p.id === "post-fabric-drop")?.liked).toBe(
+      true,
+    );
+  });
+
+  it("expired or garbled cursors start a fresh scroll session", () => {
+    const garbled = feedPage(
+      Buffer.from("rank-nope:4", "utf8").toString("base64url"),
+      4,
+    );
+    expect(garbled.items).toHaveLength(4);
+    expect(garbled.items[0].id).toBe(store.feed("kiki.adeyemi")[0].id);
   });
 });
 

--- a/web/src/mocks/store.test.ts
+++ b/web/src/mocks/store.test.ts
@@ -72,6 +72,31 @@ describe("seed narrative", () => {
     }
   });
 
+  it("#APR-1058 (child outfit gift) freezes child-scale manual measurements", () => {
+    // PR #102 review: the "Little senator" order must not carry kiki's
+    // adult vault snapshot — it's a gift with tape-measured child values
+    // entered by hand at request time.
+    const order = store.order("req-apr-1058", "kiki.adeyemi");
+    expect(order.snapshot.values.method).toBe("manual");
+    for (const m of order.snapshot.values.measurements) {
+      expect(m.value_cm, m.name).toBeLessThan(70);
+    }
+    expect(order.notes).toMatch(/nephew/i);
+    // kiki's own vault stays adult — the child session was deleted after
+    // the snapshot froze (sessions are deletable; snapshots are immutable).
+    const newest = store.sessionsFor("kiki.adeyemi")[0];
+    expect(
+      newest.measurements.find((m) => m.name === "shoulder_width")?.value_cm,
+    ).toBe(42.5);
+  });
+
+  it("#APR-1042 (ankara maxi skirt) carries a skirt-appropriate note", () => {
+    // PR #102 review: the recaptioned skirt order asked for "longer sleeves".
+    const order = store.order("req-apr-1042", "kiki.adeyemi");
+    expect(order.notes).toMatch(/ankle length/i);
+    expect(order.notes).not.toMatch(/sleeve/i);
+  });
+
   it("order snapshots are measured before the order exists (P1 realism)", () => {
     for (const order of store.orders) {
       const measured = new Date(order.snapshot.values.measured_at).getTime();

--- a/web/src/mocks/store.test.ts
+++ b/web/src/mocks/store.test.ts
@@ -424,6 +424,43 @@ describe("capture path (webcam, B4)", () => {
   });
 });
 
+describe("session exports (F2-9 / PLAT-004)", () => {
+  it("csv export inlines a header + one row per measurement", () => {
+    const { url, format } = store.sessionExport(
+      "sess-manual-tape",
+      "kiki.adeyemi",
+      "csv",
+    );
+    expect(format).toBe("csv");
+    expect(url).toMatch(/^data:text\/csv;base64,/);
+    const body = Buffer.from(url.split(",")[1], "base64").toString("utf8");
+    const lines = body.split("\n");
+    expect(lines[0]).toBe("name,value_cm,source,confidence");
+    expect(lines).toHaveLength(1 + 4); // header + the session's 4 values
+    expect(body).toContain("shoulder_width,42,");
+  });
+
+  it("pdf export is a real PDF carrying the measurement lines", () => {
+    const { url, format } = store.sessionExport(
+      "sess-recent-scan",
+      "kiki.adeyemi",
+      "pdf",
+    );
+    expect(format).toBe("pdf");
+    expect(url).toMatch(/^data:application\/pdf;base64,/);
+    const body = Buffer.from(url.split(",")[1], "base64").toString("utf8");
+    expect(body.startsWith("%PDF-1.4")).toBe(true);
+    expect(body).toContain("shoulder_width: 42.5 cm");
+    expect(body.trimEnd().endsWith("%%EOF")).toBe(true);
+  });
+
+  it("exports are tenant-scoped: another user's session reads not_found", () => {
+    expect(() =>
+      store.sessionExport("sess-recent-scan", "tunde.o", "csv"),
+    ).toThrowError(expect.objectContaining({ code: "not_found", status: 404 }));
+  });
+});
+
 describe("designer KYC gate + payout scripting", () => {
   it("pre-KYC designers can post but their posts serve post_unavailable", () => {
     store.enableDesigner("kiki.adeyemi", "Kiki Studio");

--- a/web/src/mocks/store.ts
+++ b/web/src/mocks/store.ts
@@ -261,6 +261,8 @@ export class MockStore {
     q?: string,
     tags?: string[],
     priceBand?: "budget" | "mid" | "premium",
+    maxTurnaroundDays?: number,
+    nearMe?: boolean,
   ): Post[] {
     const viewer = this.accountByUsername(viewerUsername);
     let posts = [...this.posts];
@@ -287,12 +289,33 @@ export class MockStore {
         return naira > 100_000;
       });
     }
-    return posts
-      .sort(
-        (a, b) =>
-          new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-      )
-      .map((p) => this.viewPost(p, viewer.id));
+    if (maxTurnaroundDays !== undefined) {
+      posts = posts.filter((p) => p.turnaround_days <= maxTurnaroundDays);
+    }
+    posts.sort(
+      (a, b) =>
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+    );
+    if (nearMe) {
+      // Proximity RANKING, not a hard gate (pages.md B2, X-10 tier 1):
+      // designer profile_location vs the caller's — city > state > country;
+      // locationless designers simply don't rank (sort last). Recency holds
+      // within a tier. Callers without a profile location keep recency order.
+      const home = viewer.profile_location;
+      if (home) {
+        const tierOf = (post: Post): number => {
+          const loc = this.designerByUsername(post.designer.username)?.location;
+          if (!loc) return 3;
+          if (loc.city === home.city && loc.state === home.state) return 0;
+          if (loc.state === home.state) return 1;
+          if (loc.country === home.country) return 2;
+          return 3;
+        };
+        // Array.prototype.sort is stable — recency survives within tiers.
+        posts.sort((a, b) => tierOf(a) - tierOf(b));
+      }
+    }
+    return posts.map((p) => this.viewPost(p, viewer.id));
   }
 
   post(idOrPermalink: string, viewerUsername: string): Post {

--- a/web/src/mocks/store.ts
+++ b/web/src/mocks/store.ts
@@ -87,6 +87,41 @@ function deepClone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
 
+/**
+ * A real (minimal) one-page PDF for the F2-9 pdf export: Helvetica text
+ * lines, uncompressed stream, byte-accurate xref — enough that any viewer
+ * opens it. Stands in for the backend's rendered report the way the rest of
+ * the mock stands in for api/common.
+ */
+function minimalPdf(lines: string[]): Buffer {
+  const escape = (s: string) =>
+    s.replace(/\\/g, "\\\\").replace(/\(/g, "\\(").replace(/\)/g, "\\)");
+  const text = lines
+    .map((line, i) => `1 0 0 1 72 ${720 - i * 18} Tm (${escape(line)}) Tj`)
+    .join("\n");
+  const stream = `BT\n/F1 12 Tf\n${text}\nET`;
+  const objects = [
+    "<< /Type /Catalog /Pages 2 0 R >>",
+    "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+    `<< /Length ${Buffer.byteLength(stream, "utf8")} >>\nstream\n${stream}\nendstream`,
+    "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+  ];
+  let body = "%PDF-1.4\n";
+  const offsets: number[] = [];
+  objects.forEach((obj, i) => {
+    offsets.push(Buffer.byteLength(body, "utf8"));
+    body += `${i + 1} 0 obj\n${obj}\nendobj\n`;
+  });
+  const xrefAt = Buffer.byteLength(body, "utf8");
+  body += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  for (const offset of offsets) {
+    body += `${String(offset).padStart(10, "0")} 00000 n \n`;
+  }
+  body += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefAt}\n%%EOF`;
+  return Buffer.from(body, "utf8");
+}
+
 export class MockStore {
   accounts: Account[] = deepClone(seedAccounts);
   designers: DesignerProfile[] = deepClone(seedDesigners);
@@ -723,13 +758,33 @@ export class MockStore {
     return deepClone(session);
   }
 
-  /** PLAT-004 export — the mock returns an inline data URL as the signed URL. */
+  /**
+   * PLAT-004 / F2-9 export — pdf or csv per the api.md contract; the mock
+   * returns an inline data URL where the backend will return a signed URL.
+   */
   sessionExport(
     sessionId: string,
     username: string,
     format: "csv" | "pdf",
   ): { url: string; format: string } {
     const session = this.session(sessionId, username);
+    if (format === "pdf") {
+      const pdf = minimalPdf([
+        "Apparule — measurement session export",
+        `Session ${session.id} · method ${session.method}`,
+        `Captured ${new Date(session.created_at).toDateString()}`,
+        "",
+        ...session.measurements.map(
+          (m) =>
+            `${m.name}: ${m.value_cm} cm (${m.source}` +
+            `${m.confidence !== null ? `, confidence ${m.confidence}` : ""})`,
+        ),
+      ]);
+      return {
+        url: `data:application/pdf;base64,${pdf.toString("base64")}`,
+        format,
+      };
+    }
     const rows = [
       "name,value_cm,source,confidence",
       ...session.measurements.map(

--- a/web/src/mocks/store.ts
+++ b/web/src/mocks/store.ts
@@ -140,6 +140,11 @@ export class MockStore {
   blocks = new Set<string>();
   /** Idempotency replay cache: key → serialized response (api.md §4). */
   idempotency = new Map<string, { payloadHash: string; response: unknown }>();
+  /**
+   * Ranked-cursor snapshots (api.md §5 [Decided]): rank is computed at
+   * first page and frozen for the cursor's 24h lifetime.
+   */
+  rankedSnapshots = new Map<string, { ids: string[]; created_at: number }>();
   orderCounter = 1059;
   /** Uploaded media (composer) — stands in for object storage. */
   media = new Map<string, { data: string; contentType: string }>();
@@ -241,6 +246,11 @@ export class MockStore {
     if (patch.display_name !== undefined) account.display_name = patch.display_name;
     if (patch.profile_location !== undefined) {
       account.profile_location = patch.profile_location;
+      // The designer profile's cached location mirrors the account's —
+      // settings B7 is the single write path (X-10 tier 1), and near-me
+      // must rank against the CURRENT value (PR #103 review).
+      const designer = this.designerByUsername(account.username);
+      if (designer) designer.location = patch.profile_location;
     }
     if (patch.notification_prefs !== undefined) {
       account.notification_prefs = {
@@ -274,6 +284,72 @@ export class MockStore {
   }
 
   // -- social ---------------------------------------------------------------
+
+  /**
+   * Ranked pagination (api.md §5 [Decided]): the cursor encodes a snapshot
+   * of the ranked order frozen at first-page time for its 24h lifetime, so
+   * pages never duplicate or skip posts within one scroll session — new
+   * posts appear on refresh, not mid-scroll; posts deleted after the
+   * snapshot simply drop out. Engagement state (liked/saved/counts) stays
+   * live — only the RANK is frozen. Expired/garbled cursors start a fresh
+   * scroll session (PR #103 review: the plain offset cursor recomputed the
+   * rank per page and could duplicate or skip).
+   */
+  rankedPage(
+    viewerUsername: string,
+    rank: () => Post[],
+    cursorRaw: string | null,
+    limit: number,
+  ): { items: Post[]; next_cursor: string | null } {
+    const viewer = this.accountByUsername(viewerUsername);
+    const DAY_MS = 24 * 60 * 60 * 1000;
+    let snapshotId: string | null = null;
+    let offset = 0;
+    if (cursorRaw) {
+      const decoded = Buffer.from(cursorRaw, "base64url").toString("utf8");
+      const at = decoded.lastIndexOf(":");
+      const id = decoded.slice(0, at);
+      const parsedOffset = Number(decoded.slice(at + 1));
+      const snapshot = this.rankedSnapshots.get(id);
+      if (
+        snapshot &&
+        Date.now() - snapshot.created_at < DAY_MS &&
+        Number.isFinite(parsedOffset) &&
+        parsedOffset >= 0
+      ) {
+        snapshotId = id;
+        offset = parsedOffset;
+      }
+    }
+    if (snapshotId === null) {
+      snapshotId = id("rank");
+      this.rankedSnapshots.set(snapshotId, {
+        ids: rank().map((p) => p.id),
+        created_at: Date.now(),
+      });
+      // registry hygiene: drop the oldest snapshots past a sane bound
+      while (this.rankedSnapshots.size > 100) {
+        const oldest = this.rankedSnapshots.keys().next().value;
+        if (oldest === undefined) break;
+        this.rankedSnapshots.delete(oldest);
+      }
+    }
+    const snapshot = this.rankedSnapshots.get(snapshotId)!;
+    const live = new Map(this.posts.map((p) => [p.id, p] as const));
+    const items: Post[] = [];
+    let i = offset;
+    for (; i < snapshot.ids.length && items.length < limit; i++) {
+      const post = live.get(snapshot.ids[i]);
+      if (post) items.push(this.viewPost(post, viewer.id));
+    }
+    return {
+      items,
+      next_cursor:
+        i < snapshot.ids.length
+          ? Buffer.from(`${snapshotId}:${i}`, "utf8").toString("base64url")
+          : null,
+    };
+  }
 
   feed(viewerUsername: string): Post[] {
     const viewer = this.accountByUsername(viewerUsername);

--- a/web/src/models/repositories/feed-repo.ts
+++ b/web/src/models/repositories/feed-repo.ts
@@ -25,9 +25,11 @@ function query(params: Record<string, string | undefined>): string {
 }
 
 export const feedRepo = {
-  /** GET /api/v1/feed */
-  feed: (cursor?: string) =>
-    apiFetch<Page<Post>>(`/v1/feed${query({ cursor })}`),
+  /** GET /api/v1/feed — cursor pagination per api.md §4 (`?cursor=&limit=`). */
+  feed: (cursor?: string, limit?: number) =>
+    apiFetch<Page<Post>>(
+      `/v1/feed${query({ cursor, limit: limit?.toString() })}`,
+    ),
 
   /** GET /api/v1/explore?q&tags&price_band&max_turnaround_days&near_me */
   explore: (filters: ExploreFilters = {}, cursor?: string) =>

--- a/web/src/models/repositories/feed-repo.ts
+++ b/web/src/models/repositories/feed-repo.ts
@@ -7,6 +7,13 @@ export interface ExploreFilters {
   q?: string;
   tags?: string[];
   price_band?: "budget" | "mid" | "premium";
+  /** Turnaround-time chip (pages.md B2): only posts deliverable within N days. */
+  max_turnaround_days?: number;
+  /**
+   * "Near me" chip: proximity RANKING by designer profile_location vs the
+   * caller's (X-10 tier 1) — never a hard gate (api.md §5 extension).
+   */
+  near_me?: boolean;
 }
 
 function query(params: Record<string, string | undefined>): string {
@@ -22,13 +29,15 @@ export const feedRepo = {
   feed: (cursor?: string) =>
     apiFetch<Page<Post>>(`/v1/feed${query({ cursor })}`),
 
-  /** GET /api/v1/explore?q&tags&price_band */
+  /** GET /api/v1/explore?q&tags&price_band&max_turnaround_days&near_me */
   explore: (filters: ExploreFilters = {}, cursor?: string) =>
     apiFetch<Page<Post>>(
       `/v1/explore${query({
         q: filters.q,
         tags: filters.tags?.join(","),
         price_band: filters.price_band,
+        max_turnaround_days: filters.max_turnaround_days?.toString(),
+        near_me: filters.near_me ? "1" : undefined,
         cursor,
       })}`,
     ),


### PR DESCRIPTION
## What this delivers

P1 demo-completeness pass: the four Codex P2 review findings from merged PR #102, plus the approved gap implementations from the PR2 gap analysis, plus the rail-state directive audit.

### 1 · PR #102 review fixes (`df21c29`)
- **Wide post-detail modal** — `Sheet` gains a `size` axis (`default` 480px / `wide` 896px viewport-clamped); the in-app post modal (feed, explore, profile grids) uses `wide`, a real width instead of a `max-w-*` losing to the base `md:w-[480px]` by stylesheet order.
- **Feed ↔ modal sync** — `useFeed.syncPost` re-syncs the rendered item from the server when the modal closes, so feed cards/explore tiles never show stale like/save/comment state (unit-gated).
- **Seed: APR-1042** skirt order now asks for a skirt-appropriate alteration (ankle length + side slit), not "longer sleeves".
- **Seed: APR-1058** "Little senator" is a coherent **gift order**: child-scale measurements (28 cm shoulder / 60.5 cm chest) tape-measured and entered manually at request time; the snapshot froze per the data-model rule and kiki's adult vault is untouched (unit-gated).

### 2 · Explore filter chips per pages.md B2 (`291b8a8`)
- **Turnaround-time** chips (≤ 1 week / ≤ 2 weeks / ≤ 1 month → `max_turnaround_days`).
- **"Near me"** chip — proximity **ranking** by designer `profile_location` vs the caller's (X-10 tier 1): city > state > country, recency within tiers, locationless designers sort last, no hard gate; no-op without a caller location. Documented as the api.md §5 param extension **[Proposed 2026-07-19]**.
- Seed gains `eniola.stitches` (Abuja) with a photo-true atelier post (newest overall) so near-me visibly re-ranks; follow graph and follower counts stay mirror-exact.

### 3 · MI-6 feed infinite scroll (`d8bae11`)
`/feed` pages through the api.md §4 cursor contract (page size 4 over the 7-post seed), prefetch when the viewer is 3 cards from the end (IntersectionObserver over the last three cards, jump-scroll-robust, in-flight-gated), skeleton ×2 during fetch, caught-up divider on exhaustion. e2e slows the cursor page to demo prefetch → skeletons → append → divider.

### 4 · F2-9 session exports (`7348afa`)
The vault history sheet exports any capture session per row as **CSV or PDF** via `POST /sessions/{id}/exports`; the mock now returns a real minimal PDF for `pdf` (was mislabeled CSV bytes) and 422s unknown formats. e2e asserts real browser downloads for both formats.

### 5 · Rail-state directive audit (`5f19fd4`)
NavRail expansion is viewport-driven (collapsed 72px < 1264, expanded 244px ≥ 1264; **no user toggle, no persisted state**) — an expanded rail structurally cannot squeeze the mobile content column. `e2e/nav-rail-states.spec.ts` pins the mobile shape at 390 and sweeps every dashboard route at 1264/1440 for document side-scroll + content containment; worst offenders screenshot in both states. **Zero violations found** — the sweep lands as a regression gate.

### 6 · Docs (`318fdf7`)
web-implementation.md as-built block (present-tense); **F0-8 Scalar embed at `/docs/api`: [Proposed — deferred pending ratification vs the GitBook links canon]** — not implemented.

### 7 · PR #103 review fixes (`2ce0f10`)
All three Codex P2s on this PR fixed and replied per thread: profile grids re-sync on post-modal close (incl. saved-grid removal on unsave); /feed + /explore cursors now freeze a rank snapshot per scroll session (the api.md §5 [Decided] contract — no mid-scroll duplicates/skips, engagement stays live); near-me ranks the designer's CURRENT profile location (updateMe mirrors it onto the cached designer profile).

## Gates
- lint · typecheck · unit (460) · Playwright e2e (45) · TEST_MODE build — all green locally per commit-group and on the final tree; CI green on every push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
