### PR TITLE
chore(web): code quality — PR #103 round-2 review fixes, navigation hygiene, docs sweep, parity catalog

### DIFF
--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -110,7 +110,7 @@ construction (emulator rule tests are part of CI, not optional).
   methods `GET,POST,PUT,PATCH,DELETE,OPTIONS`; headers
   `Authorization, Content-Type, Idempotency-Key, X-Org-Id`; preflight 204
   with `Access-Control-Max-Age: 600`.
-- Implemented today in api/common (`CORS_ORIGINS`, renamed from `ALLOWED_ORIGINS` for ecosystem consistency).
+- Implemented today in api/common (`CORS_ORIGINS` — the ecosystem-standard variable name).
 
 ## Telemetry (OpenTelemetry, X-9)
 

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -211,8 +211,7 @@ side-scrolls, and wide elements scroll within their own containers:
   dashboard, settings sub-screens and order detail included) asserting
   `document.scrollWidth <= viewport` at 390 AND 768, plus wide-element
   containment: any `table`/`pre`/`code` wider than the viewport must sit
-  inside an `overflow-x: auto` container that itself fits. It supersedes
-  the old 12-route dashboard.spec sweep.
+  inside an `overflow-x: auto` container that itself fits.
 - The A9 comparison table scrolls horizontally within its card below its
   min-content width (the "Self-host it" CTA was clipped at 390).
 - One `@layer base` rule — `fieldset { min-inline-size: 0 }` — normalizes

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -60,15 +60,22 @@ test("semantic landmarks: every dashboard screen renders one <main> and the prim
 
 // Runs BEFORE the B1 journey (serial file): the journey follows tunde,
 // which grows the feed past the canonical 7-post seed this test paginates.
-test("B1 MI-6: infinite scroll — cursor page prefetched near the end, skeleton ×2, caught-up", async ({
+test("B1 MI-6: infinite scroll — failed page retries, skeleton ×2, caught-up", async ({
   page,
 }) => {
-  // Slow the cursor page down so the MI-6 skeletons are observable.
+  // First cursor request FAILS (transient network); subsequent ones are
+  // slowed so the MI-6 skeletons are observable.
+  let cursorCalls = 0;
   await page.route(
     (url) =>
       url.pathname.endsWith("/api/mock/v1/feed") &&
       url.searchParams.has("cursor"),
     async (route) => {
+      cursorCalls += 1;
+      if (cursorCalls === 1) {
+        await route.abort("connectionfailed");
+        return;
+      }
       await new Promise((resolve) => setTimeout(resolve, 700));
       await route.continue();
     },
@@ -80,8 +87,15 @@ test("B1 MI-6: infinite scroll — cursor page prefetched near the end, skeleton
   await expect(cards).toHaveCount(4);
 
   // Walking toward the end crosses the 3-from-end observer → prefetch;
-  // skeleton ×2 renders while the cursor page is in flight.
+  // the aborted page surfaces the explicit retry control (PR #103) —
+  // the feed must not silently stop at an incomplete page.
   await cards.last().scrollIntoViewIfNeeded();
+  const retry = page.getByTestId("feed-load-more-retry");
+  await expect(retry).toBeVisible();
+  await expect(cards).toHaveCount(4);
+
+  // Retry → skeleton ×2 while the page is in flight → cards append.
+  await retry.click();
   await expect(page.getByTestId("feed-loading-more")).toBeVisible();
   await expect(cards).toHaveCount(7);
   await expect(page.getByTestId("feed-loading-more")).toHaveCount(0);

--- a/web/src/app/api/mock/v1/explore/route.ts
+++ b/web/src/app/api/mock/v1/explore/route.ts
@@ -27,10 +27,20 @@ export async function GET(request: Request) {
     const actor = actorUsername(request);
     const store = getStore();
     // Ranked endpoint — cursor pages come from a frozen rank snapshot
-    // ([Decided] ranked pagination), same as /feed.
+    // ([Decided] ranked pagination), same as /feed. The fingerprint binds
+    // the cursor to this endpoint + exact filter set.
+    const fingerprint = [
+      "explore",
+      q ?? "",
+      (tags ?? []).join(","),
+      priceBand ?? "",
+      maxTurnaroundDays ?? "",
+      nearMe ? "1" : "",
+    ].join("|");
     return jsonResponse(
       store.rankedPage(
         actor,
+        fingerprint,
         () => store.explore(actor, q, tags, priceBand, maxTurnaroundDays, nearMe),
         url.searchParams.get("cursor"),
         parseLimit(url),

--- a/web/src/app/api/mock/v1/feed/route.ts
+++ b/web/src/app/api/mock/v1/feed/route.ts
@@ -12,6 +12,7 @@ export async function GET(request: Request) {
     return jsonResponse(
       store.rankedPage(
         actor,
+        "feed",
         () => store.feed(actor),
         url.searchParams.get("cursor"),
         parseLimit(url),

--- a/web/src/components/dashboard/create/ComposerView.tsx
+++ b/web/src/components/dashboard/create/ComposerView.tsx
@@ -7,6 +7,7 @@
 // requests gate (flows/designer.md §1). Render-only over useComposer.
 import { useState, type FormEvent } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useAuth } from "@/controllers/auth/AuthContext";
 import { useComposer } from "@/controllers/use-composer";
 import { Banner } from "@/components/ui/Banner";
@@ -20,6 +21,7 @@ import { useToasts } from "../toast-context";
 
 export function ComposerView() {
   const { account } = useAuth();
+  const router = useRouter();
   const composer = useComposer();
   const { showToast } = useToasts();
   const [tagDraft, setTagDraft] = useState("");
@@ -80,7 +82,7 @@ export function ComposerView() {
           tone="warn"
           actionLabel="Finish verification"
           onAction={() =>
-            window.location.assign("/dashboard/designer/onboarding")
+            router.push("/dashboard/designer/onboarding")
           }
         >
           You can publish now, but posts won&apos;t accept requests until your

--- a/web/src/components/dashboard/earnings/EarningsView.tsx
+++ b/web/src/components/dashboard/earnings/EarningsView.tsx
@@ -6,6 +6,7 @@
 // change → B8) · Recent activity TransactionRow list (payouts, escrow-held,
 // itemized 10% fee lines, provider refs). Render-only over useEarnings.
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useAuth } from "@/controllers/auth/AuthContext";
 import { useEarnings } from "@/controllers/use-profile";
 import {
@@ -17,6 +18,7 @@ import { Skeleton } from "@/components/ui/Skeleton";
 
 export function EarningsView() {
   const { account } = useAuth();
+  const router = useRouter();
   const { earnings, loading, error, errorCode, payoutAccount, reload } =
     useEarnings(account?.designer.enabled ? account.username : null);
 
@@ -42,7 +44,7 @@ export function EarningsView() {
           line="Earnings are for designer profiles — become a designer to start earning."
           ctaLabel="Become a designer"
           onCta={() =>
-            window.location.assign("/dashboard/designer/onboarding")
+            router.push("/dashboard/designer/onboarding")
           }
         />
       ) : error || !earnings ? (
@@ -129,7 +131,7 @@ export function EarningsView() {
                 context="orders"
                 line="Payouts and escrow holds will itemize here — publish outfits to get commissioned."
                 ctaLabel="Create a post"
-                onCta={() => window.location.assign("/dashboard/create")}
+                onCta={() => router.push("/dashboard/create")}
               />
             ) : (
               <ul data-testid="transactions-list">

--- a/web/src/components/dashboard/explore/ExploreView.tsx
+++ b/web/src/components/dashboard/explore/ExploreView.tsx
@@ -6,6 +6,7 @@
 // search → sectioned results (Designers above Posts). Render-only over
 // useExplore.
 import { useMemo, useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
 import type { Post } from "@/models";
 import { useExplore } from "@/controllers/use-explore";
 import { Chip } from "@/components/ui/Chip";
@@ -38,6 +39,7 @@ const TURNAROUNDS = [
 ] as const;
 
 export function ExploreView() {
+  const router = useRouter();
   const explore = useExplore();
   const { showToast } = useToasts();
   const [openPostId, setOpenPostId] = useState<string | null>(null);
@@ -204,7 +206,7 @@ export function ExploreView() {
                       })
                     }
                     onOpen={() =>
-                      window.location.assign(`/dashboard/${row.username}`)
+                      router.push(`/dashboard/${row.username}`)
                     }
                   />
                 </li>

--- a/web/src/components/dashboard/feed/FeedSidebar.tsx
+++ b/web/src/components/dashboard/feed/FeedSidebar.tsx
@@ -4,6 +4,7 @@
 // designers (Follow, MI-7). Renders from the vault + suggestions
 // controllers; hidden below xl by the feed view.
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { formatAgoPhrase } from "@/lib/format";
 import { useVault } from "@/controllers/use-vault";
 import { useSuggestions } from "@/controllers/use-suggestions";
@@ -27,6 +28,7 @@ export function FeedSidebar({
   onUnfollow: (username: string, unfollow: () => Promise<void>) => void;
 }) {
   const { account } = useAuth();
+  const router = useRouter();
   const vault = useVault();
   const suggestions = useSuggestions();
   const { showToast } = useToasts();
@@ -119,7 +121,7 @@ export function FeedSidebar({
                     )
                   }
                   onOpen={() =>
-                    window.location.assign(`/dashboard/${row.username}`)
+                    router.push(`/dashboard/${row.username}`)
                   }
                 />
               </li>

--- a/web/src/components/dashboard/feed/FeedView.test.tsx
+++ b/web/src/components/dashboard/feed/FeedView.test.tsx
@@ -29,6 +29,9 @@ vi.mock("@/controllers/auth/AuthContext", () => ({
     account: { username: "kiki.adeyemi", display_name: "Kiki Adeyemi" },
   }),
 }));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn(), replace: vi.fn() }),
+}));
 
 import { FeedView } from "./FeedView";
 import { ToastProvider } from "../toast-context";

--- a/web/src/components/dashboard/feed/FeedView.tsx
+++ b/web/src/components/dashboard/feed/FeedView.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 import type { Post } from "@/models";
 import { useAuth } from "@/controllers/auth/AuthContext";
 import { useFeed } from "@/controllers/use-feed";
+import { Button } from "@/components/ui/Button";
 import { CaughtUpDivider } from "@/components/ui/CaughtUpDivider";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { PostCard } from "@/components/ui/PostCard";
@@ -201,6 +202,25 @@ export function FeedView() {
               >
                 <PostCard skeleton />
                 <PostCard skeleton />
+              </div>
+            ) : feed.loadMoreError ? (
+              // A cursor page failed: the observed cards are still
+              // intersecting, so the MI-6 observer won't re-fire on its
+              // own — offer an explicit retry (PR #103 review).
+              <div
+                role="status"
+                className="flex items-center justify-center gap-3 py-6"
+              >
+                <span className="text-body text-text-2">
+                  Couldn&apos;t load more posts.
+                </span>
+                <Button
+                  kind="quiet"
+                  data-testid="feed-load-more-retry"
+                  onClick={() => void feed.loadMore()}
+                >
+                  Retry
+                </Button>
               </div>
             ) : null}
             {feed.caughtUp ? <CaughtUpDivider className="py-6" /> : null}

--- a/web/src/components/dashboard/feed/FeedView.tsx
+++ b/web/src/components/dashboard/feed/FeedView.tsx
@@ -6,6 +6,7 @@
 // states (MI-19, MI-6). Render-only over useFeed.
 import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import type { Post } from "@/models";
 import { useAuth } from "@/controllers/auth/AuthContext";
 import { useFeed } from "@/controllers/use-feed";
@@ -44,6 +45,7 @@ function storyDesignersOf(posts: Post[]): { username: string; fresh: boolean }[]
 export function FeedView() {
   const feed = useFeed("feed");
   const { account } = useAuth();
+  const router = useRouter();
   const { showToast } = useToasts();
   const [requestPost, setRequestPost] = useState<Post | null>(null);
   const [optionsPost, setOptionsPost] = useState<Post | null>(null);
@@ -163,7 +165,7 @@ export function FeedView() {
             context="feed"
             line="Follow designers to fill your feed"
             ctaLabel="Explore designers"
-            onCta={() => window.location.assign("/dashboard/explore")}
+            onCta={() => router.push("/dashboard/explore")}
           />
         ) : (
           <>

--- a/web/src/components/dashboard/feed/RequestStepperSheet.tsx
+++ b/web/src/components/dashboard/feed/RequestStepperSheet.tsx
@@ -8,6 +8,7 @@
 import { useId, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { ChevronDown } from "lucide-react";
 import type { Post } from "@/models";
 import { formatNaira, formatCm } from "@/lib/format";
@@ -64,6 +65,7 @@ export function RequestStepperSheet({
 }: RequestStepperSheetProps) {
   const stepper = useRequestStepper(post);
   const budgetId = useId();
+  const router = useRouter();
   const [snapshotOpen, setSnapshotOpen] = useState(false);
 
   const close = (open: boolean) => {
@@ -141,7 +143,7 @@ export function RequestStepperSheet({
               onAction={
                 failure.code === "duplicate_request"
                   ? () => {
-                      window.location.assign("/dashboard/orders");
+                      router.push("/dashboard/orders");
                     }
                   : undefined
               }
@@ -163,7 +165,7 @@ export function RequestStepperSheet({
                   context="vault"
                   line="You need measurements first — capture or enter them in your vault."
                   ctaLabel="Go to vault"
-                  onCta={() => window.location.assign("/dashboard/vault")}
+                  onCta={() => router.push("/dashboard/vault")}
                 />
               ) : (
                 <ul className="flex flex-col gap-2">

--- a/web/src/components/dashboard/profile/ProfileView.tsx
+++ b/web/src/components/dashboard/profile/ProfileView.tsx
@@ -7,6 +7,7 @@
 // usePublicProfile.
 import { useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { Lock } from "lucide-react";
 import type { Post } from "@/models";
 import { formatCount } from "@/lib/format";
@@ -45,6 +46,7 @@ function FollowListSheet({
   onUnfollow: (target: UnfollowTarget) => void;
 }) {
   const list = useFollowList(username, kind, open);
+  const router = useRouter();
   const { showToast } = useToasts();
   return (
     <Sheet
@@ -87,9 +89,7 @@ function FollowListSheet({
                     unfollow: () => list.toggleFollow(row),
                   })
                 }
-                onOpen={() =>
-                  window.location.assign(`/dashboard/${row.username}`)
-                }
+                onOpen={() => router.push(`/dashboard/${row.username}`)}
               />
             </li>
           ))}
@@ -101,6 +101,7 @@ function FollowListSheet({
 
 export function ProfileView({ username }: { username: string }) {
   const { account } = useAuth();
+  const router = useRouter();
   const { profile, posts, saved, loading, error, toggleFollow, syncPost } =
     usePublicProfile(username);
   const { showToast } = useToasts();
@@ -174,7 +175,7 @@ export function ProfileView({ username }: { username: string }) {
                 context="explore"
                 line="Save outfits you love and they'll collect here."
                 ctaLabel="Explore outfits"
-                onCta={() => window.location.assign("/dashboard/explore")}
+                onCta={() => router.push("/dashboard/explore")}
               />
             ) : (
               <ul className="grid grid-cols-2 gap-1 md:grid-cols-3" data-testid="saved-grid">
@@ -346,7 +347,7 @@ export function ProfileView({ username }: { username: string }) {
             ctaLabel={tab === "first" && self ? "Create a post" : undefined}
             onCta={
               tab === "first" && self
-                ? () => window.location.assign("/dashboard/create")
+                ? () => router.push("/dashboard/create")
                 : undefined
             }
           />

--- a/web/src/controllers/use-feed.test.ts
+++ b/web/src/controllers/use-feed.test.ts
@@ -127,6 +127,26 @@ describe("useFeed", () => {
     expect(feed).toHaveBeenCalledTimes(2);
   });
 
+  it("records a cursor-page failure and recovers through the explicit retry (PR #103)", async () => {
+    feed.mockResolvedValueOnce({ items: [post("p1")], next_cursor: "c2" });
+    feed.mockRejectedValueOnce(new Error("network"));
+
+    const { result } = renderHook(() => useFeed("feed"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await act(() => result.current.loadMore());
+    // failure is surfaced — not silently swallowed as an incomplete feed
+    expect(result.current.loadMoreError).toBe(true);
+    expect(result.current.loadingMore).toBe(false);
+    expect(result.current.caughtUp).toBe(false);
+
+    // the retry control calls loadMore again: error clears, page appends
+    feed.mockResolvedValueOnce({ items: [post("p2")], next_cursor: null });
+    await act(() => result.current.loadMore());
+    expect(result.current.loadMoreError).toBe(false);
+    expect(result.current.posts.map((p) => p.id)).toEqual(["p1", "p2"]);
+    expect(result.current.caughtUp).toBe(true);
+  });
+
   it("gates concurrent loadMore calls to one in-flight page request", async () => {
     feed.mockResolvedValueOnce({ items: [post("p1")], next_cursor: "c2" });
     let release!: (v: { items: Post[]; next_cursor: null }) => void;

--- a/web/src/controllers/use-feed.ts
+++ b/web/src/controllers/use-feed.ts
@@ -13,6 +13,12 @@ export interface FeedState {
   loading: boolean;
   loadingMore: boolean;
   error: string | null;
+  /**
+   * A cursor page failed (PR #103 review): the observed cards are still
+   * intersecting, so the MI-6 observer won't re-fire on its own — the
+   * view renders an explicit retry that calls loadMore again.
+   */
+  loadMoreError: boolean;
   /** MI-6: caught-up divider once the ranked page is exhausted. */
   caughtUp: boolean;
 }
@@ -38,6 +44,7 @@ export function useFeed(mode: "feed" | "explore" = "feed", filters?: ExploreFilt
     loading: true,
     loadingMore: false,
     error: null,
+    loadMoreError: false,
     caughtUp: false,
   });
   const cursorRef = useRef<string | null>(null);
@@ -60,6 +67,7 @@ export function useFeed(mode: "feed" | "explore" = "feed", filters?: ExploreFilt
           loading: false,
           loadingMore: false,
           error: null,
+          loadMoreError: false,
           caughtUp: page.next_cursor === null,
         });
       },
@@ -89,7 +97,7 @@ export function useFeed(mode: "feed" | "explore" = "feed", filters?: ExploreFilt
     // flight — the ref gate keeps one request per cursor.
     if (!cursor || loadingMoreRef.current) return;
     loadingMoreRef.current = true;
-    setState((s) => ({ ...s, loadingMore: true }));
+    setState((s) => ({ ...s, loadingMore: true, loadMoreError: false }));
     try {
       const page =
         mode === "feed"
@@ -103,7 +111,10 @@ export function useFeed(mode: "feed" | "explore" = "feed", filters?: ExploreFilt
         caughtUp: page.next_cursor === null,
       }));
     } catch {
-      setState((s) => ({ ...s, loadingMore: false }));
+      // The failed page stays reachable through the view's retry control
+      // — the observer alone won't re-fire while the same cards remain
+      // intersecting (PR #103 review).
+      setState((s) => ({ ...s, loadingMore: false, loadMoreError: true }));
     } finally {
       loadingMoreRef.current = false;
     }

--- a/web/src/mocks/store.test.ts
+++ b/web/src/mocks/store.test.ts
@@ -277,6 +277,24 @@ describe("engagement", () => {
     expect(near[0].id).toBe("post-atelier-abuja");
   });
 
+  it("explore near_me requires country equality before city/state tiers (PR #103)", () => {
+    // Same city/state TEXT in a different country must not outrank a
+    // same-country designer — free-text names repeat across borders.
+    store.updateMe("eniola.stitches", {
+      profile_location: { city: "Lagos", state: "Lagos", country: "GH" },
+    });
+    const near = store.explore(
+      "kiki.adeyemi",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+    // her newest-overall post still ranks LAST despite the matching text
+    expect(near[near.length - 1].id).toBe("post-atelier-abuja");
+  });
+
   it("explore near_me is a no-op for callers without a profile location", () => {
     store.updateMe("kiki.adeyemi", { profile_location: null });
     const near = store.explore(
@@ -444,13 +462,13 @@ describe("capture path (webcam, B4)", () => {
 });
 
 describe("ranked pagination (api.md §5 — snapshot cursors)", () => {
-  const feedPage = (cursor: string | null, limit: number) =>
-    store.rankedPage(
-      "kiki.adeyemi",
-      () => store.feed("kiki.adeyemi"),
-      cursor,
-      limit,
-    );
+  const feedPage = (
+    cursor: string | null,
+    limit: number,
+    actor = "kiki.adeyemi",
+    fingerprint = "feed",
+  ) =>
+    store.rankedPage(actor, fingerprint, () => store.feed(actor), cursor, limit);
 
   it("freezes the rank per scroll session — no duplicates or skips mid-scroll", () => {
     const page1 = feedPage(null, 4);
@@ -500,6 +518,40 @@ describe("ranked pagination (api.md §5 — snapshot cursors)", () => {
     expect(garbled.items).toHaveLength(4);
     expect(garbled.items[0].id).toBe(store.feed("kiki.adeyemi")[0].id);
   });
+
+  it("cursors are bound to their actor + query — cross-use starts fresh (PR #103)", () => {
+    const page1 = feedPage(null, 2);
+    const cursor = page1.next_cursor!;
+    // Same cursor presented against another endpoint/filter fingerprint:
+    // not honored — a fresh explore snapshot starts at offset 0.
+    const crossQuery = store.rankedPage(
+      "kiki.adeyemi",
+      "explore|||||",
+      () => store.explore("kiki.adeyemi"),
+      cursor,
+      2,
+    );
+    expect(crossQuery.items[0].id).toBe(store.explore("kiki.adeyemi")[0].id);
+    // Same cursor replayed by ANOTHER actor: not honored either — tunde
+    // gets his own feed's first page, not kiki's snapshot offsets.
+    const crossActor = feedPage(cursor, 2, "tunde.o");
+    expect(crossActor.items[0].id).toBe(store.feed("tunde.o")[0].id);
+    // …while the minting actor's cursor still resolves its snapshot.
+    const page2 = feedPage(cursor, 2);
+    const ids = [...page1.items, ...page2.items].map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("active snapshots survive heavy first-page traffic (no FIFO eviction)", () => {
+    const page1 = feedPage(null, 2);
+    // 150 other scroll sessions begin before this cursor is consumed —
+    // size-based eviction used to invalidate it (PR #103 review).
+    for (let i = 0; i < 150; i++) feedPage(null, 2, "tunde.o");
+    const page2 = feedPage(page1.next_cursor, 2);
+    const ids = [...page1.items, ...page2.items].map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length); // continued, not restarted
+    expect(ids).toHaveLength(4);
+  });
 });
 
 describe("session exports (F2-9 / PLAT-004)", () => {
@@ -530,6 +582,26 @@ describe("session exports (F2-9 / PLAT-004)", () => {
     expect(body.startsWith("%PDF-1.4")).toBe(true);
     expect(body).toContain("shoulder_width: 42.5 cm");
     expect(body.trimEnd().endsWith("%%EOF")).toBe(true);
+  });
+
+  it("pdf export paginates large sessions — no rows fall off the page (PR #103)", () => {
+    // Grow the session well past one page's 36 lines via append-only
+    // corrections (the API accepts unbounded entries).
+    store.appendCorrections(
+      "sess-recent-scan",
+      "kiki.adeyemi",
+      Array.from({ length: 60 }, (_, i) => ({
+        name: `correction_${i}`,
+        value_cm: 40 + i / 10,
+      })),
+    );
+    const { url } = store.sessionExport("sess-recent-scan", "kiki.adeyemi", "pdf");
+    const body = Buffer.from(url.split(",")[1], "base64").toString("utf8");
+    // 4 header lines + 62 measurements = 66 lines → 2 pages
+    expect(body).toContain("/Count 2");
+    // first and LAST rows are both present in the page streams
+    expect(body).toContain("shoulder_width: 42.5 cm");
+    expect(body).toContain("correction_59:");
   });
 
   it("exports are tenant-scoped: another user's session reads not_found", () => {

--- a/web/src/mocks/store.test.ts
+++ b/web/src/mocks/store.test.ts
@@ -128,7 +128,7 @@ describe("order lifecycle enforcement", () => {
   it("rejects illegal transitions with invalid_transition", () => {
     expect(() =>
       store.setStatus("req-apr-1058", "maisonbisi", "in_progress"),
-    ).toThrowError(
+    ).toThrow(
       expect.objectContaining({ code: "invalid_transition", status: 409 }),
     );
   });
@@ -187,11 +187,11 @@ describe("order lifecycle enforcement", () => {
         session_id: "sess-recent-scan",
         delivery,
       }),
-    ).toThrowError(expect.objectContaining({ code: "duplicate_request" }));
+    ).toThrow(expect.objectContaining({ code: "duplicate_request" }));
   });
 
   it("order detail is party-only (strangers get not_found)", () => {
-    expect(() => store.order("req-apr-1042", "tunde.o")).toThrowError(
+    expect(() => store.order("req-apr-1042", "tunde.o")).toThrow(
       expect.objectContaining({ code: "not_found", status: 404 }),
     );
   });
@@ -212,7 +212,7 @@ describe("engagement", () => {
   it("rejects over-length comments", () => {
     expect(() =>
       store.addComment("post-ankara-gown", "kiki.adeyemi", "x".repeat(501)),
-    ).toThrowError(expect.objectContaining({ code: "validation_failed" }));
+    ).toThrow(expect.objectContaining({ code: "validation_failed" }));
   });
 
   it("explore price bands follow the decided defaults", () => {
@@ -324,7 +324,7 @@ describe("earnings (designer view)", () => {
   });
 
   it("non-designers get a 403", () => {
-    expect(() => store.earnings("kiki.adeyemi")).toThrowError(
+    expect(() => store.earnings("kiki.adeyemi")).toThrow(
       expect.objectContaining({ status: 403 }),
     );
   });
@@ -346,7 +346,7 @@ describe("idempotency (api.md §4)", () => {
 
   it("conflicts on the same key with a different payload", () => {
     store.idempotent("k2", "a", () => 1);
-    expect(() => store.idempotent("k2", "b", () => 2)).toThrowError(
+    expect(() => store.idempotent("k2", "b", () => 2)).toThrow(
       expect.objectContaining({ code: "idempotency_conflict", status: 409 }),
     );
   });
@@ -356,7 +356,7 @@ describe("profile", () => {
   it("rejects taken usernames with name_taken", () => {
     expect(() =>
       store.updateMe("kiki.adeyemi", { username: "maisonbisi" }),
-    ).toThrowError(expect.objectContaining({ code: "name_taken", status: 409 }));
+    ).toThrow(expect.objectContaining({ code: "name_taken", status: 409 }));
   });
 
   it("errors are MockApiError instances (envelope-able)", () => {
@@ -440,7 +440,7 @@ describe("capture path (webcam, B4)", () => {
         input_height_cm: 168,
         filename: "fixture-blurry.jpg",
       }),
-    ).toThrowError(expect.objectContaining({ code: "blurry", status: 422 }));
+    ).toThrow(expect.objectContaining({ code: "blurry", status: 422 }));
   });
 
   it("upload → pending_save → save flips complete; retake deletes", () => {
@@ -455,7 +455,7 @@ describe("capture path (webcam, B4)", () => {
     const saved = store.saveSession(session.id, "kiki.adeyemi");
     expect(saved.status).toBe("complete");
     // double-save is an invalid transition
-    expect(() => store.saveSession(session.id, "kiki.adeyemi")).toThrowError(
+    expect(() => store.saveSession(session.id, "kiki.adeyemi")).toThrow(
       expect.objectContaining({ code: "invalid_transition" }),
     );
   });
@@ -607,7 +607,7 @@ describe("session exports (F2-9 / PLAT-004)", () => {
   it("exports are tenant-scoped: another user's session reads not_found", () => {
     expect(() =>
       store.sessionExport("sess-recent-scan", "tunde.o", "csv"),
-    ).toThrowError(expect.objectContaining({ code: "not_found", status: 404 }));
+    ).toThrow(expect.objectContaining({ code: "not_found", status: 404 }));
   });
 });
 
@@ -630,7 +630,7 @@ describe("designer KYC gate + payout scripting", () => {
           city: "Lagos", state: "Lagos", country: "NG",
         },
       }),
-    ).toThrowError(expect.objectContaining({ code: "post_unavailable", status: 409 }));
+    ).toThrow(expect.objectContaining({ code: "post_unavailable", status: 409 }));
   });
 
   it("scripts Paystack resolution: resolved name / mismatch / lapse", () => {
@@ -639,7 +639,7 @@ describe("designer KYC gate + payout scripting", () => {
     expect(resolved.account_name).toBe("KIKI ADEYEMI");
     expect(() =>
       store.resolveBank("kiki.adeyemi", "058", "0012345678"),
-    ).toThrowError(expect.objectContaining({ code: "bank_resolution_failed" }));
+    ).toThrow(expect.objectContaining({ code: "bank_resolution_failed" }));
     const lapsed = store.attachPayoutAccount("kiki.adeyemi", "058", "9999999999");
     expect(lapsed.kyc_state).toBe("lapsed");
     const verified = store.attachPayoutAccount("kiki.adeyemi", "058", "0123456789");
@@ -655,7 +655,7 @@ describe("designer KYC gate + payout scripting", () => {
 
   it("customer cancel is legal from requested/quoted only", () => {
     expect(store.cancel("req-apr-1031", "kiki.adeyemi").status).toBe("cancelled");
-    expect(() => store.cancel("req-apr-1042", "kiki.adeyemi")).toThrowError(
+    expect(() => store.cancel("req-apr-1042", "kiki.adeyemi")).toThrow(
       expect.objectContaining({ code: "invalid_transition" }),
     );
   });
@@ -671,7 +671,7 @@ describe("notification prefs + moderation gate + thread auto-reply", () => {
 
   it("moderation queue is staff-only (kiki yes, tunde no)", () => {
     expect(store.moderationQueue("kiki.adeyemi").length).toBeGreaterThan(0);
-    expect(() => store.moderationQueue("tunde.o")).toThrowError(
+    expect(() => store.moderationQueue("tunde.o")).toThrow(
       expect.objectContaining({ code: "forbidden", status: 403 }),
     );
   });

--- a/web/src/mocks/store.ts
+++ b/web/src/mocks/store.ts
@@ -88,25 +88,43 @@ function deepClone<T>(value: T): T {
 }
 
 /**
- * A real (minimal) one-page PDF for the F2-9 pdf export: Helvetica text
- * lines, uncompressed stream, byte-accurate xref — enough that any viewer
- * opens it. Stands in for the backend's rendered report the way the rest of
- * the mock stands in for api/common.
+ * A real (minimal) PDF for the F2-9 pdf export: Helvetica text lines,
+ * uncompressed streams, byte-accurate xref — enough that any viewer opens
+ * it. Lines flow across as many pages as they need (PR #103 review:
+ * sessions carry unbounded manual measurements + append-only corrections,
+ * so a single page dropped rows below the media box). Stands in for the
+ * backend's rendered report the way the rest of the mock stands in for
+ * api/common.
  */
 function minimalPdf(lines: string[]): Buffer {
   const escape = (s: string) =>
     s.replace(/\\/g, "\\\\").replace(/\(/g, "\\(").replace(/\)/g, "\\)");
-  const text = lines
-    .map((line, i) => `1 0 0 1 72 ${720 - i * 18} Tm (${escape(line)}) Tj`)
-    .join("\n");
-  const stream = `BT\n/F1 12 Tf\n${text}\nET`;
+  // 12pt Helvetica on 18pt leading from y=720 down to a 72pt bottom
+  // margin → 36 lines per US-Letter page.
+  const LINES_PER_PAGE = 36;
+  const chunks: string[][] = [];
+  for (let i = 0; i < Math.max(lines.length, 1); i += LINES_PER_PAGE) {
+    chunks.push(lines.slice(i, i + LINES_PER_PAGE));
+  }
+  // Object layout: 1 catalog · 2 pages · 3 font · then per page i:
+  // page object (4+2i) + its contents stream (5+2i).
   const objects = [
     "<< /Type /Catalog /Pages 2 0 R >>",
-    "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
-    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
-    `<< /Length ${Buffer.byteLength(stream, "utf8")} >>\nstream\n${stream}\nendstream`,
+    `<< /Type /Pages /Kids [${chunks
+      .map((_, i) => `${4 + 2 * i} 0 R`)
+      .join(" ")}] /Count ${chunks.length} >>`,
     "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
   ];
+  for (const [i, chunk] of chunks.entries()) {
+    const text = chunk
+      .map((line, j) => `1 0 0 1 72 ${720 - j * 18} Tm (${escape(line)}) Tj`)
+      .join("\n");
+    const stream = `BT\n/F1 12 Tf\n${text}\nET`;
+    objects.push(
+      `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents ${5 + 2 * i} 0 R >>`,
+      `<< /Length ${Buffer.byteLength(stream, "utf8")} >>\nstream\n${stream}\nendstream`,
+    );
+  }
   let body = "%PDF-1.4\n";
   const offsets: number[] = [];
   objects.forEach((obj, i) => {
@@ -142,9 +160,15 @@ export class MockStore {
   idempotency = new Map<string, { payloadHash: string; response: unknown }>();
   /**
    * Ranked-cursor snapshots (api.md §5 [Decided]): rank is computed at
-   * first page and frozen for the cursor's 24h lifetime.
+   * first page and frozen for the cursor's 24h lifetime. Each snapshot is
+   * bound to its viewer + endpoint/filter fingerprint — a cursor minted
+   * on /feed is not honored on /explore or by another actor (PR #103
+   * review).
    */
-  rankedSnapshots = new Map<string, { ids: string[]; created_at: number }>();
+  rankedSnapshots = new Map<
+    string,
+    { ids: string[]; fingerprint: string; created_at: number }
+  >();
   orderCounter = 1059;
   /** Uploaded media (composer) — stands in for object storage. */
   media = new Map<string, { data: string; contentType: string }>();
@@ -297,12 +321,23 @@ export class MockStore {
    */
   rankedPage(
     viewerUsername: string,
+    queryFingerprint: string,
     rank: () => Post[],
     cursorRaw: string | null,
     limit: number,
   ): { items: Post[]; next_cursor: string | null } {
     const viewer = this.accountByUsername(viewerUsername);
+    const fingerprint = `${viewer.id}|${queryFingerprint}`;
     const DAY_MS = 24 * 60 * 60 * 1000;
+    // Registry hygiene = expiry only: snapshots live for the FULL 24h
+    // cursor lifetime (PR #103 review: size-based FIFO eviction silently
+    // invalidated still-active cursors under multi-user load, producing
+    // duplicate/skipped pages).
+    for (const [key, snapshot] of this.rankedSnapshots) {
+      if (Date.now() - snapshot.created_at >= DAY_MS) {
+        this.rankedSnapshots.delete(key);
+      }
+    }
     let snapshotId: string | null = null;
     let offset = 0;
     if (cursorRaw) {
@@ -313,7 +348,7 @@ export class MockStore {
       const snapshot = this.rankedSnapshots.get(id);
       if (
         snapshot &&
-        Date.now() - snapshot.created_at < DAY_MS &&
+        snapshot.fingerprint === fingerprint &&
         Number.isFinite(parsedOffset) &&
         parsedOffset >= 0
       ) {
@@ -325,14 +360,9 @@ export class MockStore {
       snapshotId = id("rank");
       this.rankedSnapshots.set(snapshotId, {
         ids: rank().map((p) => p.id),
+        fingerprint,
         created_at: Date.now(),
       });
-      // registry hygiene: drop the oldest snapshots past a sane bound
-      while (this.rankedSnapshots.size > 100) {
-        const oldest = this.rankedSnapshots.keys().next().value;
-        if (oldest === undefined) break;
-        this.rankedSnapshots.delete(oldest);
-      }
     }
     const snapshot = this.rankedSnapshots.get(snapshotId)!;
     const live = new Map(this.posts.map((p) => [p.id, p] as const));
@@ -417,10 +447,13 @@ export class MockStore {
         const tierOf = (post: Post): number => {
           const loc = this.designerByUsername(post.designer.username)?.location;
           if (!loc) return 3;
+          // City/state names repeat across countries (locations are
+          // free-text and editable), so the finer tiers require country
+          // equality first (PR #103 review).
+          if (loc.country !== home.country) return 3;
           if (loc.city === home.city && loc.state === home.state) return 0;
           if (loc.state === home.state) return 1;
-          if (loc.country === home.country) return 2;
-          return 3;
+          return 2;
         };
         // Array.prototype.sort is stable — recency survives within tiers.
         posts.sort((a, b) => tierOf(a) - tierOf(b));


### PR DESCRIPTION
## 1 · PR #103 round-2 review fixes (`4392ca4`)

All five Codex P2 threads left on merged #103, each replied on its thread:

- **Cursor↔actor/query binding** — rank snapshots store an actor + endpoint/filter fingerprint; a `/feed` cursor presented on `/explore` or replayed by another actor starts a fresh scroll session instead of leaking the original snapshot.
- **Near-me tier country equality** — city/state tiers require `country` equality first; identical free-text names across borders no longer promote.
- **Snapshot lifetime** — expiry-only sweep (24h); the size-100 FIFO eviction that could invalidate still-active cursors under multi-user load is gone (unit test runs 150 concurrent sessions against a live cursor).
- **PDF export pagination** — export lines flow across US-Letter pages (36/page, byte-accurate multi-page xref); unbounded corrections never fall off the media box.
- **Load-more retry** — `useFeed` records `loadMoreError` and FeedView renders an explicit Retry control (the intersecting MI-6 observer never re-fires by itself); the e2e aborts the first cursor request and walks the recovery.

Round-1 threads (profile-grid sync, snapshot cursors, live near-me location) verified present in the merged head before starting.

## 2 · Code-quality pass (`4519eb8`)

- 11 in-app navigations converted from `window.location.assign` (full document reloads) to `next/navigation` `router.push` across profile/explore/feed-sidebar/request-stepper/feed/earnings/composer; origin/hash reads stay on `window.location` by design.
- Vitest deprecated `toThrowError` → `toThrow`.
- Sweep results otherwise clean (greenfield): zero TODO/FIXME, no dead code or stale comments found beyond the docs items below, no `ts-ignore`/`any`, `strict: true`, no unused dependencies (`react-dom`, `@types/*`, `jsdom`, `typescript` are implicit toolchain/peer requirements), analytics `console.debug` is the documented TEST_MODE observable no-op.

## 3 · Docs current-system sweep (`590c5f9`)

- engineering.md drops the `ALLOWED_ORIGINS` rename history; web-implementation.md drops the reference to the removed 12-route sweep. `[Decided]`/`[Directive]` markers, as-built notes, and backlog rows (future replacements in features.md) are intentionally untouched.

## 4 · Script-name convergence — verified, no change needed

`dev/build/start/lint/typecheck/check:boundaries/test/test:watch/test:e2e` already match the siblings name-for-name.

## 5 · Cross-repo config divergence catalog (for the parity agent — no code changes here)

| Area | apparule | expendit | upstat |
| --- | --- | --- | --- |
| Boundary-check impl | `bash scripts/check-boundaries.sh` | `node scripts/check-boundaries.mjs` | `node scripts/check-boundaries.mjs` |
| Where boundaries ride | `test` (`check:boundaries && vitest run`) | inside composite `lint` | `lint` (`eslint && check:boundaries`) |
| `lint` composition | bare `eslint` | prettier:check + eslint + boundaries (+ `lint:fix`, `lint:staged` family) | eslint + boundaries |
| `typecheck` | `tsc --noEmit` | `next typegen && tsc --noEmit` | `tsc --noEmit` |
| vitest plugin/alias | `@vitejs/plugin-react` + manual `@` alias | none (`resolve.tsconfigPaths: true`) | `@vitejs/plugin-react` + manual `@` alias |
| vitest setup path | `./vitest.setup.ts` (root) | `src/vitest.setup.ts` | `./vitest.setup.ts` (root) |
| vitest env | no `NEXT_PUBLIC_TEST_MODE`; `globals: true`; jsdom url localhost:3000; no `src/legacy` exclude | `NEXT_PUBLIC_TEST_MODE=1`; no globals; legacy exclude | `NEXT_PUBLIC_TEST_MODE=1`; `globals: true`; legacy + e2e excludes |
| playwright port | hardcoded `3311`, `localhost`, dev server always | `PW_PORT` env (default 3100), `localhost`, CI runs `next start` | `UPSTAT_E2E_PORT` env (default 3131), `127.0.0.1`, dev server always |

## Gates

lint · typecheck · unit (465) · Playwright e2e (45) · TEST_MODE build — all green locally per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)