### PR TITLE
fix(web): code-side convergence from the Figma ↔ code audit (thread timestamps, cadence, moderation seed, decimals, MI-11 ring, suggestion avatars, Scalar toolbar)

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -295,6 +295,9 @@ approved gap implementations:
   mounts after hydration and remounts on theme change, since
   `updateConfiguration` never re-applies it); Scalar's own toggle is
   hidden and its remote default fonts are disabled (self-host ethos).
+  Scalar's developer toolbar is pinned off (`showDeveloperTools:
+  "never"` — the `"localhost"` default surfaced author chrome on the
+  public reference in local/TEST_MODE runs).
   Header construction: the sticky marketing nav (h-16) and Scalar's
   sticky layout coexist via `--scalar-custom-header-height: 64px` on the
   embed wrapper (offsets Scalar's sticky sidebar/mobile bar below the
@@ -304,6 +307,33 @@ approved gap implementations:
   pins route 200, a rendered operation from the spec, the served
   document, the footer handoff, the header/scroll sanity and the
   embed-theme sync.
+
+**Design-convergence as-built notes (2026-07-20):** the code-side fixes
+from the Figma ↔ code divergence audit (seed-side details live in §6):
+
+- Thread bubbles carry per-bubble timestamps (B3 frame): bare `HH:mm` for
+  same-day messages, `MMM d, HH:mm` (the OrderTimelineRow idiom) when
+  older, side-aligned under the bubble; delivered messages only — never
+  sending or typing bubbles.
+- Measurement values render **one decimal everywhere** ("92.0 cm", the
+  frame's "58.0 cm" idiom) via `formatCm` — MeasurementCard, SessionRow,
+  snapshot chips and the request stepper share the single formatter, so
+  tnum columns stay aligned.
+- The OWN avatar wears the measurement-freshness ring (MI-11 / the C9
+  construction) on the profile header — both the regular-user and
+  designer-self branches — while other designers keep the B6 gradient
+  story ring. The fresh/aging/stale → gradient/amber/gray mapping is one
+  helper (`freshnessRing` on the Avatar atom) shared by the vault header,
+  the feed freshness card and the profile.
+- ModerationQueueRow anatomy matches the B7a canvas: headline carries the
+  content author when known ("Reported post by @amara.designs"),
+  reporters are @-prefixed, and actioned rows render the audit line
+  ("Actioned · hide_comment by @mod.sarah · Jul 15, 09:12" — the
+  effective action; `hide_post` on a comment subject reads
+  `hide_comment`). Acting morphs the row in place; dismissing removes it;
+  the queue banner links "Learn more" to the trust & safety doc.
+- `UserRow` call sites (suggestions, explore designer search, follower
+  sheets) pass `avatar_url` through — the row always supported it.
 
 Screen-state parity **[Directive 2026-07-18, carried from design.md §8.1]**:
 every data-driven screen ships default, empty, and loading states — the
@@ -431,6 +461,9 @@ the designs:
   CC-sourced outfit photography (design.md §8.3 — same pool as the Figma
   Assets page), captions, style tags, and NGN pricing spread across the
   explore price bands (api.md §5: budget <25k, mid 25–100k, premium >100k).
+  Suggested designers (the B1 rail) carry real photo avatars — each fronts
+  their OWN published photography from the licensed pool, so the booted
+  rail matches the canvas without new assets or fabricated identities.
 - The signed-in test user: non-designer, vault populated with scan +
   manual sessions whose `measured_at` spread exercises all three freshness
   ring states (fresh/aging/stale, MI-11), follows several designers (story
@@ -439,10 +472,23 @@ the designs:
   one per state and per role view, so every StatusPill, OrderTimelineRow,
   and PaymentBox variant renders from seed — including an escrow-held
   payment with the itemized 10% fee line and a dispute-frozen order.
+  Timestamps follow the **plausible-cadence rule**: each order's events
+  spread across real-looking hours (strictly ordered, never a same-minute
+  cluster; the order and its frozen snapshot anchor to the requested
+  event) and thread messages sit minutes-to-hours around the events they
+  narrate — unit-gated in `store.test.ts`.
 - Notifications of every kind (like / follow / comment / quote /
-  status-change / payout), part unread; open moderation-queue reports; a
-  designer persona with EarningsSummary balances and TransactionRow
-  history for B9.
+  status-change / payout), part unread; a designer persona with
+  EarningsSummary balances and TransactionRow history for B9.
+- A moderation queue in the B7a canvas shape: two open reports (a spam
+  comment and a reported post with thumb + author) plus one ACTIONED
+  audit-trail exemplar by the seeded staff moderator (`mod.sarah`).
+  Reported comments exist as previews only, so post comment_counts stay
+  honest. The mock's REPORT carries audit fields — `action`,
+  `actioned_by {id, username}`, `actioned_at`, subject author — ahead of
+  the data-model.md §6.2 sketch (deviation noted, same as the profile
+  reads); the queue lists open rows first with actioned rows trailing as
+  the audit trail, and dismissals drop out.
 - Measurement snapshots frozen per request (vault edits after seed never
   mutate them — the data-model.md §5 rule holds in the mock too).
 

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -374,15 +374,26 @@ test("B7: notification prefs persist across reload; consent history renders", as
   );
 });
 
-test("B7a: staff moderation queue — dismiss clears the report", async ({
+test("B7a: staff moderation queue — audit exemplar from boot; dismiss drops a row", async ({
   page,
 }) => {
   await signIn(page);
   await page.goto("/dashboard/admin/moderation");
   const queue = page.getByTestId("moderation-queue");
+  // Seeded canvas narrative: two open rows (spam comment + reported post
+  // with author) and one actioned audit-trail exemplar.
   await expect(queue).toContainText("Buy followers cheap");
-  await queue.getByRole("button", { name: "Dismiss" }).click();
-  await expect(page.getByText(/queue is clear/)).toBeVisible();
+  await expect(queue).toContainText("Reported post by @amara.designs");
+  await expect(page.getByTestId("audit-line")).toContainText(
+    "hide_comment by @mod.sarah",
+  );
+  const spamRow = queue
+    .locator("li")
+    .filter({ hasText: "Buy followers cheap" });
+  await spamRow.getByRole("button", { name: "Dismiss" }).click();
+  await expect(queue).not.toContainText("Buy followers cheap");
+  // The rest of the queue survives the dismissal.
+  await expect(queue).toContainText("Reported post by @amara.designs");
 });
 
 test("B3 matrix: customer dispute freezes payout; confirm-delivery releases it", async ({

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -353,6 +353,20 @@ test("B5/B8: creator upsell → onboarding with Paystack resolution states → p
   await expect(page.getByTestId("profile-grid").locator("li")).toHaveCount(1);
 });
 
+test("B6 own profile: the avatar wears the measurement-freshness ring (MI-11)", async ({
+  page,
+}) => {
+  await signIn(page);
+  // /dashboard/profile redirects to the canonical own-profile route.
+  await page.goto("/dashboard/profile");
+  await page.waitForURL("**/dashboard/kiki.adeyemi");
+  const avatar = page.locator("header [data-ring]").first();
+  // Seeded vault freshness drives the band — any of the three ring states
+  // is valid here (earlier serial tests may add fresh captures), but the
+  // ring must be present ("none" would be the audited regression).
+  await expect(avatar).toHaveAttribute("data-ring", /^(gradient|amber|gray)$/);
+});
+
 test("B7: notification prefs persist across reload; consent history renders", async ({
   page,
 }) => {

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -180,6 +180,11 @@ test("B1 journey: like/save/follow → request stepper → order → quote → p
   await expect(page.getByText(/reply properly shortly/)).toBeVisible({
     timeout: 5_000,
   });
+  // B3 frame: every delivered bubble carries its send time beneath it
+  // ("14:05" today, dated when older).
+  await expect(
+    page.getByTestId("order-thread").locator("time").first(),
+  ).toBeVisible();
 });
 
 test("B3: the seeded list covers all ten lifecycle states", async ({

--- a/web/e2e/docs-api.spec.ts
+++ b/web/e2e/docs-api.spec.ts
@@ -26,6 +26,11 @@ test.describe("API reference — /docs/api", () => {
     await expect(
       page.getByText("Resolve caller's account").first(),
     ).toBeVisible();
+
+    // Scalar's developer toolbar is author chrome — never on the public
+    // reference (showDeveloperTools: "never"; the default leaks it on
+    // localhost-class hosts, which is exactly how e2e runs).
+    await expect(page.getByText("Developer Tools")).toHaveCount(0);
   });
 
   test("the OpenAPI document is served at /docs/api/openapi.yaml", async ({

--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -233,11 +233,14 @@ const sampleReport: Report = {
   subject_preview: {
     text: "🔥🔥 Buy followers cheap — link in bio",
     thumb_url: null,
+    author_username: null,
   },
   reason: "spam",
   detail: null,
   status: "open",
+  action: null,
   actioned_by: null,
+  actioned_at: null,
   created_at: daysAgo(1),
 };
 
@@ -838,7 +841,9 @@ export function ComponentGallery() {
               ...sampleReport,
               id: "rep-2",
               status: "actioned",
-              actioned_by: "staff.ops",
+              action: "hide_post",
+              actioned_by: { id: "acc-staff", username: "staff.ops" },
+              actioned_at: daysAgo(0.5),
             }}
           />
         </div>

--- a/web/src/components/dashboard/explore/ExploreView.tsx
+++ b/web/src/components/dashboard/explore/ExploreView.tsx
@@ -187,6 +187,7 @@ export function ExploreView() {
                   <UserRow
                     username={row.username}
                     meta={row.meta ?? undefined}
+                    avatarUrl={row.avatar_url}
                     verified={row.verified}
                     trailing={row.viewer_follows ? "following" : "follow"}
                     onFollow={() =>

--- a/web/src/components/dashboard/feed/FeedSidebar.tsx
+++ b/web/src/components/dashboard/feed/FeedSidebar.tsx
@@ -98,6 +98,7 @@ export function FeedSidebar({
                 <UserRow
                   username={row.username}
                   meta={row.meta ?? undefined}
+                  avatarUrl={row.avatar_url}
                   verified={row.verified}
                   trailing={row.viewer_follows ? "following" : "follow"}
                   onFollow={() =>

--- a/web/src/components/dashboard/feed/FeedSidebar.tsx
+++ b/web/src/components/dashboard/feed/FeedSidebar.tsx
@@ -9,17 +9,11 @@ import { formatAgoPhrase } from "@/lib/format";
 import { useVault } from "@/controllers/use-vault";
 import { useSuggestions } from "@/controllers/use-suggestions";
 import { useAuth } from "@/controllers/auth/AuthContext";
-import { Avatar } from "@/components/ui/Avatar";
+import { Avatar, freshnessRing } from "@/components/ui/Avatar";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { Tooltip } from "@/components/ui/Tooltip";
 import { UserRow } from "@/components/ui/UserRow";
 import { useToasts } from "../toast-context";
-
-const RING: Record<string, "gradient" | "amber" | "gray"> = {
-  fresh: "gradient",
-  aging: "amber",
-  stale: "gray",
-};
 
 export function FeedSidebar({
   onUnfollow,
@@ -65,7 +59,7 @@ export function FeedSidebar({
                 <Avatar
                   size={56}
                   name={account?.display_name ?? "You"}
-                  ring={vault.freshness ? RING[vault.freshness] : "gray"}
+                  ring={freshnessRing(vault.freshness)}
                 />
               </Link>
             </Tooltip>

--- a/web/src/components/dashboard/moderation/ModerationView.tsx
+++ b/web/src/components/dashboard/moderation/ModerationView.tsx
@@ -19,8 +19,19 @@ export function ModerationView() {
     <div className="mx-auto flex max-w-2xl flex-col gap-4 px-4 py-6">
       <header className="flex flex-col gap-4">
         <h1 className="text-title-lg font-bold text-text">Moderation queue</h1>
-        {/* Figma 182:1223: audit-log notice as an info Banner. */}
-        <Banner tone="info">
+        {/* Figma 182:1223: audit-log notice as an info Banner with the
+            "Learn more" action link (→ the data-model trust & safety doc). */}
+        <Banner
+          tone="info"
+          actionLabel="Learn more"
+          onAction={() =>
+            window.open(
+              "https://cuesoft.gitbook.io/apparule/system/data-model",
+              "_blank",
+              "noopener",
+            )
+          }
+        >
           Every action here is recorded in the audit log.
         </Banner>
       </header>

--- a/web/src/components/dashboard/orders/OrderDetailView.tsx
+++ b/web/src/components/dashboard/orders/OrderDetailView.tsx
@@ -468,6 +468,7 @@ export function OrderDetailView({ orderId }: { orderId: string }) {
                         text={message.body}
                         content={message.image_url ? "image" : "text"}
                         imageUrl={message.image_url ?? undefined}
+                        timestamp={message.created_at}
                         state={
                           message.state === "sent" ? undefined : message.state
                         }

--- a/web/src/components/dashboard/profile/ProfileView.test.tsx
+++ b/web/src/components/dashboard/profile/ProfileView.test.tsx
@@ -64,7 +64,12 @@ function designerProfile(selfViewing: boolean): PublicProfile {
       display_name: "Amara Designs",
       bio: "Ankara & contemporary tailoring.",
       avatar_url: null,
-      payout_account: null,
+      payout_account: {
+        provider_ref: null,
+        bank_name: null,
+        account_last4: null,
+        kyc_state: "none",
+      },
       verified: true,
       location: { city: "Lagos", state: "Lagos", country: "NG" },
       followers_count: 8,

--- a/web/src/components/dashboard/profile/ProfileView.test.tsx
+++ b/web/src/components/dashboard/profile/ProfileView.test.tsx
@@ -1,0 +1,140 @@
+// B6 profile header — MI-11: the OWN avatar wears the measurement-
+// freshness ring (C9 construction); other people's designer avatars keep
+// the B6 story-ring (gradient).
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import type { PublicProfile } from "@/models";
+import { ToastProvider } from "../toast-context";
+
+const usePublicProfileMock = vi.fn();
+const useVaultMock = vi.fn();
+
+vi.mock("@/controllers/auth/AuthContext", () => ({
+  useAuth: () => ({
+    status: "signed_in",
+    account: { username: "kiki.adeyemi", display_name: "Kiki Adeyemi" },
+  }),
+}));
+vi.mock("@/controllers/use-public-profile", () => ({
+  usePublicProfile: (...a: unknown[]) => usePublicProfileMock(...a),
+  useFollowList: () => ({
+    loading: true,
+    rows: [],
+    toggleFollow: vi.fn(),
+  }),
+}));
+vi.mock("@/controllers/use-vault", () => ({
+  useVault: (...a: unknown[]) => useVaultMock(...a),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn(), replace: vi.fn() }),
+}));
+
+import { ProfileView } from "./ProfileView";
+
+function profileResult(profile: PublicProfile) {
+  return {
+    profile,
+    posts: [],
+    saved: [],
+    loading: false,
+    error: null,
+    toggleFollow: vi.fn(),
+    syncPost: vi.fn(),
+  };
+}
+
+const ownUserProfile: PublicProfile = {
+  kind: "user",
+  account: {
+    username: "kiki.adeyemi",
+    display_name: "Kiki Adeyemi",
+    avatar_url: null,
+  },
+  viewer_is_self: true,
+};
+
+function designerProfile(selfViewing: boolean): PublicProfile {
+  return {
+    kind: "designer",
+    designer: {
+      id: "des-amara",
+      account_id: "acc-amara",
+      username: "amara.designs",
+      display_name: "Amara Designs",
+      bio: "Ankara & contemporary tailoring.",
+      avatar_url: null,
+      payout_account: null,
+      verified: true,
+      location: { city: "Lagos", state: "Lagos", country: "NG" },
+      followers_count: 8,
+      following_count: 2,
+      posts_count: 0,
+    },
+    viewer_follows: false,
+    viewer_is_self: selfViewing,
+  };
+}
+
+function renderProfile(profile: PublicProfile, username: string) {
+  usePublicProfileMock.mockReturnValue(profileResult(profile));
+  return render(
+    <ToastProvider>
+      <ProfileView username={username} />
+    </ToastProvider>,
+  );
+}
+
+beforeEach(() => {
+  usePublicProfileMock.mockReset();
+  useVaultMock.mockReset();
+  useVaultMock.mockReturnValue({ freshness: "aging", loading: false });
+});
+
+describe("ProfileView — own-profile freshness ring (MI-11)", () => {
+  it("own regular-user profile wears the freshness ring (aging → amber)", () => {
+    const { container } = renderProfile(ownUserProfile, "kiki.adeyemi");
+    expect(container.querySelector('[data-ring="amber"]')).not.toBeNull();
+  });
+
+  it.each([
+    ["fresh", "gradient"],
+    ["stale", "gray"],
+  ] as const)("freshness %s renders ring=%s", (freshness, ring) => {
+    useVaultMock.mockReturnValue({ freshness, loading: false });
+    const { container } = renderProfile(ownUserProfile, "kiki.adeyemi");
+    expect(container.querySelector(`[data-ring="${ring}"]`)).not.toBeNull();
+  });
+
+  it("no ring while the vault is still loading", () => {
+    useVaultMock.mockReturnValue({ freshness: null, loading: true });
+    const { container } = renderProfile(ownUserProfile, "kiki.adeyemi");
+    expect(container.querySelector('[data-ring="none"]')).not.toBeNull();
+  });
+
+  it("someone else's regular-user profile never fetches the vault", () => {
+    renderProfile(
+      {
+        ...ownUserProfile,
+        account: { ...ownUserProfile.account, username: "ada.eze" },
+        viewer_is_self: false,
+      },
+      "ada.eze",
+    );
+    expect(useVaultMock).not.toHaveBeenCalled();
+  });
+
+  it("own designer profile wears the freshness ring too", () => {
+    const { container } = renderProfile(designerProfile(true), "kiki.adeyemi");
+    expect(container.querySelector('[data-ring="amber"]')).not.toBeNull();
+  });
+
+  it("other designers keep the gradient story ring (B6)", () => {
+    const { container } = renderProfile(
+      designerProfile(false),
+      "amara.designs",
+    );
+    expect(container.querySelector('[data-ring="gradient"]')).not.toBeNull();
+    expect(useVaultMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/dashboard/profile/ProfileView.tsx
+++ b/web/src/components/dashboard/profile/ProfileView.tsx
@@ -16,7 +16,8 @@ import {
   useFollowList,
   usePublicProfile,
 } from "@/controllers/use-public-profile";
-import { Avatar } from "@/components/ui/Avatar";
+import { useVault } from "@/controllers/use-vault";
+import { Avatar, freshnessRing } from "@/components/ui/Avatar";
 import { Button } from "@/components/ui/Button";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { GridTile } from "@/components/ui/GridTile";
@@ -99,6 +100,33 @@ function FollowListSheet({
   );
 }
 
+/**
+ * Own-profile avatar (MI-11 / C9 construction): the viewer's own avatar
+ * carries the measurement-freshness ring — same Avatar ring canon as the
+ * vault header and the feed freshness card. Mounted only for self so the
+ * vault fetch never runs on other people's profiles.
+ */
+function OwnProfileAvatar({
+  name,
+  src,
+  verified,
+}: {
+  name: string;
+  src?: string | null;
+  verified?: boolean;
+}) {
+  const vault = useVault();
+  return (
+    <Avatar
+      size={96}
+      name={name}
+      src={src}
+      verified={verified}
+      ring={vault.loading ? "none" : freshnessRing(vault.freshness)}
+    />
+  );
+}
+
 export function ProfileView({ username }: { username: string }) {
   const { account } = useAuth();
   const router = useRouter();
@@ -139,7 +167,11 @@ export function ProfileView({ username }: { username: string }) {
     return (
       <div className="mx-auto flex max-w-4xl flex-col gap-6 px-4 py-6">
         <header className="flex items-center gap-6">
-          <Avatar size={96} name={profile.account.display_name} />
+          {self ? (
+            <OwnProfileAvatar name={profile.account.display_name} />
+          ) : (
+            <Avatar size={96} name={profile.account.display_name} />
+          )}
           <div className="flex min-w-0 flex-col gap-1">
             <h1 className="text-title-lg font-bold text-text">
               {profile.account.username}
@@ -238,13 +270,23 @@ export function ProfileView({ username }: { username: string }) {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-6 px-4 py-6">
       <header className="flex items-start gap-6">
-        <Avatar
-          size={96}
-          name={d.display_name}
-          src={d.avatar_url}
-          ring="gradient"
-          verified={d.verified}
-        />
+        {self ? (
+          // MI-11: the OWN avatar wears the freshness ring; others keep the
+          // B6 story-ring construction (gradient).
+          <OwnProfileAvatar
+            name={d.display_name}
+            src={d.avatar_url}
+            verified={d.verified}
+          />
+        ) : (
+          <Avatar
+            size={96}
+            name={d.display_name}
+            src={d.avatar_url}
+            ring="gradient"
+            verified={d.verified}
+          />
+        )}
         <div className="flex min-w-0 flex-1 flex-col gap-2">
           <div className="flex flex-wrap items-center gap-3">
             <h1 className="text-title-lg font-bold text-text">{d.username}</h1>

--- a/web/src/components/dashboard/profile/ProfileView.tsx
+++ b/web/src/components/dashboard/profile/ProfileView.tsx
@@ -68,6 +68,7 @@ function FollowListSheet({
               <UserRow
                 username={row.username}
                 meta={row.meta ?? undefined}
+                avatarUrl={row.avatar_url}
                 verified={row.verified}
                 trailing={
                   row.is_designer

--- a/web/src/components/dashboard/vault/VaultView.tsx
+++ b/web/src/components/dashboard/vault/VaultView.tsx
@@ -11,7 +11,7 @@ import { formatAgoPhrase } from "@/lib/format";
 import type { MeasurementSession } from "@/models";
 import { useAuth } from "@/controllers/auth/AuthContext";
 import { useVault } from "@/controllers/use-vault";
-import { Avatar } from "@/components/ui/Avatar";
+import { Avatar, freshnessRing } from "@/components/ui/Avatar";
 import { Button } from "@/components/ui/Button";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { MeasurementCard } from "@/components/ui/MeasurementCard";
@@ -24,12 +24,6 @@ import {
   WebcamCaptureSheet,
 } from "./CaptureSheets";
 import { useToasts } from "../toast-context";
-
-const RING: Record<string, "gradient" | "amber" | "gray"> = {
-  fresh: "gradient",
-  aging: "amber",
-  stale: "gray",
-};
 
 export function VaultView() {
   const { account } = useAuth();
@@ -92,7 +86,7 @@ export function VaultView() {
         <Avatar
           size={96}
           name={account?.display_name ?? "You"}
-          ring={vault.freshness ? RING[vault.freshness] : "gray"}
+          ring={freshnessRing(vault.freshness)}
         />
         <div className="flex min-w-0 flex-1 flex-col gap-2 pt-1">
           <h1 className="text-title-lg font-bold text-text">

--- a/web/src/components/docs/ScalarApiReference.tsx
+++ b/web/src/components/docs/ScalarApiReference.tsx
@@ -7,8 +7,10 @@
 // the OS live) via `forceDarkModeState` — `darkMode` alone is only an
 // initial hint and loses to Scalar's internal state. Scalar's own theme
 // toggle is hidden (ours is the master) and the remote default fonts are
-// disabled (self-host ethos: no external runtime dependencies). The dev
-// toolbar needs no config: Scalar only shows it on localhost.
+// disabled (self-host ethos: no external runtime dependencies). Scalar's
+// developer toolbar ("Developer Tools · Configure · Share · Deploy") is
+// disabled outright — its localhost default still surfaced author chrome
+// on the public reference during local/TEST_MODE runs (audit 2026-07-20).
 import { useSyncExternalStore } from "react";
 import { ApiReferenceReact } from "@scalar/api-reference-react";
 import "@scalar/api-reference-react/style.css";
@@ -44,6 +46,9 @@ export function ScalarApiReference() {
         forceDarkModeState: resolvedTheme,
         hideDarkModeToggle: true,
         withDefaultFonts: false,
+        // Public docs surface — never Scalar's dev toolbar (default is
+        // "localhost", which leaks it in local + TEST_MODE builds).
+        showDeveloperTools: "never",
       }}
     />
   );

--- a/web/src/components/ui/Avatar.test.tsx
+++ b/web/src/components/ui/Avatar.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { Avatar } from "./Avatar";
+import { Avatar, freshnessRing } from "./Avatar";
 
 describe("Avatar (§8.2)", () => {
   it.each([32, 44, 56, 64, 96] as const)("renders size=%s", (size) => {
@@ -26,5 +26,12 @@ describe("Avatar (§8.2)", () => {
   it("shows the designer-verified badge", () => {
     render(<Avatar name="Amara Designs" verified />);
     expect(screen.getByTestId("verified-badge")).toBeInTheDocument();
+  });
+
+  it("freshnessRing maps the MI-11 bands (gradient/amber/gray, gray when empty)", () => {
+    expect(freshnessRing("fresh")).toBe("gradient");
+    expect(freshnessRing("aging")).toBe("amber");
+    expect(freshnessRing("stale")).toBe("gray");
+    expect(freshnessRing(null)).toBe("gray");
   });
 });

--- a/web/src/components/ui/Avatar.tsx
+++ b/web/src/components/ui/Avatar.tsx
@@ -13,9 +13,21 @@
 import clsx from "clsx";
 import Image from "next/image";
 import { Check } from "lucide-react";
+import type { Freshness } from "@/models";
 
 export type AvatarSize = 32 | 44 | 56 | 64 | 96;
 export type AvatarRing = "none" | "gradient" | "amber" | "gray";
+
+/**
+ * MI-11 freshness → ring mapping (design.md §2: gradient <30d, amber
+ * 30–90d, gray >90d; no measurements reads gray). One mapping for every
+ * own-avatar surface — vault header, feed freshness card, own profile.
+ */
+export function freshnessRing(freshness: Freshness | null): AvatarRing {
+  if (freshness === "fresh") return "gradient";
+  if (freshness === "aging") return "amber";
+  return "gray";
+}
 
 export interface AvatarProps {
   size?: AvatarSize;

--- a/web/src/components/ui/ModerationQueueRow.test.tsx
+++ b/web/src/components/ui/ModerationQueueRow.test.tsx
@@ -10,7 +10,8 @@ describe("ModerationQueueRow (§8.2b, A-6)", () => {
     // Figma master (93:1219): "Reported comment" headline + excerpt meta
     expect(screen.getByText("Reported comment")).toBeInTheDocument();
     expect(screen.getByText(/Buy followers cheap/)).toBeInTheDocument();
-    expect(screen.getByText(/Reported by tunde.o/)).toBeInTheDocument();
+    expect(screen.getByText(/Reported by @/)).toBeInTheDocument();
+    expect(screen.getByText(/tunde.o/)).toBeInTheDocument();
     expect(screen.getByText("spam")).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Hide comment" }),
@@ -32,19 +33,45 @@ describe("ModerationQueueRow (§8.2b, A-6)", () => {
     expect(onAction).toHaveBeenCalledWith("suspend_account");
   });
 
-  it("actioned state swaps actions for the audit line", () => {
+  it("headline carries the content author when known (B7a canvas)", () => {
+    render(
+      <ModerationQueueRow
+        report={{
+          ...fixtureReport,
+          subject_kind: "post",
+          subject_preview: {
+            text: "New fabric drop",
+            thumb_url: "/demo/outfit-w14.jpg",
+            author_username: "amara.designs",
+          },
+        }}
+      />,
+    );
+    expect(
+      screen.getByText("Reported post by @amara.designs"),
+    ).toBeInTheDocument();
+  });
+
+  it("actioned state swaps actions for the audit line (effective action + @moderator + time)", () => {
     render(
       <ModerationQueueRow
         report={{
           ...fixtureReport,
           status: "actioned",
-          actioned_by: "staff.ops",
+          action: "hide_post", // comment subject → reads hide_comment
+          actioned_by: { id: "acc-staff", username: "staff.ops" },
+          actioned_at: "2026-07-15T09:12:00",
         }}
       />,
     );
-    expect(screen.getByTestId("audit-line")).toHaveTextContent("staff.ops");
+    expect(screen.getByTestId("audit-line")).toHaveTextContent(
+      "Actioned · hide_comment by @staff.ops · Jul 15, 09:12",
+    );
     expect(
       screen.queryByRole("button", { name: "Hide post" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Hide comment" }),
     ).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/ui/ModerationQueueRow.tsx
+++ b/web/src/components/ui/ModerationQueueRow.tsx
@@ -2,9 +2,12 @@
 
 // ModerationQueueRow — design.md §8.2b: subject preview (post/comment thumb
 // + reporter context) · reason · actions hide_post / suspend_account /
-// dismiss · state open / actioned (audit: actioned_by).
+// dismiss · state open / actioned (audit line: effective action + @moderator
+// + timestamp, B7a canvas: "Actioned · hide_comment by @mod.sarah · Jul 15,
+// 09:12").
 import clsx from "clsx";
 import Image from "next/image";
+import { format } from "date-fns";
 import type { ModerationAction, Report } from "@/models";
 import { formatAgoPhrase } from "@/lib/format";
 import { Button } from "./Button";
@@ -21,6 +24,12 @@ export function ModerationQueueRow({
   className,
 }: ModerationQueueRowProps) {
   const open = report.status === "open";
+  // Audit line shows the EFFECTIVE action: hide_post on a comment subject
+  // hides the comment, so it reads "hide_comment" (canvas idiom).
+  const effectiveAction =
+    report.action === "hide_post" && report.subject_kind === "comment"
+      ? "hide_comment"
+      : report.action;
   return (
     <div
       data-state={open ? "open" : "actioned"}
@@ -42,14 +51,18 @@ export function ModerationQueueRow({
             />
           </span>
         ) : null}
-        {/* Figma master (93:1219): "Reported post/comment" headline, the
-            excerpt + reporter in the meta line, warn-tinted Spam pill. */}
+        {/* Figma master (93:1219): "Reported post/comment" headline (with
+            the content author when known — "Reported post by @amara.designs"),
+            the excerpt + reporter in the meta line, warn-tinted Spam pill. */}
         <div className="min-w-0 flex-1">
           <p className="text-body font-semibold text-text">
             Reported {report.subject_kind}
+            {report.subject_preview.author_username
+              ? ` by @${report.subject_preview.author_username}`
+              : ""}
           </p>
           <p className="mt-0.5 line-clamp-2 text-caption text-text-2">
-            “{report.subject_preview.text}” · Reported by{" "}
+            “{report.subject_preview.text}” · Reported by @
             {report.reporter.username} · {formatAgoPhrase(report.created_at)}
           </p>
         </div>
@@ -79,7 +92,11 @@ export function ModerationQueueRow({
         </div>
       ) : (
         <p data-testid="audit-line" className="text-micro text-text-2">
-          Actioned · by {report.actioned_by ?? "moderator"}
+          Actioned{effectiveAction ? ` · ${effectiveAction}` : ""} by @
+          {report.actioned_by?.username ?? "moderator"}
+          {report.actioned_at
+            ? ` · ${format(new Date(report.actioned_at), "MMM d, HH:mm")}`
+            : ""}
         </p>
       )}
     </div>

--- a/web/src/components/ui/ThreadBubble.test.tsx
+++ b/web/src/components/ui/ThreadBubble.test.tsx
@@ -33,6 +33,37 @@ describe("ThreadBubble (§8.2b as built)", () => {
     expect(container.querySelector("[data-state]")).toBeNull();
   });
 
+  it("renders a per-bubble timestamp — bare time today, dated when older (B3 frame)", () => {
+    const today = new Date();
+    today.setHours(14, 5, 0, 0);
+    render(
+      <ThreadBubble side="sent" text="hi" timestamp={today.toISOString()} />,
+    );
+    expect(screen.getByText("14:05")).toBeInTheDocument();
+
+    const older = new Date("2026-03-04T13:58:00");
+    render(
+      <ThreadBubble
+        side="received"
+        text="ok"
+        timestamp={older.toISOString()}
+      />,
+    );
+    expect(screen.getByText("Mar 4, 13:58")).toBeInTheDocument();
+  });
+
+  it("timestamp waits for delivery and never applies to typing", () => {
+    const iso = new Date().toISOString();
+    const { container, rerender } = render(
+      <ThreadBubble side="sent" text="…" state="sending" timestamp={iso} />,
+    );
+    expect(container.querySelector("time")).toBeNull();
+    rerender(<ThreadBubble side="received" content="typing" timestamp={iso} />);
+    expect(container.querySelector("time")).toBeNull();
+    rerender(<ThreadBubble side="sent" text="…" timestamp={iso} />);
+    expect(container.querySelector("time")).not.toBeNull();
+  });
+
   it("sending dims; failed offers retry", async () => {
     const onRetry = vi.fn();
     const { rerender, container } = render(

--- a/web/src/components/ui/ThreadBubble.tsx
+++ b/web/src/components/ui/ThreadBubble.tsx
@@ -2,9 +2,12 @@
 
 // ThreadBubble — design.md §8.2b (as built): side sent / received ·
 // content text / image / typing (MI-17 three-dot "responding…" pulse) ·
-// state sending / sent / failed (send-state axis doesn't apply to typing).
+// state sending / sent / failed (send-state axis doesn't apply to typing) ·
+// per-bubble timestamp beneath the bubble (B3 frame idiom: "14:05"),
+// side-aligned; older-than-today messages carry the date.
 import clsx from "clsx";
 import Image from "next/image";
+import { format, isSameDay } from "date-fns";
 
 export type ThreadBubbleContent = "text" | "image" | "typing";
 export type ThreadBubbleState = "sending" | "sent" | "failed";
@@ -15,6 +18,8 @@ export interface ThreadBubbleProps {
   state?: ThreadBubbleState;
   text?: string;
   imageUrl?: string;
+  /** ISO send time — renders under the bubble once the message is sent. */
+  timestamp?: string | null;
   onRetry?: () => void;
   className?: string;
 }
@@ -25,10 +30,16 @@ export function ThreadBubble({
   state = "sent",
   text,
   imageUrl,
+  timestamp,
   onRetry,
   className,
 }: ThreadBubbleProps) {
   const sent = side === "sent";
+  // B3 frame: bare "HH:mm" under each bubble; messages from an earlier day
+  // prefix the date (the OrderTimelineRow idiom) so times stay meaningful.
+  const showTimestamp = Boolean(
+    timestamp && content !== "typing" && state === "sent",
+  );
   return (
     <div
       data-side={side}
@@ -80,6 +91,22 @@ export function ThreadBubble({
           text
         )}
       </div>
+      {showTimestamp ? (
+        <time
+          dateTime={timestamp!}
+          // Render-time timestamps may differ between server and client by
+          // design (same rationale as OrderTimelineRow).
+          suppressHydrationWarning
+          className="tnum mt-0.5 text-micro text-text-2"
+        >
+          {format(
+            new Date(timestamp!),
+            isSameDay(new Date(timestamp!), new Date())
+              ? "HH:mm"
+              : "MMM d, HH:mm",
+          )}
+        </time>
+      ) : null}
       {state === "failed" && content !== "typing" ? (
         <button
           type="button"

--- a/web/src/components/ui/fixtures.ts
+++ b/web/src/components/ui/fixtures.ts
@@ -158,11 +158,14 @@ export const fixtureReport: Report = {
   subject_preview: {
     text: "Buy followers cheap — link in bio",
     thumb_url: null,
+    author_username: null,
   },
   reason: "spam",
   detail: null,
   status: "open",
+  action: null,
   actioned_by: null,
+  actioned_at: null,
   created_at: daysAgo(1),
 };
 

--- a/web/src/controllers/use-moderation.ts
+++ b/web/src/controllers/use-moderation.ts
@@ -81,8 +81,13 @@ export function useModeration() {
   const act = useCallback(
     async (reportId: string, action: ModerationAction) => {
       const actioned = await moderationRepo.act(reportId, action);
-      // Open queue only shows open reports — actioned rows drop out.
-      setReports((prev) => prev.filter((r) => r.id !== reportId));
+      // Dismissed rows leave the queue; hide/suspend rows morph in place
+      // into the audit-trail state (the queue keeps what moderation did).
+      setReports((prev) =>
+        action === "dismiss"
+          ? prev.filter((r) => r.id !== reportId)
+          : prev.map((r) => (r.id === reportId ? actioned : r)),
+      );
       return actioned;
     },
     [],

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -8,9 +8,10 @@ describe("format utilities", () => {
     expect(formatNaira(-620_000)).toBe("−₦6,200");
   });
 
-  it("formats centimetres and inches", () => {
+  it("formats centimetres and inches — always one decimal (Figma '58.0 cm' idiom)", () => {
     expect(formatCm(42.5)).toBe("42.5 cm");
-    expect(formatCm(42)).toBe("42 cm");
+    expect(formatCm(42)).toBe("42.0 cm");
+    expect(formatCm(92)).toBe("92.0 cm");
     expect(formatCm(50.8, "in")).toBe("20.0 in");
   });
 

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -11,13 +11,17 @@ export function formatNaira(cents: number, currency = "NGN"): string {
   return `${cents < 0 ? "−" : ""}${symbol}${formatted}`;
 }
 
-/** 42.5 → "42.5 cm" (or inches when the vault unit toggle flips, MI-13). */
+/**
+ * 42.5 → "42.5 cm" (or inches when the vault unit toggle flips, MI-13).
+ * Always one decimal — the Figma idiom ("58.0 cm") keeps tabular columns
+ * aligned; "92 cm" next to "78.5 cm" broke the tnum grid (audit 2026-07-20).
+ */
 export function formatCm(valueCm: number, unit: "cm" | "in" = "cm"): string {
   if (unit === "in") {
     const inches = valueCm / 2.54;
     return `${inches.toFixed(1)} in`;
   }
-  return `${valueCm % 1 === 0 ? valueCm.toFixed(0) : valueCm.toFixed(1)} cm`;
+  return `${valueCm.toFixed(1)} cm`;
 }
 
 /** Compact social counts ("12.4k followers", IG-style — Figma 182:969). */

--- a/web/src/mocks/seed.ts
+++ b/web/src/mocks/seed.ts
@@ -149,6 +149,26 @@ export const seedAccounts: Account[] = [
     ],
     created_at: daysAgo(160),
   },
+  {
+    // Platform moderator — the B7a audit-trail actor (the actioned queue
+    // row reads "… by @mod.sarah"). Staff, not a designer; no social edges.
+    id: "acc-sarah",
+    firebase_uid: "test-uid-sarah",
+    email: "sarah@apparule.example.com",
+    username: "mod.sarah",
+    display_name: "Sarah Bello",
+    avatar_url: null,
+    profile_location: { city: "Lagos", state: "Lagos", country: "NG" },
+    deletion_state: "active",
+    designer: { enabled: false, kyc_complete: false },
+    is_staff: true,
+    notification_prefs: defaultPrefs(),
+    consent: [
+      { document: "tos", version: "1.0", accepted_at: daysAgo(320) },
+      { document: "privacy", version: "1.0", accepted_at: daysAgo(320) },
+    ],
+    created_at: daysAgo(320),
+  },
 ];
 
 // Community members — the wider Lagos-scene audience around the four core
@@ -1671,6 +1691,11 @@ export const seedNotifications: Notification[] = [
   },
 ];
 
+// The B7a queue narrative (canvas shape): two open reports — a spam
+// comment and a reported post with its thumb — plus one actioned exemplar
+// so the audit-trail row state renders from boot. Reported comments exist
+// as previews only (the spam one was never a seeded comment; the actioned
+// one is hidden), so post comment_counts stay honest.
 export const seedReports: Report[] = [
   {
     id: "rep-1",
@@ -1680,12 +1705,51 @@ export const seedReports: Report[] = [
     subject_preview: {
       text: "🔥🔥 Buy followers cheap — link in bio",
       thumb_url: null,
+      author_username: null,
     },
     reason: "spam",
     detail: null,
     status: "open",
+    action: null,
     actioned_by: null,
-    created_at: daysAgo(1),
+    actioned_at: null,
+    created_at: daysAgoAt(1, "21:37"),
+  },
+  {
+    id: "rep-2",
+    reporter: { id: "acc-chidi", username: "chidi.n" },
+    subject_kind: "post",
+    subject_id: "post-fabric-drop",
+    subject_preview: {
+      text: "New fabric drop — bring your vault measurements and pick a silhouette.",
+      thumb_url: "/demo/outfit-w14.jpg",
+      author_username: "amara.designs",
+    },
+    reason: "spam",
+    detail: "Reads like an ad, not an outfit post.",
+    status: "open",
+    action: null,
+    actioned_by: null,
+    actioned_at: null,
+    created_at: daysAgoAt(2, "08:19"),
+  },
+  {
+    id: "rep-3",
+    reporter: { id: "acc-zainab", username: "zainab.k" },
+    subject_kind: "comment",
+    subject_id: "cmt-counterfeit-1",
+    subject_preview: {
+      text: "DM for the exact same aso-oke, half the price 👀",
+      thumb_url: null,
+      author_username: null,
+    },
+    reason: "counterfeit",
+    detail: "Selling knockoffs of maisonbisi pieces in the comments.",
+    status: "actioned",
+    action: "hide_post", // comment subject — renders as hide_comment
+    actioned_by: { id: "acc-sarah", username: "mod.sarah" },
+    actioned_at: daysAgoAt(5, "09:12"),
+    created_at: daysAgoAt(6, "22:05"),
   },
 ];
 

--- a/web/src/mocks/seed.ts
+++ b/web/src/mocks/seed.ts
@@ -99,7 +99,10 @@ export const seedAccounts: Account[] = [
     email: "tunde@example.com",
     username: "tunde.o",
     display_name: "Tunde Okonkwo",
-    avatar_url: null,
+    // Suggestion-rail avatars are real photos from the licensed pool
+    // (audit 2026-07-20: initials-only reads as broken beside the canvas).
+    // Each designer fronts their OWN published work — no new assets.
+    avatar_url: "/demo/outfit-w15.jpg",
     profile_location: { city: "Lagos", state: "Lagos", country: "NG" },
     deletion_state: "active",
     designer: { enabled: true, kyc_complete: true },
@@ -135,7 +138,7 @@ export const seedAccounts: Account[] = [
     email: "eniola@example.com",
     username: "eniola.stitches",
     display_name: "Eniola Stitches",
-    avatar_url: null,
+    avatar_url: "/demo/outfit-w10.jpg", // her own atelier post photo
     // The one non-Lagos designer: kiki (Lagos) ranks her LAST under the
     // explore "near me" proximity ordering — the visible contrast case.
     profile_location: { city: "Abuja", state: "FCT", country: "NG" },
@@ -290,7 +293,7 @@ export const seedDesigners: DesignerProfile[] = [
     username: "tunde.o",
     display_name: "Tunde Okonkwo",
     bio: "Agbada, senator suits, and sharp menswear.",
-    avatar_url: null,
+    avatar_url: "/demo/outfit-w15.jpg", // mirrors acc-tunde — one identity
     payout_account: {
       provider_ref: "PSTK-RCP-77310",
       bank_name: "Access Bank",
@@ -328,7 +331,7 @@ export const seedDesigners: DesignerProfile[] = [
     username: "eniola.stitches",
     display_name: "Eniola Stitches",
     bio: "Bespoke womenswear from the Abuja atelier — corporate and occasion.",
-    avatar_url: null,
+    avatar_url: "/demo/outfit-w10.jpg", // mirrors acc-eniola — one identity
     payout_account: {
       provider_ref: "PSTK-RCP-55492",
       bank_name: "UBA",

--- a/web/src/mocks/seed.ts
+++ b/web/src/mocks/seed.ts
@@ -27,6 +27,21 @@ export function daysAgo(days: number, base: Date = NOW()): string {
   return new Date(base.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
 }
 
+/**
+ * N days ago, pinned to a plausible local time of day ("HH:mm"). daysAgo
+ * alone stamps everything with the boot minute, so a multi-event order
+ * timeline read as a synthetic same-minute cluster (PR #102 cadence rule:
+ * timelines must read like days of real back-and-forth, not one batch
+ * insert). Only used for whole-day offsets ≥ 1 — a pinned time on a
+ * same-day offset could land in the future.
+ */
+function daysAgoAt(days: number, time: string, base: Date = NOW()): string {
+  const d = new Date(base.getTime() - days * 24 * 60 * 60 * 1000);
+  const [hours, minutes] = time.split(":").map(Number);
+  d.setHours(hours, minutes, 0, 0);
+  return d.toISOString();
+}
+
 function hoursAgo(hours: number): string {
   return new Date(NOW().getTime() - hours * 60 * 60 * 1000).toISOString();
 }
@@ -1018,6 +1033,13 @@ interface SeedOrderInput {
     kind: string;
     actor: "customer" | "designer" | "system";
     at: number;
+    /**
+     * Local time of day ("HH:mm") for the event — required for whole-day
+     * offsets so each order's story spreads across real-looking hours
+     * (PR #102 cadence rule); omit only for same-day offsets (< 1), which
+     * stay relative to boot.
+     */
+    time?: string;
   }[];
   quote?: number | null;
   budget?: number | null;
@@ -1038,6 +1060,17 @@ function makeOrder(input: SeedOrderInput): CommissionRequest {
   const post = postById(input.postId);
   const id = `req-apr-${input.num}`;
   const quote = input.quote ?? null;
+  const events = input.events.map((e, i) => ({
+    id: `evt-${input.num}-${i}`,
+    request_id: id,
+    kind: e.kind,
+    actor: e.actor,
+    created_at: e.time ? daysAgoAt(e.at, e.time) : daysAgo(e.at),
+  }));
+  // The order (and the snapshot freeze) exists from the moment it was
+  // requested — anchor both to the first event so the record is one
+  // coherent story, not three separately-stamped rows.
+  const requestedAt = events[0].created_at;
   return {
     id,
     order_number: `APR-${input.num}`,
@@ -1097,15 +1130,9 @@ function makeOrder(input: SeedOrderInput): CommissionRequest {
                   { name: "hip_width", value_cm: 37.0 },
                 ],
               },
-      created_at: daysAgo(input.createdDaysAgo),
+      created_at: requestedAt,
     },
-    events: input.events.map((e, i) => ({
-      id: `evt-${input.num}-${i}`,
-      request_id: id,
-      kind: e.kind,
-      actor: e.actor,
-      created_at: daysAgo(e.at),
-    })),
+    events,
     payment:
       input.payment && quote !== null
         ? {
@@ -1118,7 +1145,7 @@ function makeOrder(input: SeedOrderInput): CommissionRequest {
             platform_fee_cents: Math.round(quote * 0.1),
           }
         : null,
-    created_at: daysAgo(input.createdDaysAgo),
+    created_at: requestedAt,
   };
 }
 
@@ -1163,36 +1190,38 @@ export const seedOrders: CommissionRequest[] = [
           { name: "hip_width", value_cm: 36.8 },
         ],
       },
-      created_at: daysAgo(8),
+      created_at: daysAgoAt(8, "09:14"),
     },
+    // Event times spread across real-looking hours (PR #102 cadence rule);
+    // the B3 canvas timeline adopts these same stamps.
     events: [
       {
         id: "evt-1042-1",
         request_id: "req-apr-1042",
         kind: "requested",
         actor: "customer",
-        created_at: daysAgo(8),
+        created_at: daysAgoAt(8, "09:14"),
       },
       {
         id: "evt-1042-2",
         request_id: "req-apr-1042",
         kind: "quoted",
         actor: "designer",
-        created_at: daysAgo(7),
+        created_at: daysAgoAt(7, "14:02"),
       },
       {
         id: "evt-1042-3",
         request_id: "req-apr-1042",
         kind: "paid",
         actor: "customer",
-        created_at: daysAgo(6),
+        created_at: daysAgoAt(6, "10:26"),
       },
       {
         id: "evt-1042-4",
         request_id: "req-apr-1042",
         kind: "in_progress",
         actor: "designer",
-        created_at: daysAgo(5),
+        created_at: daysAgoAt(5, "09:40"),
       },
     ],
     payment: {
@@ -1204,7 +1233,7 @@ export const seedOrders: CommissionRequest[] = [
       amount_cents: 4_500_000,
       platform_fee_cents: 450_000, // 10% (A-1)
     },
-    created_at: daysAgo(8),
+    created_at: daysAgoAt(8, "09:14"),
   },
   {
     id: "req-apr-1058",
@@ -1254,7 +1283,7 @@ export const seedOrders: CommissionRequest[] = [
           { name: "waist_girth", value_cm: 55.0 },
         ],
       },
-      created_at: daysAgo(40),
+      created_at: daysAgoAt(40, "11:05"),
     },
     events: [
       {
@@ -1262,42 +1291,42 @@ export const seedOrders: CommissionRequest[] = [
         request_id: "req-apr-1058",
         kind: "requested",
         actor: "customer",
-        created_at: daysAgo(40),
+        created_at: daysAgoAt(40, "11:05"),
       },
       {
         id: "evt-1058-2",
         request_id: "req-apr-1058",
         kind: "quoted",
         actor: "designer",
-        created_at: daysAgo(38),
+        created_at: daysAgoAt(38, "16:40"),
       },
       {
         id: "evt-1058-3",
         request_id: "req-apr-1058",
         kind: "paid",
         actor: "customer",
-        created_at: daysAgo(36),
+        created_at: daysAgoAt(36, "08:57"),
       },
       {
         id: "evt-1058-4",
         request_id: "req-apr-1058",
         kind: "in_progress",
         actor: "designer",
-        created_at: daysAgo(30),
+        created_at: daysAgoAt(30, "09:18"),
       },
       {
         id: "evt-1058-5",
         request_id: "req-apr-1058",
         kind: "shipped",
         actor: "designer",
-        created_at: daysAgo(10),
+        created_at: daysAgoAt(10, "17:25"),
       },
       {
         id: "evt-1058-6",
         request_id: "req-apr-1058",
         kind: "delivered",
         actor: "customer",
-        created_at: daysAgo(7),
+        created_at: daysAgoAt(7, "13:44"),
       },
     ],
     payment: {
@@ -1309,7 +1338,7 @@ export const seedOrders: CommissionRequest[] = [
       amount_cents: 6_200_000,
       platform_fee_cents: 620_000,
     },
-    created_at: daysAgo(40),
+    created_at: daysAgoAt(40, "11:05"),
   },
   makeOrder({
     num: 1031,
@@ -1318,7 +1347,7 @@ export const seedOrders: CommissionRequest[] = [
     createdDaysAgo: 1,
     budget: 6_000_000,
     notes: "Need it for my brother's wedding in August.",
-    events: [{ kind: "requested", actor: "customer", at: 1 }],
+    events: [{ kind: "requested", actor: "customer", at: 1, time: "18:32" }],
   }),
   makeOrder({
     num: 1033,
@@ -1330,8 +1359,9 @@ export const seedOrders: CommissionRequest[] = [
     dueInDays: 12,
     notes: "Two-piece for an engagement shoot.",
     events: [
-      { kind: "requested", actor: "customer", at: 3 },
-      // 0.25d = 6h — matches the unread "quoted ₦40,000" notification.
+      { kind: "requested", actor: "customer", at: 3, time: "12:47" },
+      // 0.25d = 6h, relative to boot — matches the unread "quoted ₦40,000"
+      // notification (hoursAgo(6)); same-day offsets stay unpinned.
       { kind: "quoted", actor: "designer", at: 0.25 },
     ],
   }),
@@ -1344,9 +1374,9 @@ export const seedOrders: CommissionRequest[] = [
     dueInDays: 21,
     payment: "held",
     events: [
-      { kind: "requested", actor: "customer", at: 6 },
-      { kind: "quoted", actor: "designer", at: 5 },
-      { kind: "paid", actor: "customer", at: 4 },
+      { kind: "requested", actor: "customer", at: 6, time: "09:05" },
+      { kind: "quoted", actor: "designer", at: 5, time: "15:22" },
+      { kind: "paid", actor: "customer", at: 4, time: "19:48" },
     ],
   }),
   makeOrder({
@@ -1359,11 +1389,11 @@ export const seedOrders: CommissionRequest[] = [
     payment: "held",
     tracking: "GIG-5567-LAG",
     events: [
-      { kind: "requested", actor: "customer", at: 20 },
-      { kind: "quoted", actor: "designer", at: 19 },
-      { kind: "paid", actor: "customer", at: 18 },
-      { kind: "in_progress", actor: "designer", at: 15 },
-      { kind: "shipped", actor: "designer", at: 3 },
+      { kind: "requested", actor: "customer", at: 20, time: "10:12" },
+      { kind: "quoted", actor: "designer", at: 19, time: "13:37" },
+      { kind: "paid", actor: "customer", at: 18, time: "08:26" },
+      { kind: "in_progress", actor: "designer", at: 15, time: "11:54" },
+      { kind: "shipped", actor: "designer", at: 3, time: "16:09" },
     ],
   }),
   makeOrder({
@@ -1378,11 +1408,11 @@ export const seedOrders: CommissionRequest[] = [
       detail: "Colours differ from the reference photos.",
     },
     events: [
-      { kind: "requested", actor: "customer", at: 25 },
-      { kind: "quoted", actor: "designer", at: 24 },
-      { kind: "paid", actor: "customer", at: 22 },
-      { kind: "in_progress", actor: "designer", at: 20 },
-      { kind: "disputed", actor: "customer", at: 2 },
+      { kind: "requested", actor: "customer", at: 25, time: "14:31" },
+      { kind: "quoted", actor: "designer", at: 24, time: "10:58" },
+      { kind: "paid", actor: "customer", at: 22, time: "20:15" },
+      { kind: "in_progress", actor: "designer", at: 20, time: "09:47" },
+      { kind: "disputed", actor: "customer", at: 2, time: "18:03" },
     ],
   }),
   makeOrder({
@@ -1392,8 +1422,8 @@ export const seedOrders: CommissionRequest[] = [
     createdDaysAgo: 30,
     decline: "workload",
     events: [
-      { kind: "requested", actor: "customer", at: 30 },
-      { kind: "declined", actor: "designer", at: 29 },
+      { kind: "requested", actor: "customer", at: 30, time: "13:20" },
+      { kind: "declined", actor: "designer", at: 29, time: "09:36" },
     ],
   }),
   makeOrder({
@@ -1404,10 +1434,10 @@ export const seedOrders: CommissionRequest[] = [
     quote: 4_200_000,
     payment: "refunded",
     events: [
-      { kind: "requested", actor: "customer", at: 60 },
-      { kind: "quoted", actor: "designer", at: 58 },
-      { kind: "paid", actor: "customer", at: 55 },
-      { kind: "refunded", actor: "system", at: 41 },
+      { kind: "requested", actor: "customer", at: 60, time: "11:41" },
+      { kind: "quoted", actor: "designer", at: 58, time: "15:07" },
+      { kind: "paid", actor: "customer", at: 55, time: "10:33" },
+      { kind: "refunded", actor: "system", at: 41, time: "09:02" },
     ],
   }),
   makeOrder({
@@ -1416,12 +1446,14 @@ export const seedOrders: CommissionRequest[] = [
     status: "cancelled",
     createdDaysAgo: 45,
     events: [
-      { kind: "requested", actor: "customer", at: 45 },
-      { kind: "cancelled", actor: "customer", at: 44 },
+      { kind: "requested", actor: "customer", at: 45, time: "17:29" },
+      { kind: "cancelled", actor: "customer", at: 44, time: "08:44" },
     ],
   }),
 ];
 
+// Message times sit minutes-to-hours around the order events they narrate
+// (PR #102 cadence rule — the thread and the timeline tell one story).
 export const seedThreadMessages = [
   {
     id: "msg-1042-1",
@@ -1429,7 +1461,7 @@ export const seedThreadMessages = [
     author_id: "acc-kiki",
     body: "Hi Amara! Excited about this one — here's my inspiration.",
     image_url: "/demo/outfit-w01.jpg",
-    created_at: daysAgo(8),
+    created_at: daysAgoAt(8, "09:31"), // shortly after requesting (09:14)
   },
   {
     id: "msg-1042-2",
@@ -1437,7 +1469,7 @@ export const seedThreadMessages = [
     author_id: "des-amara",
     body: "Love it. Quote sent — I can have it ready two weeks after payment.",
     image_url: null,
-    created_at: daysAgo(7),
+    created_at: daysAgoAt(7, "14:05"), // right behind the quote (14:02)
   },
   {
     id: "msg-1042-3",
@@ -1445,7 +1477,7 @@ export const seedThreadMessages = [
     author_id: "des-amara",
     body: "Fabric cut today — progress shot attached.",
     image_url: "/demo/outfit-w14.jpg",
-    created_at: daysAgo(2),
+    created_at: daysAgoAt(2, "16:12"),
   },
   {
     id: "msg-1058-1",
@@ -1453,7 +1485,7 @@ export const seedThreadMessages = [
     author_id: "acc-kiki",
     body: "Colour scheme: royal blue and white, please — same as the post.",
     image_url: null,
-    created_at: daysAgo(39),
+    created_at: daysAgoAt(39, "10:20"),
   },
   {
     id: "msg-1058-2",
@@ -1461,7 +1493,7 @@ export const seedThreadMessages = [
     author_id: "des-bisi",
     body: "Delivered via GIG — enjoy the wedding!",
     image_url: null,
-    created_at: daysAgo(10),
+    created_at: daysAgoAt(10, "17:31"), // minutes after shipping (17:25)
   },
   // The helper-built orders carry short, state-appropriate exchanges so
   // every thread reads like a real buyer–designer conversation.
@@ -1471,7 +1503,7 @@ export const seedThreadMessages = [
     author_id: "acc-kiki",
     body: "Sent the request — it's for my brother's wedding on Aug 22. Can you match the fabric in your post?",
     image_url: null,
-    created_at: daysAgo(1),
+    created_at: daysAgoAt(1, "18:41"), // right after requesting (18:32)
   },
   {
     id: "msg-1033-1",
@@ -1487,7 +1519,7 @@ export const seedThreadMessages = [
     author_id: "des-amara",
     body: "Just quoted ₦40,000 — three weeks is fine if payment lands this week.",
     image_url: null,
-    created_at: daysAgo(0.25),
+    created_at: daysAgo(0.24), // ~15 min after the 0.25d quote event
   },
   {
     id: "msg-1036-1",
@@ -1503,7 +1535,7 @@ export const seedThreadMessages = [
     author_id: "des-tunde",
     body: "Shipped via GIG — tracking GIG-5567-LAG. Apologies for the two-day slip, the collars took longer than planned.",
     image_url: null,
-    created_at: daysAgo(3),
+    created_at: daysAgoAt(3, "16:14"), // minutes after shipping (16:09)
   },
   {
     id: "msg-1018-1",
@@ -1527,7 +1559,7 @@ export const seedThreadMessages = [
     author_id: "des-tunde",
     body: "Fully booked until September, so I have to decline — sorry! maisonbisi does beautiful work in this style.",
     image_url: null,
-    created_at: daysAgo(29),
+    created_at: daysAgoAt(29, "09:41"), // right after declining (09:36)
   },
 ];
 

--- a/web/src/mocks/store.test.ts
+++ b/web/src/mocks/store.test.ts
@@ -107,6 +107,62 @@ describe("seed narrative", () => {
     }
   });
 
+  it("order events read as real days of back-and-forth (PR #102 cadence)", () => {
+    // The synthetic failure class: every event stamped with the boot
+    // minute (an entire timeline at "15:51"). Each order's events must be
+    // strictly ordered, never in the future, and a multi-event timeline
+    // never collapses onto one wall-clock minute.
+    const wallMinute = (iso: string) => {
+      const d = new Date(iso);
+      return `${d.getHours()}:${d.getMinutes()}`;
+    };
+    for (const order of store.orders) {
+      const times = order.events.map((e) => new Date(e.created_at).getTime());
+      for (let i = 1; i < times.length; i++) {
+        expect(times[i], `${order.id} event ${i}`).toBeGreaterThan(
+          times[i - 1],
+        );
+      }
+      expect(Math.max(...times), order.id).toBeLessThanOrEqual(Date.now());
+      if (order.events.length > 1) {
+        const minutes = new Set(
+          order.events.map((e) => wallMinute(e.created_at)),
+        );
+        expect(minutes.size, order.id).toBeGreaterThan(1);
+      }
+      // One coherent record: the order (and its frozen snapshot) exists
+      // from the requested event, not from a separately-stamped boot time.
+      expect(order.created_at, order.id).toBe(order.events[0].created_at);
+      expect(order.snapshot.created_at, order.id).toBe(order.created_at);
+    }
+  });
+
+  it("thread messages follow the same cadence rule per thread (PR #102)", () => {
+    const wallMinute = (iso: string) => {
+      const d = new Date(iso);
+      return `${d.getHours()}:${d.getMinutes()}`;
+    };
+    const byThread = new Map<string, typeof store.messages>();
+    for (const message of store.messages) {
+      const list = byThread.get(message.request_id) ?? [];
+      list.push(message);
+      byThread.set(message.request_id, list);
+    }
+    for (const [requestId, messages] of byThread) {
+      const times = messages.map((m) => new Date(m.created_at).getTime());
+      for (let i = 1; i < times.length; i++) {
+        expect(times[i], `${requestId} message ${i}`).toBeGreaterThan(
+          times[i - 1],
+        );
+      }
+      expect(Math.max(...times), requestId).toBeLessThanOrEqual(Date.now());
+      if (messages.length > 1) {
+        const minutes = new Set(messages.map((m) => wallMinute(m.created_at)));
+        expect(minutes.size, requestId).toBeGreaterThan(1);
+      }
+    }
+  });
+
   it("feed contains only followed designers (amara + bisi, not tunde)", () => {
     const feed = store.feed("kiki.adeyemi");
     expect(feed.length).toBeGreaterThan(0);

--- a/web/src/mocks/store.test.ts
+++ b/web/src/mocks/store.test.ts
@@ -799,6 +799,30 @@ describe("notification prefs + moderation gate + thread auto-reply", () => {
     );
   });
 
+  it("queue seeds the canvas narrative: open rows lead, actioned audit row renders, dismissed drop", () => {
+    const queue = store.moderationQueue("kiki.adeyemi");
+    expect(queue.length).toBe(3);
+    expect(queue.filter((r) => r.status === "open").length).toBe(2);
+    // Open rows lead; the actioned exemplar (audit trail) trails.
+    expect(queue[queue.length - 1].status).toBe("actioned");
+    const actioned = queue[queue.length - 1];
+    expect(actioned.actioned_by?.username).toBe("mod.sarah");
+    expect(actioned.action).toBe("hide_post");
+    expect(actioned.actioned_at).toBeTruthy();
+    // The reported-post row carries its author + thumb (canvas anatomy).
+    const postReport = queue.find((r) => r.subject_kind === "post")!;
+    expect(postReport.subject_preview.author_username).toBe("amara.designs");
+    expect(postReport.subject_preview.thumb_url).toMatch(/^\/demo\//);
+    // Acting writes the audit fields; dismissing removes the row.
+    const acted = store.actOnReport("rep-2", "kiki.adeyemi", "hide_post");
+    expect(acted.actioned_by?.username).toBe("kiki.adeyemi");
+    expect(acted.action).toBe("hide_post");
+    store.actOnReport("rep-1", "kiki.adeyemi", "dismiss");
+    const after = store.moderationQueue("kiki.adeyemi");
+    expect(after.some((r) => r.id === "rep-1")).toBe(false);
+    expect(after.find((r) => r.id === "rep-2")?.status).toBe("actioned");
+  });
+
   it("scripts one counterparty auto-reply per thread (MI-17)", () => {
     const before = store.messagesFor("req-apr-1042", "kiki.adeyemi").length;
     store.addMessage("req-apr-1042", "kiki.adeyemi", "Any progress?", null);

--- a/web/src/mocks/store.test.ts
+++ b/web/src/mocks/store.test.ts
@@ -163,6 +163,19 @@ describe("seed narrative", () => {
     }
   });
 
+  it("suggested designers carry real photo avatars from the licensed pool", () => {
+    // Audit 2026-07-20: initials-only suggestion rows read as broken next
+    // to the canvas narrative. Each suggested designer fronts their own
+    // published photography — counts and identities stay honest.
+    const rows = store.suggestedDesigners("kiki.adeyemi");
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(row.avatar_url, row.username).toMatch(
+        /^\/demo\/outfit-w\d+\.jpg$/,
+      );
+    }
+  });
+
   it("feed contains only followed designers (amara + bisi, not tunde)", () => {
     const feed = store.feed("kiki.adeyemi");
     expect(feed.length).toBeGreaterThan(0);

--- a/web/src/mocks/store.ts
+++ b/web/src/mocks/store.ts
@@ -1599,11 +1599,15 @@ export class MockStore {
       subject_preview: {
         text: post?.caption ?? comment?.body ?? subjectId,
         thumb_url: post?.media[0]?.url ?? null,
+        author_username:
+          post?.designer.username ?? comment?.author.username ?? null,
       },
       reason,
       detail: detail ?? null,
       status: "open",
+      action: null,
       actioned_by: null,
+      actioned_at: null,
       created_at: new Date().toISOString(),
     };
     this.reports.unshift(report);
@@ -1633,7 +1637,13 @@ export class MockStore {
 
   moderationQueue(moderatorUsername: string): Report[] {
     this.requireStaff(moderatorUsername);
-    return deepClone(this.reports.filter((r) => r.status === "open"));
+    // Open reports lead; actioned rows stay listed as the audit trail
+    // (canvas narrative — the queue shows what moderation did, not just
+    // what's pending). Dismissed reports leave the queue.
+    return deepClone([
+      ...this.reports.filter((r) => r.status === "open"),
+      ...this.reports.filter((r) => r.status === "actioned"),
+    ]);
   }
 
   actOnReport(
@@ -1652,7 +1662,9 @@ export class MockStore {
       if (comment) comment.hidden_by_moderation = true;
     }
     report.status = action === "dismiss" ? "dismissed" : "actioned";
-    report.actioned_by = moderator.id;
+    report.action = action;
+    report.actioned_by = { id: moderator.id, username: moderator.username };
+    report.actioned_at = new Date().toISOString();
     return deepClone(report);
   }
 

--- a/web/src/models/entities/moderation.ts
+++ b/web/src/models/entities/moderation.ts
@@ -11,10 +11,18 @@ export interface Report {
   subject_kind: ReportSubjectKind;
   subject_id: string;
   /** Preview of the reported content for the queue row. */
-  subject_preview: { text: string; thumb_url: string | null };
+  subject_preview: {
+    text: string;
+    thumb_url: string | null;
+    /** Author of the reported content ("Reported post by @…"), if known. */
+    author_username: string | null;
+  };
   reason: ReportReason;
   detail: string | null;
   status: "open" | "actioned" | "dismissed";
-  actioned_by: string | null;
+  /** Audit trail (B7a queue row): what was done, by whom, when. */
+  action: ModerationAction | null;
+  actioned_by: { id: string; username: string } | null;
+  actioned_at: string | null;
   created_at: string;
 }


### PR DESCRIPTION
CODE-side fixes from the adjudicated Figma ↔ code divergence audit (2026-07-20 ledger). Figma-side items ship separately via the design agent; the adjudicate-once sub-screen header pattern was ruled in code's favor (AppBar kind=sub) — no code change here by design.

## Per-item

1. **Thread bubble timestamps (B3 frame — fix code).** `ThreadBubble` gains a `timestamp` prop: bare `HH:mm` for same-day messages, `MMM d, HH:mm` (the OrderTimelineRow idiom) when older, side-aligned under the bubble, delivered messages only (never sending/typing). Wired from `message.created_at` in the order detail. Unit tests + an e2e assertion in the MI-17 journey.

2. **Order-event cadence (PR #102 realism rule — fix code).** Every seeded order event was stamped with the boot minute (the audited "all 15:51" cluster). Events now pin plausible local times of day along each order's story (`daysAgoAt` helper); thread messages sit minutes-to-hours around the events they narrate; the order and its frozen snapshot anchor to the requested event. APR-1042 adopts the canvas stamps (09:14 / 14:02 / 10:26 / 09:40) so the design agent can converge the frame on the same story. **Unit-gated**: per-order strict ordering, no future stamps, no same-minute clusters — same rule for threads.

3. **Moderation seed → canvas narrative shape.** Boot now shows two open reports (the spam comment + a reported post with thumb and author) and one ACTIONED audit exemplar ("Actioned · hide_comment by @mod.sarah · Jul 15, 09:12"), backed by a seeded staff moderator persona. Counts stay honest: reported comments are previews only, so comment_counts never shift. `Report` gains audit fields (`action`, `actioned_by {id, username}`, `actioned_at`, subject author — mock-ahead-of-contract, deviation noted in web-implementation §6); the queue lists open rows first with actioned rows trailing; acting morphs the row in place, dismissing removes it; row anatomy per canvas (@-prefixed reporter, author in headline) and the banner carries the "Learn more" link.

4. **Measurement decimals (adjudicated: fix code).** `formatCm` always renders one decimal ("92.0 cm", the frame's "58.0 cm" idiom) — MeasurementCard, SessionRow, snapshot chips, and the request stepper share the formatter, so tnum columns align.

5. **Own-profile freshness ring (MI-11, C9 construction).** The own avatar wears the measurement-freshness ring on the profile header (regular-user and designer-self branches); other designers keep the B6 gradient story ring, and other users' profiles never fetch the vault. The band → ring mapping is centralized (`freshnessRing` on the Avatar atom; vault header + feed card refactored onto it). Unit tests for the mapping and both branches; e2e asserts the rendered ring on /dashboard/profile.

6. **Rail-suggestion avatars.** tunde.o and eniola.stitches (the seeded suggestions) front their OWN published photography from the licensed /demo pool — no new assets, no fabricated identities, counts untouched. `UserRow` call sites (suggestions, explore designer search, follower sheets) now pass `avatar_url` through. Unit-gated: suggested designers must carry /demo photo avatars.

7. **Scalar dev toolbar hidden on /docs/api.** `showDeveloperTools: "never"` in the embed configuration (the `"localhost"` default surfaced author chrome on the public reference in local/TEST_MODE runs); e2e asserts the toolbar stays absent.

**Docs:** web-implementation.md — §6 seed narrative updated (cadence rule, moderation queue shape + REPORT deviation note, suggestion avatars) plus a dated design-convergence as-built block and the Scalar toolbar note.

## Gates

- `npm run lint` (prettier + eslint + boundary gate): clean
- `npm run typecheck`: clean
- `npm test`: 79 files / 484+ tests green (incl. the new cadence, moderation, ring and avatar gates)
- `NEXT_PUBLIC_TEST_MODE=1 npm run build`: clean
- `CI=1 playwright test` against the prod TEST_MODE build: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
