### PR TITLE
docs: explore filter chips as built + vault per-session export (F2-9)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -326,7 +326,7 @@ Stage 5 and non-blocking; everything else feeds Stages 1–4.
 | ThreadBubble | side: sent / received · content: text / image attachment (images only, [order-lifecycle.md](order-lifecycle.md) §5) · state: sending / sent / failed · typing variant: three-dot "responding…" pulse (MI-17) · theme ×2 · **as built (2026-07-17):** typing folds into `content: text / image / typing` (13 children — not the full 2×3×3 matrix; the send-state axis doesn't apply to typing) |
 | CommentRow | avatar 32 + username + text + timestamp + like heart · state: default / liked / posting-optimistic (MI-18) / reply-indent · theme ×2 |
 | NotificationRow | kind: like / follow / comment / quote / status-change / payout · state: unread / read · trailing: post thumb / Follow button / none · theme ×2 |
-| SessionRow | context: history (date + method chip + values + delete) / picker (radio select + freshness warning: fresh / aging / stale) · state: default / selected · theme ×2 |
+| SessionRow | context: history (date + method chip + values + per-session CSV/PDF export controls + delete — the vault history sheet exports one session per file, F2-9) / picker (radio select + freshness warning: fresh / aging / stale) · state: default / selected · theme ×2 **[Revised 2026-07-19]** |
 | ModerationQueueRow | subject preview: post/comment thumb + reporter context · reason · actions: hide_post / suspend_account / dismiss · state: open / actioned (audit: actioned_by) · theme ×2 |
 | EarningsSummary | balance (released) / pending (held escrow) cards · TransactionRow: kind payout / escrow-held / fee-line (10%) · amount tabular + provider ref · theme ×2 |
 | EmptyState (extends §8.2) | + capture/camera-permission-denied: explainer + settings deep-link + "enter manually instead" |

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -57,7 +57,7 @@ toggle, support (`clients.cuesoft.io`).
 - Masonry grid of outfit posts (1:1 crops); hover: like/comment counts
   overlay fade-in 120ms; click → post modal (IG desktop pattern: media left,
   detail right).
-- Filter chips: style tags, price band, turnaround time, "near me" **[Proposed]**
+- Filter chips: style tags, price band, turnaround (≤1w / ≤2w / ≤1m), "Near me" — Near me re-ranks results (city > state > country); it is not a hard filter **[Revised 2026-07-19]**
   — proximity ranking by designer `profile_location` (data-model.md §2,
   X-10 tier 1); designers without a location simply don't rank in proximity
   results (no hard gate).


### PR DESCRIPTION
## Summary

Pins the P1 PR3 UI additions **[Revised 2026-07-19]** where the docs quoted the old constructions:

- **`pages.md` B2** — filter chip row: style tags · price band · **turnaround (≤1w / ≤2w / ≤1m)** · **"Near me"** (re-ranks city > state > country — no hard filter); `[Proposed]` dropped, the row is built.
- **`design.md` §8.2 SessionRow** — history rows carry **per-session CSV/PDF export controls** ahead of the delete action (vault history sheet, F2-9).

Matches the Figma file as revised today: all 8 explore filter chip rows normalized (B2 ×2 · C3 ×4 · Home demos ×2), SessionRow history variants gained the export cluster, Sheet set carries the size-axis contract (default 480 / wide 896 viewport-clamped) with a wide exemplar on canvas, PostCard notes the wide-Sheet post-detail context, and the MI-6 feed skeleton/caught-up state frames were verified present (no additions needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)