### PR TITLE
fix(web): /docs/api header coexistence + tri-state theme (light | dark | system)

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -290,11 +290,20 @@ approved gap implementations:
   source — served by the `/docs/api/openapi.yaml` route handler from a
   build-time string asset (`npm run generate:openapi`, wired as
   `predev`/`prebuild`/`pretypecheck`; output gitignored under
-  `src/generated/`). Theme follows ThemeProvider (Scalar `darkMode`
-  config; its own toggle hidden); remote default fonts are disabled
-  (self-host ethos). The footer Docs column's "API reference" links
-  `/docs/api`; `e2e/docs-api.spec.ts` pins route 200, a rendered
-  operation from the spec, the served document, and the footer handoff.
+  `src/generated/`). Theme: the embed is forced to the RESOLVED theme
+  via Scalar's `forceDarkModeState` (a creation-time override — the view
+  mounts after hydration and remounts on theme change, since
+  `updateConfiguration` never re-applies it); Scalar's own toggle is
+  hidden and its remote default fonts are disabled (self-host ethos).
+  Header construction: the sticky marketing nav (h-16) and Scalar's
+  sticky layout coexist via `--scalar-custom-header-height: 64px` on the
+  embed wrapper (offsets Scalar's sticky sidebar/mobile bar below the
+  nav and shrinks its viewport math — one coherent page scroll) plus
+  `isolate` so no Scalar z-index paints over the nav. The footer Docs
+  column's "API reference" links `/docs/api`; `e2e/docs-api.spec.ts`
+  pins route 200, a rendered operation from the spec, the served
+  document, the footer handoff, the header/scroll sanity and the
+  embed-theme sync.
 
 Screen-state parity **[Directive 2026-07-18, carried from design.md §8.1]**:
 every data-driven screen ships default, empty, and loading states — the
@@ -304,9 +313,25 @@ Figma templates, and the QA loop checks all three.
 ## 3. Token mapping — design.md §2 → `web/src/design/tokens.css`
 
 One custom property per Figma variable in the `apparule/tokens` collection
-(design.md §7); light values on `:root`, dark on `[data-theme="dark"]`,
-`prefers-color-scheme` honored with manual override (the NavRail theme
-toggle sets `data-theme`).
+(design.md §7); light values on `:root`, dark on `[data-theme="dark"]`
+(the tokens.css `prefers-color-scheme` block remains as the no-JS
+fallback only).
+
+**Theme contract as-built (2026-07-20, ratified — identical across
+apparule, expendit and upstat).** The preference is tri-state
+light | dark | system: `ThemeProvider` persists it at `apparule.theme`
+("light"/"dark" stored explicitly; KEY ABSENT = system — the
+cross-product storage convention), and `data-theme` on `<html>` always
+carries the RESOLVED theme — system resolves via `prefers-color-scheme`
+and tracks it live (a matchMedia listener updates `data-theme` on an OS
+flip, no reload). The pre-paint init script applies the resolved theme
+(no FOUC in any mode). `ThemeToggle` (marketing nav + NavRail rail item)
+cycles light → dark → system with distinct icons (sun / moon / monitor);
+its aria-label announces the active mode. Settings → Appearance keeps
+the three-way System/Light/Dark select over the same `setPreference`.
+The Scalar embed follows `resolvedTheme` (F0-8 note, §2). Unit tests pin
+the storage convention, live system tracking and cycle order; e2e pins
+the cycle, an emulated OS flip in system mode and reload persistence.
 
 | Group | Token names |
 | --- | --- |

--- a/web/e2e/docs-api.spec.ts
+++ b/web/e2e/docs-api.spec.ts
@@ -38,6 +38,78 @@ test.describe("API reference — /docs/api", () => {
     expect(body).toContain("title: Apparule API");
   });
 
