### PR TITLE
fix(web): unset theme boots the design default — system is an explicit choice

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -320,9 +320,10 @@ fallback only).
 **Theme contract as-built (2026-07-20, ratified — identical across
 apparule, expendit and upstat).** The preference is tri-state
 light | dark | system: `ThemeProvider` persists it at `apparule.theme`
-("light"/"dark" stored explicitly; KEY ABSENT = system — the
-cross-product storage convention), and `data-theme` on `<html>` always
-carries the RESOLVED theme — system resolves via `prefers-color-scheme`
+("light"/"dark"/"system" all stored explicitly; KEY ABSENT = light,
+apparule's design default — the cross-product storage convention;
+"system" is never modeled as key-absent), and `data-theme` on `<html>`
+always carries the RESOLVED theme — system resolves via `prefers-color-scheme`
 and tracks it live (a matchMedia listener updates `data-theme` on an OS
 flip, no reload). The pre-paint init script applies the resolved theme
 (no FOUC in any mode). `ThemeToggle` (marketing nav + NavRail rail item)

--- a/web/e2e/docs-api.spec.ts
+++ b/web/e2e/docs-api.spec.ts
@@ -85,16 +85,29 @@ test.describe("API reference — /docs/api", () => {
     ).toBeVisible({ timeout: 20_000 });
 
     // Scalar mirrors the resolved theme on body (light-mode/dark-mode).
+    // Fresh boot is light, the design default (key absent).
     const body = page.locator("body");
     await expect(body).toHaveClass(/light-mode/);
 
-    // system mode (default) follows an OS scheme flip live.
+    // Select system explicitly (light → dark → system) to exercise live
+    // OS-flip tracking.
+    await page
+      .getByRole("button", { name: "Theme: light — switch to dark" })
+      .click();
+    await page
+      .getByRole("button", { name: "Theme: dark — switch to system" })
+      .click();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+    await expect(body).toHaveClass(/light-mode/, { timeout: 15_000 });
+
+    // system mode follows an OS scheme flip live.
     await page.emulateMedia({ colorScheme: "dark" });
     await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
     await expect(body).toHaveClass(/dark-mode/, { timeout: 15_000 });
 
-    // Explicit choice via the nav toggle wins over the OS (dark stays after
-    // cycling system → light → the embed resyncs to light).
+    // Explicit choice via the nav toggle wins over the OS (system stays
+    // dark from the OS flip; cycling system → light and the embed resyncs
+    // to light).
     await page
       .getByRole("button", { name: "Theme: system — switch to light" })
       .click();

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -156,28 +156,40 @@ test.describe("Marketing site — home page", () => {
     await page.goto("/");
     const html = page.locator("html");
 
-    // Fresh visit = system (key absent), resolved from the OS (light here).
+    // Fresh visit = light (key absent), the design default.
     await expect(html).toHaveAttribute("data-theme", "light");
-    await page
-      .getByRole("button", { name: "Theme: system — switch to light" })
-      .click();
-    await expect(html).toHaveAttribute("data-theme", "light");
-
+    expect(
+      await page.evaluate(() =>
+        window.localStorage.getItem("apparule.theme"),
+      ),
+    ).toBeNull();
     await page
       .getByRole("button", { name: "Theme: light — switch to dark" })
       .click();
     await expect(html).toHaveAttribute("data-theme", "dark");
 
-    // Third press returns to system — resolved live from the OS.
     await page
       .getByRole("button", { name: "Theme: dark — switch to system" })
       .click();
+    // "system" is now stored explicitly (not key-absent); resolved from
+    // the OS (light here).
+    expect(
+      await page.evaluate(() =>
+        window.localStorage.getItem("apparule.theme"),
+      ),
+    ).toBe("system");
     await expect(html).toHaveAttribute("data-theme", "light");
 
     // System mode follows an OS-level scheme flip without a reload.
     await page.emulateMedia({ colorScheme: "dark" });
     await expect(html).toHaveAttribute("data-theme", "dark");
     await page.emulateMedia({ colorScheme: "light" });
+    await expect(html).toHaveAttribute("data-theme", "light");
+
+    // Fourth press returns to light, closing the cycle.
+    await page
+      .getByRole("button", { name: "Theme: system — switch to light" })
+      .click();
     await expect(html).toHaveAttribute("data-theme", "light");
   });
 
@@ -462,11 +474,13 @@ test.describe("nav/footer parity canon", () => {
       0,
     );
 
-    // the theme toggle works from inside the panel (system → light → dark)
-    await panel.getByRole("button", { name: /^Theme: system/ }).click();
-    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+    // the theme toggle works from inside the panel (fresh boot is light,
+    // the design default; light → dark → system)
     await panel.getByRole("button", { name: /^Theme: light/ }).click();
     await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    await panel.getByRole("button", { name: /^Theme: dark/ }).click();
+    // "system" is stored explicitly; resolved from the OS (light here).
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
 
     // a link click closes the disclosure
     await panel.getByRole("link", { name: "Features" }).click();
@@ -524,16 +538,17 @@ test.describe("nav/footer parity canon", () => {
   test("theme toggle flips and persists on home and dashboard", async ({
     page,
   }) => {
-    // marketing surface: system → light → dark, persisted across reload
+    // marketing surface: fresh boot is light (the design default, key
+    // absent) → dark, persisted across reload
     await page.goto("/");
-    await page.getByRole("button", { name: /^Theme: system/ }).click();
     await page.getByRole("button", { name: /^Theme: light/ }).click();
     await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
     await page.reload();
     await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
 
     // dashboard surface (same apparule.theme key via NavRail toggle):
-    // dark → system removes the key; resolved follows the OS again.
+    // dark → system now stores "system" explicitly; resolved follows the
+    // OS again.
     await page.goto("/signin");
     await page.getByRole("button", { name: /continue with google/i }).click();
     await page.waitForURL("**/dashboard");
@@ -543,7 +558,7 @@ test.describe("nav/footer parity canon", () => {
     const stored = await page.evaluate(() =>
       window.localStorage.getItem("apparule.theme"),
     );
-    expect(stored).toBeNull();
+    expect(stored).toBe("system");
     await page.reload();
     await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
   });

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -159,9 +159,7 @@ test.describe("Marketing site — home page", () => {
     // Fresh visit = light (key absent), the design default.
     await expect(html).toHaveAttribute("data-theme", "light");
     expect(
-      await page.evaluate(() =>
-        window.localStorage.getItem("apparule.theme"),
-      ),
+      await page.evaluate(() => window.localStorage.getItem("apparule.theme")),
     ).toBeNull();
     await page
       .getByRole("button", { name: "Theme: light — switch to dark" })
@@ -174,9 +172,7 @@ test.describe("Marketing site — home page", () => {
     // "system" is now stored explicitly (not key-absent); resolved from
     // the OS (light here).
     expect(
-      await page.evaluate(() =>
-        window.localStorage.getItem("apparule.theme"),
-      ),
+      await page.evaluate(() => window.localStorage.getItem("apparule.theme")),
     ).toBe("system");
     await expect(html).toHaveAttribute("data-theme", "light");
 

--- a/web/src/components/home/interactive.test.tsx
+++ b/web/src/components/home/interactive.test.tsx
@@ -259,23 +259,24 @@ describe("HomeNavBar (A1)", () => {
         <HomeNavBar />
       </ThemeProvider>,
     );
-    // Default preference is system — the label announces the active mode.
+    // Key absent = light, the design default — the label announces it.
     const toggle = screen.getByRole("button", {
-      name: "Theme: system — switch to light",
+      name: "Theme: light — switch to dark",
     });
     await userEvent.click(toggle);
-    expect(document.documentElement).toHaveAttribute("data-theme", "light");
-    await userEvent.click(
-      screen.getByRole("button", { name: "Theme: light — switch to dark" }),
-    );
     expect(document.documentElement).toHaveAttribute("data-theme", "dark");
     await userEvent.click(
       screen.getByRole("button", { name: "Theme: dark — switch to system" }),
     );
-    // system resolves via matchMedia (light in the test polyfill) and the
-    // stored key is removed.
+    // "system" is stored explicitly; data-theme carries the RESOLVED theme
+    // (light — the jsdom matchMedia stub reports no dark preference).
     expect(document.documentElement).toHaveAttribute("data-theme", "light");
-    expect(window.localStorage.getItem("apparule.theme")).toBeNull();
+    expect(window.localStorage.getItem("apparule.theme")).toBe("system");
+    await userEvent.click(
+      screen.getByRole("button", { name: "Theme: system — switch to light" }),
+    );
+    expect(document.documentElement).toHaveAttribute("data-theme", "light");
+    expect(window.localStorage.getItem("apparule.theme")).toBe("light");
   });
 
   it("nav: Sign in text link + Try Cloud CTA hands off with try_cloud_click", async () => {

--- a/web/src/design/ThemeProvider.test.tsx
+++ b/web/src/design/ThemeProvider.test.tsx
@@ -1,7 +1,8 @@
 // Theme provider — tri-state contract (ratified 2026-07-20): preference
-// light | dark | system persisted at apparule.theme (key absent = system);
-// data-theme always carries the RESOLVED theme; system tracks
-// prefers-color-scheme live via a matchMedia listener.
+// light | dark | system persisted at apparule.theme (key absent = light,
+// the design default; "system" stored explicitly); data-theme always
+// carries the RESOLVED theme; system tracks prefers-color-scheme live via
+// a matchMedia listener.
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -65,7 +66,18 @@ describe("ThemeProvider", () => {
     expect(themeInitScript).toContain("setAttribute");
   });
 
-  it("defaults to system and reports the resolved OS theme", () => {
+  it("defaults to light (the design default) when no key is stored", () => {
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("pref")).toHaveTextContent("light");
+    expect(screen.getByTestId("resolved")).toHaveTextContent("light");
+  });
+
+  it("stored system resolves via the OS preference (both directions)", () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, "system");
     render(
       <ThemeProvider>
         <Probe />
@@ -73,6 +85,18 @@ describe("ThemeProvider", () => {
     );
     expect(screen.getByTestId("pref")).toHaveTextContent("system");
     expect(screen.getByTestId("resolved")).toHaveTextContent("light");
+  });
+
+  it("stored system resolves dark when the OS prefers dark", () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, "system");
+    systemMatches = true;
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("pref")).toHaveTextContent("system");
+    expect(screen.getByTestId("resolved")).toHaveTextContent("dark");
   });
 
   it("manual dark override applies the resolved attribute and persists", async () => {
@@ -87,7 +111,7 @@ describe("ThemeProvider", () => {
     expect(screen.getByTestId("resolved")).toHaveTextContent("dark");
   });
 
-  it("returning to system removes the stored key (absent = system) and re-resolves", async () => {
+  it("choosing system stores it explicitly and re-resolves via the OS", async () => {
     render(
       <ThemeProvider>
         <Probe />
@@ -95,8 +119,8 @@ describe("ThemeProvider", () => {
     );
     await userEvent.click(screen.getByRole("button", { name: "dark" }));
     await userEvent.click(screen.getByRole("button", { name: "system" }));
-    // Key absent = system — the cross-product storage convention.
-    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBeNull();
+    // "system" is stored like any preference (key absent = design default).
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("system");
     // data-theme stays populated with the RESOLVED theme (light OS here).
     expect(document.documentElement.getAttribute("data-theme")).toBe("light");
     expect(screen.getByTestId("pref")).toHaveTextContent("system");

--- a/web/src/design/ThemeProvider.tsx
+++ b/web/src/design/ThemeProvider.tsx
@@ -6,8 +6,9 @@
  * and upstat):
  *
  * - `preference` is what the user chose; persisted at `apparule.theme`
- *   ("light"/"dark" stored explicitly; KEY ABSENT = system — the
- *   cross-product storage convention).
+ *   ("light"/"dark"/"system" all stored explicitly; KEY ABSENT = light,
+ *   apparule's design default — the cross-product storage convention;
+ *   "system" is never modeled as key-absent).
  * - `data-theme` on <html> always carries the RESOLVED theme ("light" or
  *   "dark"): explicit preferences resolve to themselves; system resolves
  *   via `prefers-color-scheme` and tracks it LIVE (matchMedia listener —
@@ -77,11 +78,14 @@ function emit(): void {
 function readStoredPreference(): ThemePreference {
   try {
     const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
-    if (stored === "light" || stored === "dark") return stored;
+    if (stored === "light" || stored === "dark" || stored === "system")
+      return stored;
   } catch {
-    // storage unavailable (private mode etc.) — fall through to system
+    // storage unavailable (private mode etc.) — fall through to the default
   }
-  return "system";
+  // Key absent = the product's design default (light-first, design.md §2);
+  // "system" is an explicit choice, stored like any other preference.
+  return "light";
 }
 
 function systemPrefersDark(): boolean {
@@ -103,7 +107,7 @@ function readResolvedTheme(): ResolvedTheme {
 }
 
 function getServerPreference(): ThemePreference {
-  return "system";
+  return "light";
 }
 
 function getServerResolved(): ResolvedTheme {
@@ -121,7 +125,7 @@ interface ThemeContextValue {
   preference: ThemePreference;
   /** The concrete theme currently applied ("system" resolved live). */
   resolvedTheme: ResolvedTheme;
-  /** Set + persist the preference; "system" removes the stored key. */
+  /** Set + persist the preference ("system" is stored explicitly). */
   setPreference: (preference: ThemePreference) => void;
 }
 
@@ -142,11 +146,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const setPreference = useCallback((next: ThemePreference) => {
     applyResolved(resolveTheme(next));
     try {
-      if (next === "system") {
-        window.localStorage.removeItem(THEME_STORAGE_KEY);
-      } else {
-        window.localStorage.setItem(THEME_STORAGE_KEY, next);
-      }
+      window.localStorage.setItem(THEME_STORAGE_KEY, next);
     } catch {
       // non-fatal: preference just won't persist
     }
@@ -173,8 +173,9 @@ export function useTheme(): ThemeContextValue {
  * Pre-paint theme bootstrap (inlined by the root layout). A fully static
  * string — no runtime code construction (CodeQL js/bad-code-sanitization);
  * the literal storage key must match THEME_STORAGE_KEY (unit-tested).
- * Applies the RESOLVED theme: stored light/dark verbatim, otherwise the
- * OS preference — so system mode paints correctly on first frame (no FOUC).
+ * Applies the RESOLVED theme: stored light/dark verbatim, stored "system"
+ * via the OS preference, key absent = light (the design default) — no FOUC
+ * in any mode.
  */
 export const themeInitScript =
-  '(function(){try{var t=localStorage.getItem("apparule.theme");if(t!=="light"&&t!=="dark"){t=window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light";}document.documentElement.setAttribute("data-theme",t);}catch(e){}})();';
+  '(function(){try{var t=localStorage.getItem("apparule.theme");if(t==="system"){t=window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light";}else if(t!=="light"&&t!=="dark"){t="light";}document.documentElement.setAttribute("data-theme",t);}catch(e){}})();';


### PR DESCRIPTION
## Summary
- Theme contract fix (cross-product, ratified 2026-07-20): `ThemeProvider`'s stored preference now treats **key absent = light**, apparule's design default. `"system"` is stored explicitly at `apparule.theme` via `setItem` — it is never modeled as key-absent.
- `setPreference` always calls `localStorage.setItem` (the `removeItem` branch for `"system"` is gone); `getServerPreference` and `themeInitScript` follow the same default.
- Updates `ThemeProvider.test.tsx`, the `HomeNavBar` toggle test in `interactive.test.tsx`, and `docs/web-implementation.md` to describe the new contract (no archaeology — old "key absent = system" wording removed).
- Aligns `e2e/home.spec.ts` and `e2e/docs-api.spec.ts`: fresh-boot assertions now check the design default (light) with a null stored key, and cycling through "system" now asserts `apparule.theme` reads back `"system"`.
- Mirrors the identical fix landing on upstat (`fix/scalar-header-theme`) and expendit (`fix/theme-default-contract`), each keeping its own design default (upstat: dark, expendit: dark, apparule: light).

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (469 passed)
- [x] `NEXT_PUBLIC_TEST_MODE=1 npm run build`
- [x] `npx playwright test` (50 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)