### PR TITLE
fix(web): timezone-stable timestamps — review P2 gaps from the #112 Codex pass

### DIFF
--- a/web/src/components/ui/EarningsSummary.test.tsx
+++ b/web/src/components/ui/EarningsSummary.test.tsx
@@ -27,4 +27,18 @@ describe("EarningsSummary + TransactionRow (§8.2b)", () => {
     render(<TransactionRow entry={fee} />);
     expect(screen.getByText("−₦6,200")).toBeInTheDocument();
   });
+
+  it("old payout dates read the UTC calendar day — SSR/client-stable (review P2)", () => {
+    // 23:30Z on Jan 15: a host in Lagos (+01:00) would locally render
+    // "16 Jan" while a UTC server said "15 Jan" — a hydration mismatch
+    // and visible date flip. The ≥30d fallback derives from UTC.
+    const entry = {
+      ...fixtureEarnings.transactions[0],
+      created_at: "2026-01-15T23:30:00Z",
+    };
+    render(<TransactionRow entry={entry} />);
+    const time = screen.getByText("15 Jan");
+    expect(time.tagName).toBe("TIME");
+    expect(time).toHaveAttribute("dateTime", "2026-01-15T23:30:00Z");
+  });
 });

--- a/web/src/components/ui/EarningsSummary.tsx
+++ b/web/src/components/ui/EarningsSummary.tsx
@@ -82,7 +82,13 @@ export function TransactionRow({
           {label ?? `${meta.label} · ${entry.order_number}`}
         </p>
         <p className="truncate text-micro text-text-2">
-          {formatAgo(entry.created_at)}
+          {/* suppressHydrationWarning: the relative window ("6h", "3d")
+              reads the render-time clock (PostCard convention); the ≥30d
+              absolute fallback is UTC-derived, so the server and every
+              client agree on the payout's calendar day. */}
+          <time dateTime={entry.created_at} suppressHydrationWarning>
+            {formatAgo(entry.created_at)}
+          </time>
           {entry.provider_ref ? ` · ${entry.provider_ref}` : ""}
         </p>
       </div>

--- a/web/src/components/ui/ThreadBubble.test.tsx
+++ b/web/src/components/ui/ThreadBubble.test.tsx
@@ -34,22 +34,33 @@ describe("ThreadBubble (§8.2b as built)", () => {
   });
 
   it("renders a per-bubble timestamp — bare time today, dated when older (B3 frame)", () => {
+    // UTC-anchored instants: the label is UTC-derived (hydration-stable),
+    // so these expectations hold on any host timezone.
     const today = new Date();
-    today.setHours(14, 5, 0, 0);
+    today.setUTCHours(14, 5, 0, 0);
     render(
       <ThreadBubble side="sent" text="hi" timestamp={today.toISOString()} />,
     );
     expect(screen.getByText("14:05")).toBeInTheDocument();
 
-    const older = new Date("2026-03-04T13:58:00");
     render(
       <ThreadBubble
         side="received"
         text="ok"
-        timestamp={older.toISOString()}
+        timestamp="2026-03-04T13:58:00Z"
       />,
     );
     expect(screen.getByText("Mar 4, 13:58")).toBeInTheDocument();
+  });
+
+  it("timestamps derive from UTC — never the host timezone (review P2)", () => {
+    // 23:30Z: any non-UTC host would land this on a different local
+    // wall-clock (and often a different calendar day) — the rendered
+    // label must stay the UTC reading either way, matching SSR output.
+    render(
+      <ThreadBubble side="sent" text="late" timestamp="2026-03-04T23:30:00Z" />,
+    );
+    expect(screen.getByText("Mar 4, 23:30")).toBeInTheDocument();
   });
 
   it("timestamp waits for delivery and never applies to typing", () => {

--- a/web/src/components/ui/ThreadBubble.tsx
+++ b/web/src/components/ui/ThreadBubble.tsx
@@ -7,7 +7,7 @@
 // side-aligned; older-than-today messages carry the date.
 import clsx from "clsx";
 import Image from "next/image";
-import { format, isSameDay } from "date-fns";
+import { formatDateTimeUtc, formatTimeUtc, isSameUtcDay } from "@/lib/format";
 
 export type ThreadBubbleContent = "text" | "image" | "typing";
 export type ThreadBubbleState = "sending" | "sent" | "failed";
@@ -94,17 +94,16 @@ export function ThreadBubble({
       {showTimestamp ? (
         <time
           dateTime={timestamp!}
-          // Render-time timestamps may differ between server and client by
-          // design (same rationale as OrderTimelineRow).
+          // The label is UTC-derived — a pure function of the instant, so
+          // SSR and the client emit the identical string in any timezone.
+          // suppressHydrationWarning guards only the same-day check racing
+          // a UTC midnight between server render and hydration.
           suppressHydrationWarning
           className="tnum mt-0.5 text-micro text-text-2"
         >
-          {format(
-            new Date(timestamp!),
-            isSameDay(new Date(timestamp!), new Date())
-              ? "HH:mm"
-              : "MMM d, HH:mm",
-          )}
+          {isSameUtcDay(timestamp!, new Date())
+            ? formatTimeUtc(timestamp!)
+            : formatDateTimeUtc(timestamp!)}
         </time>
       ) : null}
       {state === "failed" && content !== "typing" ? (

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { formatAgo, formatAgoPhrase, formatCm, formatNaira } from "./format";
+import {
+  formatAgo,
+  formatAgoPhrase,
+  formatCm,
+  formatDateTimeUtc,
+  formatDateUtc,
+  formatNaira,
+  formatTimeUtc,
+  isSameUtcDay,
+} from "./format";
 
 describe("format utilities", () => {
   it("formats kobo to naira", () => {
@@ -30,5 +39,33 @@ describe("format utilities", () => {
     // ≥30d switches to an absolute date — prefixed, never suffixed with "ago"
     expect(formatAgoPhrase("2026-05-22T12:00:00Z", now)).toBe("on 22 May");
     expect(formatAgoPhrase("2026-05-22T12:00:00Z", now)).not.toMatch(/ago/);
+  });
+
+  it("UTC-derived timestamp text is timezone-stable (review P2: no SSR/client drift)", () => {
+    // 23:30Z sits on a different local calendar day in most timezones
+    // (e.g. Lagos = +01:00 → May 23). The formatters must read the UTC
+    // clock, so every host — server or browser — emits the same string.
+    expect(formatTimeUtc("2026-07-14T13:58:00Z")).toBe("13:58");
+    expect(formatTimeUtc("2026-05-22T23:30:00Z")).toBe("23:30");
+    expect(formatDateUtc("2026-05-22T23:30:00Z")).toBe("22 May");
+    expect(formatDateTimeUtc("2026-03-04T23:30:00Z")).toBe("Mar 4, 23:30");
+    // Single-digit hour/minute pad ("09:05", not "9:5").
+    expect(formatTimeUtc("2026-07-14T09:05:00Z")).toBe("09:05");
+  });
+
+  it("formatAgo's ≥30d fallback reads the UTC calendar day", () => {
+    const now = new Date("2026-07-18T12:00:00Z");
+    // Near-midnight instant: local rendering would flip this to "23 May"
+    // on UTC+ hosts, splitting SSR (UTC) from the client.
+    expect(formatAgo("2026-05-22T23:30:00Z", now)).toBe("22 May");
+  });
+
+  it("same-UTC-day check ignores the host timezone", () => {
+    expect(isSameUtcDay("2026-05-22T23:30:00Z", "2026-05-22T00:10:00Z")).toBe(
+      true,
+    );
+    expect(isSameUtcDay("2026-05-22T23:30:00Z", "2026-05-23T00:10:00Z")).toBe(
+      false,
+    );
   });
 });

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -59,8 +59,56 @@ export function formatAgo(iso: string, now: Date = new Date()): string {
   }
   if (days < 7) return `${days}d`;
   if (days < 30) return `${Math.floor(days / 7)}w`;
-  return new Date(iso).toLocaleDateString("en-NG", {
-    month: "short",
-    day: "numeric",
-  });
+  return formatDateUtc(iso);
+}
+
+// ---------------------------------------------------------------------------
+// UTC-derived timestamp text. These are pure functions of the instant, so
+// the server and every client render the identical string regardless of
+// host timezone — hydrated <time> labels never mismatch or flip (the local
+// alternative emits different calendar days/times across timezones for the
+// same instant). The API speaks UTC ISO strings; these read that same
+// UTC clock.
+// ---------------------------------------------------------------------------
+
+const UTC_MONTHS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+/** "13:58" — UTC wall-clock time (per-bubble thread stamps). */
+export function formatTimeUtc(iso: string): string {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}`;
+}
+
+/** "22 May" — UTC calendar date (the ≥30d relative-label fallback). */
+export function formatDateUtc(iso: string): string {
+  const d = new Date(iso);
+  return `${d.getUTCDate()} ${UTC_MONTHS[d.getUTCMonth()]}`;
+}
+
+/** "Mar 4, 13:58" — UTC date + time (older-than-today thread bubbles). */
+export function formatDateTimeUtc(iso: string): string {
+  const d = new Date(iso);
+  return `${UTC_MONTHS[d.getUTCMonth()]} ${d.getUTCDate()}, ${formatTimeUtc(iso)}`;
+}
+
+/** True when both instants fall on the same UTC calendar day. */
+export function isSameUtcDay(a: string | Date, b: string | Date): boolean {
+  return (
+    new Date(a).toISOString().slice(0, 10) ===
+    new Date(b).toISOString().slice(0, 10)
+  );
 }


### PR DESCRIPTION
Closes out the four Codex P2 findings from the (closed) #112 review by verifying each against current `main` (post #113/#115) and shipping only the two that still exist in living code.

## Verification matrix

| # | Finding (on #112) | On current main | Action |
| --- | --- | --- | --- |
| a | ComposerView "Set a base price" option never updates composer state | The pricing Select was part of #112's discarded B5 composer work — no such control exists on main (`ComposerView` has the base-price input alone; empty = quote-on-request, no dead option) | none — not applicable |
| b | Compact snapshot labels drop qualifiers when measurements share a prefix | Main's snapshot chip row labels via `humanizeMeasureName` (full name, qualifiers kept: "Hip Width" / "Hip Girth"); the first-underscore truncation and the ambiguous `hip_width`/`hip_girth` seed pair were both #112-only | none — already unambiguous |
| c | Payout dates render SSR/client-inconsistently | **Live bug** — `TransactionRow` renders `formatAgo` bare; its ≥30d fallback read the HOST calendar (`toLocaleDateString`), so a payout near midnight UTC hydrates onto a different day | fixed here |
| d | Thread timestamps not timezone-stable | **Live bug** — `ThreadBubble` formatted local time (`date-fns format` + `isSameDay(now)`); `suppressHydrationWarning` masked the React error but the SSR/client divergence (and post-hydration flip) remained | fixed here |

## Fix

Timestamp text becomes a pure function of the instant: UTC-derived helpers in `lib/format` — `formatTimeUtc` ("13:58"), `formatDateUtc` ("22 May"), `formatDateTimeUtc` ("Mar 4, 13:58"), `isSameUtcDay` — render the UTC clock identically on the server and every client.

- `ThreadBubble` uses them for the per-bubble stamp; its `suppressHydrationWarning` is now narrowly scoped (comment updated) to the same-day check racing a UTC midnight between SSR and hydration.
- `TransactionRow` wraps its stamp in `<time dateTime>` (PostCard convention) and inherits the UTC-stable ≥30d fallback via `formatAgo`.

## Gates

- lint (prettier + eslint + boundaries) ✓ · typecheck ✓ · unit 490/490 ✓ · `NEXT_PUBLIC_TEST_MODE=1` build ✓ · Playwright e2e ✓
- New unit gates asserted TZ-independent: suite additionally verified under `TZ=Africa/Lagos` and `TZ=America/New_York` (the old implementations fail there; UTC-only CI could never catch this class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