+  test("header behaves: nav stays visible over the embed, one scroll container", async ({
+    page,
+  }) => {
+    await page.goto("/docs/api");
+    await expect(
+      page.getByRole("heading", { name: "Apparule API" }),
+    ).toBeVisible({ timeout: 20_000 });
+
+    // One coherent scroll container: the page scrolls; no full-viewport
+    // inner scroller wraps the embed (Scalar's viewport math is offset by
+    // --scalar-custom-header-height so its sidebar fits under the nav).
+    const layout = await page.evaluate(() => ({
+      pageScrollable:
+        document.documentElement.scrollHeight > window.innerHeight,
+      fullHeightInnerScrollers: [...document.querySelectorAll("*")].filter(
+        (el) =>
+          el.scrollHeight > el.clientHeight + 10 &&
+          ["auto", "scroll"].includes(getComputedStyle(el).overflowY) &&
+          el.clientHeight >= window.innerHeight,
+      ).length,
+    }));
+    expect(layout.pageScrollable).toBe(true);
+    expect(layout.fullHeightInnerScrollers).toBe(0);
+
+    // After scrolling, the marketing nav (sticky) is still fully visible —
+    // Scalar's sticky sidebar must not paint over it (isolate + offset).
+    await page.mouse.wheel(0, 800);
+    await expect(
+      page.getByRole("link", { name: "Star cuesoftinc/apparule on GitHub" }),
+    ).toBeVisible();
+    const navBox = await page
+      .locator("nav")
+      .first()
+      .evaluate((el) => el.getBoundingClientRect().top);
+    expect(navBox).toBe(0);
+  });
+
+  test("the embed follows the tri-state theme, incl. a live OS flip in system mode", async ({
+    page,
+  }) => {
+    await page.emulateMedia({ colorScheme: "light" });
+    await page.goto("/docs/api");
+    await expect(
+      page.getByRole("heading", { name: "Apparule API" }),
+    ).toBeVisible({ timeout: 20_000 });
+
+    // Scalar mirrors the resolved theme on body (light-mode/dark-mode).
+    const body = page.locator("body");
+    await expect(body).toHaveClass(/light-mode/);
+
+    // system mode (default) follows an OS scheme flip live.
+    await page.emulateMedia({ colorScheme: "dark" });
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    await expect(body).toHaveClass(/dark-mode/, { timeout: 15_000 });
+
+    // Explicit choice via the nav toggle wins over the OS (dark stays after
+    // cycling system → light → the embed resyncs to light).
+    await page
+      .getByRole("button", { name: "Theme: system — switch to light" })
+      .click();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+    await expect(body).toHaveClass(/light-mode/, { timeout: 15_000 });
+    await expect(
+      page.getByRole("heading", { name: "Apparule API" }),
+    ).toBeVisible({ timeout: 20_000 });
+
+    // The choice persists across reload (stored at apparule.theme).
+    await page.reload();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+    await expect(body).toHaveClass(/light-mode/, { timeout: 20_000 });
+  });
+
   test("the footer API reference link navigates to /docs/api", async ({
     page,
   }) => {

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -152,14 +152,32 @@ test.describe("Marketing site — home page", () => {
     ).toBeInViewport();
   });
 
-  test("theme toggle switches light and dark", async ({ page }) => {
+  test("theme toggle cycles light → dark → system", async ({ page }) => {
     await page.goto("/");
     const html = page.locator("html");
 
-    await page.getByRole("button", { name: /switch to dark theme/i }).click();
+    // Fresh visit = system (key absent), resolved from the OS (light here).
+    await expect(html).toHaveAttribute("data-theme", "light");
+    await page
+      .getByRole("button", { name: "Theme: system — switch to light" })
+      .click();
+    await expect(html).toHaveAttribute("data-theme", "light");
+
+    await page
+      .getByRole("button", { name: "Theme: light — switch to dark" })
+      .click();
     await expect(html).toHaveAttribute("data-theme", "dark");
 
-    await page.getByRole("button", { name: /switch to light theme/i }).click();
+    // Third press returns to system — resolved live from the OS.
+    await page
+      .getByRole("button", { name: "Theme: dark — switch to system" })
+      .click();
+    await expect(html).toHaveAttribute("data-theme", "light");
+
+    // System mode follows an OS-level scheme flip without a reload.
+    await page.emulateMedia({ colorScheme: "dark" });
+    await expect(html).toHaveAttribute("data-theme", "dark");
+    await page.emulateMedia({ colorScheme: "light" });
     await expect(html).toHaveAttribute("data-theme", "light");
   });
 
@@ -444,10 +462,11 @@ test.describe("nav/footer parity canon", () => {
       0,
     );
 
-    // the theme toggle works from inside the panel
-    await panel.getByRole("button", { name: /switch to dark theme/i }).click();
+    // the theme toggle works from inside the panel (system → light → dark)
+    await panel.getByRole("button", { name: /^Theme: system/ }).click();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+    await panel.getByRole("button", { name: /^Theme: light/ }).click();
     await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
-    await panel.getByRole("button", { name: /switch to light theme/i }).click();
 
     // a link click closes the disclosure
     await panel.getByRole("link", { name: "Features" }).click();
@@ -505,28 +524,28 @@ test.describe("nav/footer parity canon", () => {
   test("theme toggle flips and persists on home and dashboard", async ({
     page,
   }) => {
-    // marketing surface
+    // marketing surface: system → light → dark, persisted across reload
     await page.goto("/");
-    await page.getByRole("button", { name: /switch to dark theme/i }).click();
+    await page.getByRole("button", { name: /^Theme: system/ }).click();
+    await page.getByRole("button", { name: /^Theme: light/ }).click();
     await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
     await page.reload();
     await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
 
-    // dashboard surface (same apparule.theme key via NavRail toggle)
+    // dashboard surface (same apparule.theme key via NavRail toggle):
+    // dark → system removes the key; resolved follows the OS again.
     await page.goto("/signin");
     await page.getByRole("button", { name: /continue with google/i }).click();
     await page.waitForURL("**/dashboard");
     await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
-    await page.getByRole("button", { name: /switch to light theme/i }).click();
-    await expect(page.locator("html")).not.toHaveAttribute(
-      "data-theme",
-      "dark",
+    await page.getByRole("button", { name: /^Theme: dark/ }).click();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+    const stored = await page.evaluate(() =>
+      window.localStorage.getItem("apparule.theme"),
     );
+    expect(stored).toBeNull();
     await page.reload();
-    await expect(page.locator("html")).not.toHaveAttribute(
-      "data-theme",
-      "dark",
-    );
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
   });
 });
 

--- a/web/src/app/docs/api/page.tsx
+++ b/web/src/app/docs/api/page.tsx
@@ -21,7 +21,13 @@ export default function ApiReferencePage() {
     <div className="flex min-h-screen flex-col bg-bg text-text">
       <PageViewTracker path="/docs/api" />
       <HomeNavBar />
-      <main className="flex-1">
+      {/* Header-fix construction (2026-07-20): the sticky marketing nav
+          (h-16 = 64px) and Scalar's own sticky layout coexist by telling
+          Scalar about the header — `--scalar-custom-header-height` offsets
+          its sticky sidebar/mobile header below the nav and shrinks its
+          viewport math to match (one coherent scroll). `isolate` opens a
+          stacking context so no Scalar z-index can paint over the nav. */}
+      <main className="isolate flex-1 [--scalar-custom-header-height:64px]">
         <ScalarApiReference />
       </main>
       {/* Minimal footer strip — verbatim legal line only (parity canon). */}

--- a/web/src/components/docs/ScalarApiReference.tsx
+++ b/web/src/components/docs/ScalarApiReference.tsx
@@ -2,48 +2,46 @@
 
 // Scalar API reference embed (F0-8) — renders the interactive reference
 // from the repo's canonical spec served at /docs/api/openapi.yaml. The
-// embed follows the product theme: dark/light comes from ThemeProvider
-// (system-resolved), Scalar's own toggle is hidden, and the remote
-// default fonts are disabled (self-host ethos: no external runtime
-// dependencies) so the reference renders in the app's font stack.
+// embed follows the product theme contract (2026-07-20): Scalar's dark
+// mode is FORCED to the resolved theme from ThemeProvider (system tracks
+// the OS live) via `forceDarkModeState` — `darkMode` alone is only an
+// initial hint and loses to Scalar's internal state. Scalar's own theme
+// toggle is hidden (ours is the master) and the remote default fonts are
+// disabled (self-host ethos: no external runtime dependencies). The dev
+// toolbar needs no config: Scalar only shows it on localhost.
 import { useSyncExternalStore } from "react";
 import { ApiReferenceReact } from "@scalar/api-reference-react";
 import "@scalar/api-reference-react/style.css";
 import { useTheme } from "@/design/ThemeProvider";
 
-const DARK_QUERY = "(prefers-color-scheme: dark)";
-
-function subscribeToSystemTheme(listener: () => void): () => void {
-  const query = window.matchMedia(DARK_QUERY);
-  query.addEventListener("change", listener);
-  return () => query.removeEventListener("change", listener);
-}
-
-function readSystemPrefersDark(): boolean {
-  return window.matchMedia(DARK_QUERY).matches;
-}
-
-// Server snapshot: light — Scalar only mounts client-side and the config
-// updates on hydration, so this is just the pre-mount default.
-function getServerSnapshot(): boolean {
-  return false;
+// Hydration probe: false for the server/hydration render, true after.
+const emptySubscribe = () => () => {};
+function useHydrated(): boolean {
+  return useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false,
+  );
 }
 
 export function ScalarApiReference() {
-  const { preference } = useTheme();
-  const systemPrefersDark = useSyncExternalStore(
-    subscribeToSystemTheme,
-    readSystemPrefersDark,
-    getServerSnapshot,
-  );
-  const isDark =
-    preference === "system" ? systemPrefersDark : preference === "dark";
+  const { resolvedTheme } = useTheme();
+
+  // Scalar reads `forceDarkModeState` ONCE at creation (a frozen override —
+  // `updateConfiguration` never re-applies it), so: (1) skip the hydration
+  // frame, where the provider still reports the server snapshot, so the
+  // first create sees the real resolved theme; (2) remount on resolved-theme
+  // changes (`key`) so every theme flip re-creates the app with the right
+  // forced state — configuration only, no reaching into Scalar internals.
+  const hydrated = useHydrated();
+  if (!hydrated) return null;
 
   return (
     <ApiReferenceReact
+      key={resolvedTheme}
       configuration={{
         url: "/docs/api/openapi.yaml",
-        darkMode: isDark,
+        forceDarkModeState: resolvedTheme,
         hideDarkModeToggle: true,
         withDefaultFonts: false,
       }}

--- a/web/src/components/home/HomeNavBar.tsx
+++ b/web/src/components/home/HomeNavBar.tsx
@@ -5,18 +5,14 @@
 // `github_click` / `try_cloud_click`, the Try Cloud → /signin handoff, and
 // the theme toggle.
 import { useRouter } from "next/navigation";
-import { Moon, Sun } from "lucide-react";
 import { HomeNav } from "@/components/ui/HomeNav";
-import { IconButton } from "@/components/ui/IconButton";
-import { useTheme } from "@/design/ThemeProvider";
+import { ThemeToggle } from "@/components/ui/ThemeToggle";
 import { track } from "@/controllers/use-analytics";
 import { useGithubStars } from "@/controllers/use-github-stars";
 
 export function HomeNavBar() {
   const router = useRouter();
   const stars = useGithubStars();
-  const { preference, setPreference } = useTheme();
-  const nextTheme = preference === "dark" ? "light" : "dark";
 
   return (
     <HomeNav
@@ -26,15 +22,7 @@ export function HomeNavBar() {
         track("try_cloud_click", { section: "nav" });
         router.push("/signin");
       }}
-      trailing={
-        <IconButton
-          size="sm"
-          aria-label={`Switch to ${nextTheme} theme`}
-          onClick={() => setPreference(nextTheme)}
-        >
-          {preference === "dark" ? <Sun size={20} /> : <Moon size={20} />}
-        </IconButton>
-      }
+      trailing={<ThemeToggle size="sm" />}
     />
   );
 }

--- a/web/src/components/home/interactive.test.tsx
+++ b/web/src/components/home/interactive.test.tsx
@@ -253,21 +253,29 @@ describe("DevelopersSection (A7b)", () => {
 });
 
 describe("HomeNavBar (A1)", () => {
-  it("toggles the theme (light ↔ dark) from the nav", async () => {
+  it("cycles the theme (light → dark → system) from the nav", async () => {
     render(
       <ThemeProvider>
         <HomeNavBar />
       </ThemeProvider>,
     );
+    // Default preference is system — the label announces the active mode.
     const toggle = screen.getByRole("button", {
-      name: /switch to dark theme/i,
+      name: "Theme: system — switch to light",
     });
     await userEvent.click(toggle);
+    expect(document.documentElement).toHaveAttribute("data-theme", "light");
+    await userEvent.click(
+      screen.getByRole("button", { name: "Theme: light — switch to dark" }),
+    );
     expect(document.documentElement).toHaveAttribute("data-theme", "dark");
     await userEvent.click(
-      screen.getByRole("button", { name: /switch to light theme/i }),
+      screen.getByRole("button", { name: "Theme: dark — switch to system" }),
     );
+    // system resolves via matchMedia (light in the test polyfill) and the
+    // stored key is removed.
     expect(document.documentElement).toHaveAttribute("data-theme", "light");
+    expect(window.localStorage.getItem("apparule.theme")).toBeNull();
   });
 
   it("nav: Sign in text link + Try Cloud CTA hands off with try_cloud_click", async () => {

--- a/web/src/components/ui/NavRail.test.tsx
+++ b/web/src/components/ui/NavRail.test.tsx
@@ -49,8 +49,10 @@ describe("NavRail (§8.2b)", () => {
 
   it("footer slot carries theme toggle + support link", () => {
     renderRail({ expanded: true });
+    // Tri-state cycle (theme contract 2026-07-20): the label announces
+    // the active mode and the next one.
     expect(
-      screen.getByRole("button", { name: /switch to .* theme/i }),
+      screen.getByRole("button", { name: /^Theme: .* — switch to .*/ }),
     ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /support/i })).toHaveAttribute(
       "href",

--- a/web/src/components/ui/NavRail.tsx
+++ b/web/src/components/ui/NavRail.tsx
@@ -9,16 +9,19 @@ import Link from "next/link";
 import {
   Home,
   Info,
-  Moon,
   Package,
   Plus,
   Ruler,
   Search,
   Settings,
-  Sun,
   User,
   type LucideIcon,
 } from "lucide-react";
+import {
+  THEME_CYCLE,
+  THEME_ICONS,
+  themeToggleLabel,
+} from "@/components/ui/ThemeToggle";
 import { useTheme } from "@/design/ThemeProvider";
 
 export interface NavRailItemSpec {
@@ -68,7 +71,8 @@ export function NavRail({
   className,
 }: NavRailProps) {
   const { preference, setPreference } = useTheme();
-  const nextTheme = preference === "dark" ? "light" : "dark";
+  // Tri-state cycle (theme contract 2026-07-20): light → dark → system.
+  const ThemeIcon = THEME_ICONS[preference];
   return (
     <nav
       data-expanded={expanded}
@@ -104,11 +108,11 @@ export function NavRail({
       <div className="flex flex-col gap-1 pt-3">
         <button
           type="button"
-          onClick={() => setPreference(nextTheme)}
-          aria-label={`Switch to ${nextTheme} theme`}
+          onClick={() => setPreference(THEME_CYCLE[preference])}
+          aria-label={themeToggleLabel(preference)}
           className={itemClasses(false, expanded)}
         >
-          {preference === "dark" ? <Sun size={24} /> : <Moon size={24} />}
+          <ThemeIcon size={24} />
           {expanded ? <span>Theme</span> : null}
         </button>
         <a

--- a/web/src/components/ui/ThemeToggle.tsx
+++ b/web/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+// ThemeToggle — the tri-state cycle control (theme contract, ratified
+// 2026-07-20): light → dark → system → light, with a distinct icon per
+// mode (sun / moon / monitor) and an aria-label announcing the ACTIVE
+// mode plus the mode a press switches to. Rendered as an IconButton in
+// the marketing nav; NavRail reuses the cycle/icon/label primitives with
+// its own rail-item styling.
+import { Monitor, Moon, Sun } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { IconButton } from "@/components/ui/IconButton";
+import { useTheme, type ThemePreference } from "@/design/ThemeProvider";
+
+/** light → dark → system → light. */
+export const THEME_CYCLE: Record<ThemePreference, ThemePreference> = {
+  light: "dark",
+  dark: "system",
+  system: "light",
+};
+
+export const THEME_ICONS: Record<ThemePreference, LucideIcon> = {
+  light: Sun,
+  dark: Moon,
+  system: Monitor,
+};
+
+/** Accessible name: announces the active mode and the next one. */
+export function themeToggleLabel(preference: ThemePreference): string {
+  return `Theme: ${preference} — switch to ${THEME_CYCLE[preference]}`;
+}
+
+export function ThemeToggle({ size = "sm" }: { size?: "md" | "sm" }) {
+  const { preference, setPreference } = useTheme();
+  const Icon = THEME_ICONS[preference];
+  return (
+    <IconButton
+      size={size}
+      aria-label={themeToggleLabel(preference)}
+      onClick={() => setPreference(THEME_CYCLE[preference])}
+    >
+      <Icon size={20} />
+    </IconButton>
+  );
+}

--- a/web/src/design/ThemeProvider.test.tsx
+++ b/web/src/design/ThemeProvider.test.tsx
@@ -1,15 +1,18 @@
-// Theme provider: manual override sets data-theme + persists; "system"
-// clears the attribute (tokens.css then follows prefers-color-scheme).
-import { beforeEach, describe, expect, it } from "vitest";
-import { render, screen } from "@testing-library/react";
+// Theme provider — tri-state contract (ratified 2026-07-20): preference
+// light | dark | system persisted at apparule.theme (key absent = system);
+// data-theme always carries the RESOLVED theme; system tracks
+// prefers-color-scheme live via a matchMedia listener.
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { THEME_STORAGE_KEY, ThemeProvider, useTheme } from "./ThemeProvider";
 
 function Probe() {
-  const { preference, setPreference } = useTheme();
+  const { preference, resolvedTheme, setPreference } = useTheme();
   return (
     <div>
       <span data-testid="pref">{preference}</span>
+      <span data-testid="resolved">{resolvedTheme}</span>
       <button onClick={() => setPreference("dark")}>dark</button>
       <button onClick={() => setPreference("light")}>light</button>
       <button onClick={() => setPreference("system")}>system</button>
@@ -17,28 +20,62 @@ function Probe() {
   );
 }
 
+// Controllable matchMedia stand-in: the provider attaches ONE module-level
+// change listener on first subscribe; `flipSystem` drives it like an OS
+// theme change. Installed before the first render in this file so the
+// provider binds to it.
+let systemMatches = false;
+const changeListeners = new Set<() => void>();
+function flipSystem(matches: boolean) {
+  systemMatches = matches;
+  act(() => {
+    for (const l of changeListeners) l();
+  });
+}
+
+beforeAll(() => {
+  window.matchMedia = ((query: string) => ({
+    get matches() {
+      return systemMatches;
+    },
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: (_: string, cb: () => void) => changeListeners.add(cb),
+    removeEventListener: (_: string, cb: () => void) =>
+      changeListeners.delete(cb),
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+});
+
 beforeEach(() => {
   window.localStorage.clear();
   document.documentElement.removeAttribute("data-theme");
+  systemMatches = false;
 });
 
 describe("ThemeProvider", () => {
   it("themeInitScript stays in sync with the storage key", async () => {
     const { themeInitScript } = await import("./ThemeProvider");
     expect(themeInitScript).toContain(`"${THEME_STORAGE_KEY}"`);
+    // System mode must resolve pre-paint (no FOUC): the script consults
+    // prefers-color-scheme and always sets the resolved data-theme.
+    expect(themeInitScript).toContain("prefers-color-scheme");
+    expect(themeInitScript).toContain("setAttribute");
   });
 
-  it("defaults to system (no data-theme attribute)", () => {
+  it("defaults to system and reports the resolved OS theme", () => {
     render(
       <ThemeProvider>
         <Probe />
       </ThemeProvider>,
     );
     expect(screen.getByTestId("pref")).toHaveTextContent("system");
-    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+    expect(screen.getByTestId("resolved")).toHaveTextContent("light");
   });
 
-  it("manual dark override sets the attribute and persists", async () => {
+  it("manual dark override applies the resolved attribute and persists", async () => {
     render(
       <ThemeProvider>
         <Probe />
@@ -47,18 +84,49 @@ describe("ThemeProvider", () => {
     await userEvent.click(screen.getByRole("button", { name: "dark" }));
     expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
     expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+    expect(screen.getByTestId("resolved")).toHaveTextContent("dark");
   });
 
-  it("returning to system clears override + storage", async () => {
+  it("returning to system removes the stored key (absent = system) and re-resolves", async () => {
     render(
       <ThemeProvider>
         <Probe />
       </ThemeProvider>,
     );
-    await userEvent.click(screen.getByRole("button", { name: "light" }));
-    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    await userEvent.click(screen.getByRole("button", { name: "dark" }));
     await userEvent.click(screen.getByRole("button", { name: "system" }));
-    expect(document.documentElement.hasAttribute("data-theme")).toBe(false);
+    // Key absent = system — the cross-product storage convention.
     expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBeNull();
+    // data-theme stays populated with the RESOLVED theme (light OS here).
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    expect(screen.getByTestId("pref")).toHaveTextContent("system");
+  });
+
+  it("system mode tracks prefers-color-scheme changes live", async () => {
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "system" }));
+    expect(screen.getByTestId("resolved")).toHaveTextContent("light");
+    flipSystem(true); // OS switches to dark
+    expect(screen.getByTestId("resolved")).toHaveTextContent("dark");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+    flipSystem(false); // and back
+    expect(screen.getByTestId("resolved")).toHaveTextContent("light");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+  });
+
+  it("explicit preferences ignore OS theme changes", async () => {
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "dark" }));
+    flipSystem(false);
+    expect(screen.getByTestId("resolved")).toHaveTextContent("dark");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
   });
 });

--- a/web/src/design/ThemeProvider.tsx
+++ b/web/src/design/ThemeProvider.tsx
@@ -1,18 +1,24 @@
 "use client";
 
 /**
- * Theme provider — manual light/dark override with system default
- * (docs/design.md §2, §7: true Light/Dark modes; components bind one token
- * and switch by mode).
+ * Theme provider — tri-state light | dark | system (docs/design.md §2, §7;
+ * theme contract ratified 2026-07-20, identical across apparule, expendit
+ * and upstat):
  *
- * - `system` (default): no data-theme attribute → tokens.css follows
- *   prefers-color-scheme.
- * - `light` / `dark`: data-theme set on <html>, persisted in localStorage.
+ * - `preference` is what the user chose; persisted at `apparule.theme`
+ *   ("light"/"dark" stored explicitly; KEY ABSENT = system — the
+ *   cross-product storage convention).
+ * - `data-theme` on <html> always carries the RESOLVED theme ("light" or
+ *   "dark"): explicit preferences resolve to themselves; system resolves
+ *   via `prefers-color-scheme` and tracks it LIVE (matchMedia listener —
+ *   an OS theme flip updates data-theme without a reload).
+ * - tokens.css keeps its media-query fallback for the pre-JS/no-JS case;
+ *   with JS the attribute is authoritative.
  *
  * The preference lives in an external module store (localStorage-backed,
  * read via useSyncExternalStore) so no state syncs through effects; a tiny
- * inline script in the root layout applies the persisted override before
- * first paint to avoid a theme flash.
+ * inline script in the root layout applies the resolved theme before first
+ * paint (no FOUC in any mode, including system).
  */
 
 import {
@@ -25,14 +31,39 @@ import {
 } from "react";
 
 export type ThemePreference = "light" | "dark" | "system";
+export type ResolvedTheme = "light" | "dark";
 
 export const THEME_STORAGE_KEY = "apparule.theme";
+const DARK_QUERY = "(prefers-color-scheme: dark)";
 
 // -- external preference store ----------------------------------------------
 
 const listeners = new Set<() => void>();
 
+// System tracking: one module-level matchMedia listener, attached lazily on
+// first subscription (client only), kept for the app lifetime.
+let systemListenerAttached = false;
+
+function onSystemChange(): void {
+  // Only the system preference re-resolves on an OS flip.
+  if (readStoredPreference() === "system") {
+    applyResolved(resolveTheme("system"));
+    emit();
+  }
+}
+
+function ensureSystemListener(): void {
+  if (systemListenerAttached || typeof window === "undefined") return;
+  try {
+    window.matchMedia(DARK_QUERY).addEventListener("change", onSystemChange);
+    systemListenerAttached = true;
+  } catch {
+    // matchMedia unavailable — system just won't track live
+  }
+}
+
 function subscribe(listener: () => void): () => void {
+  ensureSystemListener();
   listeners.add(listener);
   return () => {
     listeners.delete(listener);
@@ -53,17 +84,34 @@ function readStoredPreference(): ThemePreference {
   return "system";
 }
 
-function getServerSnapshot(): ThemePreference {
+function systemPrefersDark(): boolean {
+  try {
+    return window.matchMedia(DARK_QUERY).matches;
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve a preference to the concrete theme ("system" → the OS theme). */
+export function resolveTheme(preference: ThemePreference): ResolvedTheme {
+  if (preference === "light" || preference === "dark") return preference;
+  return systemPrefersDark() ? "dark" : "light";
+}
+
+function readResolvedTheme(): ResolvedTheme {
+  return resolveTheme(readStoredPreference());
+}
+
+function getServerPreference(): ThemePreference {
   return "system";
 }
 
-function applyPreference(preference: ThemePreference): void {
-  const root = document.documentElement;
-  if (preference === "system") {
-    root.removeAttribute("data-theme");
-  } else {
-    root.setAttribute("data-theme", preference);
-  }
+function getServerResolved(): ResolvedTheme {
+  return "light";
+}
+
+function applyResolved(theme: ResolvedTheme): void {
+  document.documentElement.setAttribute("data-theme", theme);
 }
 
 // -- context ------------------------------------------------------------------
@@ -71,7 +119,9 @@ function applyPreference(preference: ThemePreference): void {
 interface ThemeContextValue {
   /** The user's stored preference (may be "system"). */
   preference: ThemePreference;
-  /** Set + persist the preference; "system" clears the override. */
+  /** The concrete theme currently applied ("system" resolved live). */
+  resolvedTheme: ResolvedTheme;
+  /** Set + persist the preference; "system" removes the stored key. */
   setPreference: (preference: ThemePreference) => void;
 }
 
@@ -81,11 +131,16 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const preference = useSyncExternalStore(
     subscribe,
     readStoredPreference,
-    getServerSnapshot,
+    getServerPreference,
+  );
+  const resolvedTheme = useSyncExternalStore(
+    subscribe,
+    readResolvedTheme,
+    getServerResolved,
   );
 
   const setPreference = useCallback((next: ThemePreference) => {
-    applyPreference(next);
+    applyResolved(resolveTheme(next));
     try {
       if (next === "system") {
         window.localStorage.removeItem(THEME_STORAGE_KEY);
@@ -99,8 +154,8 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const value = useMemo(
-    () => ({ preference, setPreference }),
-    [preference, setPreference],
+    () => ({ preference, resolvedTheme, setPreference }),
+    [preference, resolvedTheme, setPreference],
   );
 
   return (
@@ -118,6 +173,8 @@ export function useTheme(): ThemeContextValue {
  * Pre-paint theme bootstrap (inlined by the root layout). A fully static
  * string — no runtime code construction (CodeQL js/bad-code-sanitization);
  * the literal storage key must match THEME_STORAGE_KEY (unit-tested).
+ * Applies the RESOLVED theme: stored light/dark verbatim, otherwise the
+ * OS preference — so system mode paints correctly on first frame (no FOUC).
  */
 export const themeInitScript =
-  '(function(){try{var t=localStorage.getItem("apparule.theme");if(t==="light"||t==="dark"){document.documentElement.setAttribute("data-theme",t);}}catch(e){}})();';
+  '(function(){try{var t=localStorage.getItem("apparule.theme");if(t!=="light"&&t!=="dark"){t=window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light";}document.documentElement.setAttribute("data-theme",t);}catch(e){}})();';


### PR DESCRIPTION
## Summary

User feedback on the shipped Scalar reference (F0-8): the **/docs/api header was wonky** — after any scroll, Scalar's sticky sidebar pinned to `top: 0` and painted over the marketing nav (wordmark obscured at 1440; at 390 Scalar's mobile bar replaced the nav entirely) — and the embed **ignored the product theme** (nav dark, reference light). Both root-caused with before/after screenshots (1440 + 390, light + dark).

## Header fix

Scalar sizes its layout to `100dvh` and pins sticky elements at `top: 0` unless told about a custom header. The embed wrapper now sets:
- `--scalar-custom-header-height: 64px` (nav h-16) — Scalar's sidebar/mobile bar offset below the nav and its viewport math shrinks to match: **one coherent page scroll**, no double scrollbar, nav keeps its normal sticky marketing behavior (incl. the 390 hamburger disclosure over the embed).
- `isolate` on the wrapper — a stacking context so no Scalar z-index (it ships up to 99999) can paint over the nav.

## Tri-state theme (ratified 2026-07-20, identical contract across apparule/expendit/upstat)

- **ThemeProvider**: `preference` = `light | dark | system`, persisted at `apparule.theme` — **key absent = system** (the cross-product storage convention). `data-theme` on `<html>` always carries the **resolved** theme; system tracks `prefers-color-scheme` **live** (matchMedia listener — an OS flip updates `data-theme` without reload). Pre-paint init script resolves system mode too (no FOUC).
- **ThemeToggle** (new shared control): cycles light → dark → system with sun / moon / monitor (lucide); aria-label announces the active mode (`Theme: dark — switch to system`). Wired into HomeNav + NavRail; Settings → Appearance keeps the three-way System/Light/Dark select over the same store.
- **Scalar embed sync**: forced to `resolvedTheme` via `forceDarkModeState` + `hideDarkModeToggle`. Scalar reads that override **once at creation** (`updateConfiguration` never re-applies it, and plain `darkMode` is silently ignored after mount) — so the view mounts post-hydration and **remounts on resolved-theme change** (`key`), configuration-only, no forking into Scalar internals.

## Tests

- Unit: provider tri-state contract (storage convention, live system tracking via a controllable matchMedia, explicit-preference isolation, init-script literals), ThemeToggle cycle + labels (nav, NavRail).
- e2e (`docs-api.spec.ts` + `home.spec.ts`): /docs/api header sanity (page scrolls, **no full-height inner scroller**, nav fully visible after scroll), embed follows the resolved theme incl. an **emulated `prefers-color-scheme` flip in system mode** (asserted on Scalar's own `light-mode`/`dark-mode` body class), toggle cycles three states, persistence across reload on home + dashboard.

## Gates

- `npm run lint` (prettier + eslint + check:boundaries) ✅
- `npm run typecheck` ✅
- `npm test` — 78 files, 467 passed ✅
- `NEXT_PUBLIC_TEST_MODE=1 npm run build` ✅
- `CI=1 npx playwright test` — 50 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)