### PR TITLE
feat(web): self-host snippet goes tabbed — Docker Compose | Helm (Figma 415:2)

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -340,6 +340,24 @@ every data-driven screen ships default, empty, and loading states — the
 three-frame rule applies to the implementation exactly as it does to the
 Figma templates, and the QA loop checks all three.
 
+**Self-host tabbed snippet as-built (2026-07-20, PR #TBD).** The A7c
+compose one-liner is now the user-approved Docker Compose | Helm tab pair
+(Figma proposal 415:2), built as `CodeSnippetTabs` in the §8.2b marketing
+kit beside `CodeSnippetBlock` (whose copy-pill grammar — Copy → ✓ Copied
+morph — it reuses). Mirrored two-line commands: `git clone
+https://github.com/cuesoftinc/apparule` shared; `cd apparule && docker
+compose up --build -d` (the repo's `make up`) vs `cd apparule && helm
+install apparule deploy/helm` (the real chart path). Copy targets the
+ACTIVE tab's full block; the rendered `$ ` prompts are decorative
+(select-none) and stay out of the payload. Tab grammar per the frame:
+Micro/12 Semi Bold labels on the dark block, active = 2px `link`
+underline, inactive at 60%; tablist semantics with roving tabindex +
+Arrow/Home/End. Both tabs are two lines, so switching never shifts layout
+(apparule carries no extra caption — the "what ships" lines stay). Unit:
+`CodeSnippetTabs.test.tsx` (tab state, per-tab copy payload, roving
+focus, copied-morph reset); e2e: `home.spec.ts` pins helm-tab copy → the
+clipboard payload plus the 1440/390 container fit.
+
 ## 3. Token mapping — design.md §2 → `web/src/design/tokens.css`
 
 One custom property per Figma variable in the `apparule/tokens` collection

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -340,7 +340,7 @@ every data-driven screen ships default, empty, and loading states — the
 three-frame rule applies to the implementation exactly as it does to the
 Figma templates, and the QA loop checks all three.
 
-**Self-host tabbed snippet as-built (2026-07-20, PR #TBD).** The A7c
+**Self-host tabbed snippet as-built (2026-07-20, PR #118).** The A7c
 compose one-liner is now the user-approved Docker Compose | Helm tab pair
 (Figma proposal 415:2), built as `CodeSnippetTabs` in the §8.2b marketing
 kit beside `CodeSnippetBlock` (whose copy-pill grammar — Copy → ✓ Copied

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -57,11 +57,14 @@ test.describe("Marketing site — home page", () => {
     ).toBeVisible();
     expect(await page.getByTestId("dev-topic-card").count()).toBe(3);
 
-    // A7c self-host + A7 architecture diagram
+    // A7c self-host (tabbed, Figma 415:2) + A7 architecture diagram
     await expect(
       page.getByRole("heading", { name: "Self-host — own your data" }),
     ).toBeVisible();
-    await expect(page.getByText("docker compose up -d")).toBeVisible();
+    await expect(
+      page.getByText("cd apparule && docker compose up --build -d"),
+    ).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Helm" })).toBeVisible();
     await expect(page.getByTestId("architecture-diagram")).toBeVisible();
 
     // A9 comparison
@@ -189,13 +192,52 @@ test.describe("Marketing site — home page", () => {
     await expect(html).toHaveAttribute("data-theme", "light");
   });
 
-  test("snippet copy button morphs to the copied check", async ({ page }) => {
+  // A7c tabbed snippet (Figma 415:2): tab switch is instant with no layout
+  // shift, copy targets the ACTIVE tab's full two-line block, and the
+  // section fits the 1440/390 container canons.
+  test("self-host tabs — helm copy lands the full block on the clipboard", async ({
+    page,
+    context,
+  }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    await page.setViewportSize({ width: 1440, height: 900 });
     await page.goto("/");
-    await page
-      .getByRole("heading", { name: "Self-host — own your data" })
-      .scrollIntoViewIfNeeded();
-    await page.getByRole("button", { name: "Copy command" }).click();
-    await expect(page.getByTestId("copied-check")).toBeVisible();
+    const section = page.locator("#self-host");
+    await section.scrollIntoViewIfNeeded();
+    const block = page.getByTestId("selfhost-snippet");
+    const tablist = block.getByRole("tablist", { name: "Install method" });
+    await expect(tablist).toBeVisible();
+
+    const before = await block.boundingBox();
+    await tablist.getByRole("tab", { name: "Helm" }).click();
+    await expect(
+      block.getByText("cd apparule && helm install apparule deploy/helm"),
+    ).toBeVisible();
+    // no layout shift — the mirrored two-line block keeps its box
+    const after = await block.boundingBox();
+    expect(after!.height).toBe(before!.height);
+    expect(after!.width).toBe(before!.width);
+
+    await block.getByRole("button", { name: "Copy commands" }).click();
+    await expect(block.getByTestId("copied-check")).toBeVisible();
+    const clip = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clip).toBe(
+      "git clone https://github.com/cuesoftinc/apparule\ncd apparule && helm install apparule deploy/helm",
+    );
+
+    // 390 canon: the block stays inside the viewport, no document overflow
+    await page.setViewportSize({ width: 390, height: 844 });
+    await section.scrollIntoViewIfNeeded();
+    const mobile = await block.boundingBox();
+    expect(mobile!.width).toBeLessThanOrEqual(390);
+    const overflow = await page.evaluate(
+      () =>
+        Math.max(
+          document.documentElement.scrollWidth,
+          document.body.scrollWidth,
+        ) - document.documentElement.clientWidth,
+    );
+    expect(overflow).toBeLessThanOrEqual(0);
   });
 });
 

--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -27,6 +27,7 @@ import { CaughtUpDivider } from "@/components/ui/CaughtUpDivider";
 import { CountdownRing } from "@/components/ui/CountdownRing";
 import { Chip } from "@/components/ui/Chip";
 import { CodeSnippetBlock } from "@/components/ui/CodeSnippetBlock";
+import { CodeSnippetTabs } from "@/components/ui/CodeSnippetTabs";
 import { CommentRow } from "@/components/ui/CommentRow";
 import { CommunityCard } from "@/components/ui/CommunityCard";
 import { ComparisonTable } from "@/components/ui/ComparisonTable";
@@ -1129,6 +1130,20 @@ export function ComponentGallery() {
         <ComparisonTable />
         <div className="max-w-md">
           <CodeSnippetBlock />
+        </div>
+        <div className="max-w-md">
+          <CodeSnippetTabs
+            tabs={[
+              {
+                label: "Docker Compose",
+                code: "git clone https://github.com/cuesoftinc/apparule\ncd apparule && docker compose up --build -d",
+              },
+              {
+                label: "Helm",
+                code: "git clone https://github.com/cuesoftinc/apparule\ncd apparule && helm install apparule deploy/helm",
+              },
+            ]}
+          />
         </div>
         <CommunityCard />
       </Section>

--- a/web/src/components/home/SelfHostSection.tsx
+++ b/web/src/components/home/SelfHostSection.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-// A7c Self-host (canvas 186:160–186:170, 198:6492/6493, 264:8529) —
-// data-ownership pitch · the shared `docker compose up -d` snippet with
-// copy-✓ morph (A7 asset) · "what ships" line · architecture mini-diagram ·
-// docs quickstart link. `self_host_click` fires on the docs handoff.
-import { CodeSnippetBlock } from "@/components/ui/CodeSnippetBlock";
+// A7c Self-host (canvas 186:160–186:170, 198:6492/6493, 264:8529; tabbed
+// proposal 415:2) — data-ownership pitch · the Docker Compose | Helm
+// tabbed snippet with copy-✓ morph (mirrored two-line commands; compose =
+// `make up`, helm chart at deploy/helm) · "what ships" line · architecture
+// mini-diagram · docs quickstart link. `self_host_click` fires on the docs
+// handoff.
+import { CodeSnippetTabs } from "@/components/ui/CodeSnippetTabs";
 import { track } from "@/controllers/use-analytics";
 import { ArchitectureDiagram } from "./ArchitectureDiagram";
 
@@ -30,8 +32,20 @@ export function SelfHostSection() {
             S3-compatible storage. Your customers&apos; measurements never leave
             your box.
           </p>
-          <div className="mt-6 max-w-[420px]">
-            <CodeSnippetBlock code="docker compose up -d" />
+          <div className="mt-6 max-w-[460px]" data-testid="selfhost-snippet">
+            <CodeSnippetTabs
+              label="Install method"
+              tabs={[
+                {
+                  label: "Docker Compose",
+                  code: "git clone https://github.com/cuesoftinc/apparule\ncd apparule && docker compose up --build -d",
+                },
+                {
+                  label: "Helm",
+                  code: "git clone https://github.com/cuesoftinc/apparule\ncd apparule && helm install apparule deploy/helm",
+                },
+              ]}
+            />
           </div>
           <p className="mt-3 text-caption text-text-2">
             All services, your storage, no lock-in.

--- a/web/src/components/home/SelfHostSection.tsx
+++ b/web/src/components/home/SelfHostSection.tsx
@@ -18,7 +18,10 @@ export function SelfHostSection() {
       className="mx-auto w-full max-w-[1128px] scroll-mt-20 px-6 py-12"
     >
       <div className="flex flex-col items-start gap-10 md:flex-row md:gap-16">
-        <div className="max-w-[560px] flex-1">
+        {/* min-w-0: the snippet's nowrap command lines must not widen the
+            flex item past the viewport at 390 — they scroll inside the
+            block's own overflow-x rail instead (container canon) */}
+        <div className="w-full min-w-0 max-w-[560px] flex-1">
           <h2
             id="self-host-heading"
             className="text-title-lg font-bold text-text"

--- a/web/src/components/home/sections.test.tsx
+++ b/web/src/components/home/sections.test.tsx
@@ -91,10 +91,17 @@ describe("DesignersSection (A6)", () => {
 });
 
 describe("SelfHostSection (A7c)", () => {
-  it("renders pitch, one-liner, what-ships and the docs link", () => {
+  it("renders pitch, tabbed snippet, what-ships and the docs link", () => {
     render(<SelfHostSection />);
     expect(screen.getByText("Self-host — own your data")).toBeInTheDocument();
-    expect(screen.getByText(/docker compose up -d/)).toBeInTheDocument();
+    // tabbed snippet (Figma 415:2): Docker Compose active, Helm mirrored
+    expect(
+      screen.getByRole("tablist", { name: "Install method" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/cd apparule && docker compose up --build -d/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Helm" })).toBeInTheDocument();
     expect(screen.getByText("api-common")).toBeInTheDocument();
     expect(screen.getByText("api-measure")).toBeInTheDocument();
     expect(

--- a/web/src/components/ui/CodeSnippetTabs.test.tsx
+++ b/web/src/components/ui/CodeSnippetTabs.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CodeSnippetTabs } from "./CodeSnippetTabs";
+
+const TABS = [
+  {
+    label: "Docker Compose",
+    code: "git clone https://github.com/cuesoftinc/apparule\ncd apparule && docker compose up --build -d",
+  },
+  {
+    label: "Helm",
+    code: "git clone https://github.com/cuesoftinc/apparule\ncd apparule && helm install apparule deploy/helm",
+  },
+];
+
+function mockClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+  return writeText;
+}
+
+describe("CodeSnippetTabs (§8.2b marketing, pages.md A7c tabbed — Figma 415:2)", () => {
+  it("renders the tablist with Docker Compose active and mirrored two-line commands", () => {
+    render(<CodeSnippetTabs tabs={TABS} />);
+    expect(
+      screen.getByRole("tablist", { name: "Install method" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Docker Compose" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(
+      screen.getByText(/git clone https:\/\/github\.com\/cuesoftinc\/apparule/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/cd apparule && docker compose up --build -d/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/helm install apparule/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("switches tabs and copies the ACTIVE tab's full block (prompts stay out)", async () => {
+    const writeText = mockClipboard();
+    render(<CodeSnippetTabs tabs={TABS} />);
+    await userEvent.click(screen.getByRole("tab", { name: "Helm" }));
+    expect(
+      screen.getByText(/cd apparule && helm install apparule deploy\/helm/),
+    ).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Copy commands" }),
+    );
+    expect(writeText).toHaveBeenCalledWith(TABS[1].code);
+    expect(await screen.findByTestId("copied-check")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+  });
+
+  it("copies the docker block while Docker Compose is active", async () => {
+    const writeText = mockClipboard();
+    render(<CodeSnippetTabs tabs={TABS} />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Copy commands" }),
+    );
+    expect(writeText).toHaveBeenCalledWith(TABS[0].code);
+  });
+
+  it("roves focus with arrow keys (tablist semantics)", async () => {
+    render(<CodeSnippetTabs tabs={TABS} />);
+    const docker = screen.getByRole("tab", { name: "Docker Compose" });
+    const helm = screen.getByRole("tab", { name: "Helm" });
+    expect(docker).toHaveAttribute("tabindex", "0");
+    expect(helm).toHaveAttribute("tabindex", "-1");
+    docker.focus();
+    await userEvent.keyboard("{ArrowRight}");
+    expect(helm).toHaveFocus();
+    expect(helm).toHaveAttribute("aria-selected", "true");
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(docker).toHaveFocus();
+    expect(docker).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("resets the copied morph when the tab switches", async () => {
+    mockClipboard();
+    render(<CodeSnippetTabs tabs={TABS} />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Copy commands" }),
+    );
+    expect(screen.getByTestId("copied-check")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("tab", { name: "Helm" }));
+    expect(screen.queryByTestId("copied-check")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Copy commands" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/ui/CodeSnippetTabs.test.tsx
+++ b/web/src/components/ui/CodeSnippetTabs.test.tsx
@@ -39,9 +39,7 @@ describe("CodeSnippetTabs (§8.2b marketing, pages.md A7c tabbed — Figma 415:2
     expect(
       screen.getByText(/cd apparule && docker compose up --build -d/),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByText(/helm install apparule/),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/helm install apparule/)).not.toBeInTheDocument();
   });
 
   it("switches tabs and copies the ACTIVE tab's full block (prompts stay out)", async () => {

--- a/web/src/components/ui/CodeSnippetTabs.tsx
+++ b/web/src/components/ui/CodeSnippetTabs.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+// CodeSnippetTabs — design.md §8.2b Home section kit: the A7c self-host
+// snippet as a mirrored Docker Compose | Helm pair (Figma proposal 415:2).
+// Tab grammar per the frame: Micro/12 Semi Bold labels on the dark block,
+// active tab = 2px link underline; the copy pill keeps the CodeSnippetBlock
+// grammar (Copy → ✓ Copied morph) and always copies the ACTIVE tab's full
+// two-line block — the rendered `$ ` prompts are decorative (select-none)
+// and stay out of the payload. Tablist semantics: roving tabindex +
+// Arrow/Home/End focus.
+import { useRef, useState } from "react";
+import clsx from "clsx";
+import { Check, Copy } from "lucide-react";
+
+export interface CodeSnippetTab {
+  label: string;
+  /** Newline-separated shell commands (rendered one per line). */
+  code: string;
+}
+
+export interface CodeSnippetTabsProps {
+  tabs: CodeSnippetTab[];
+  /** Accessible name for the tablist. */
+  label?: string;
+  className?: string;
+}
+
+export function CodeSnippetTabs({
+  tabs,
+  label = "Install method",
+  className,
+}: CodeSnippetTabsProps) {
+  const [active, setActive] = useState(0);
+  const [copied, setCopied] = useState(false);
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(tabs[active].code);
+    } catch {
+      // clipboard unavailable — morph anyway so the action never feels dead
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  function select(i: number) {
+    setActive(i);
+    setCopied(false);
+  }
+
+  function onTabKeyDown(event: React.KeyboardEvent, index: number) {
+    const last = tabs.length - 1;
+    let next: number | null = null;
+    if (event.key === "ArrowRight") next = index === last ? 0 : index + 1;
+    else if (event.key === "ArrowLeft") next = index === 0 ? last : index - 1;
+    else if (event.key === "Home") next = 0;
+    else if (event.key === "End") next = last;
+    if (next === null) return;
+    event.preventDefault();
+    select(next);
+    tabRefs.current[next]?.focus();
+  }
+
+  return (
+    <div
+      className={clsx(
+        "rounded-card border border-border bg-text/95",
+        className,
+      )}
+    >
+      <div className="flex items-start gap-4 pl-5 pr-3 pt-3">
+        <div role="tablist" aria-label={label} className="flex flex-1 gap-4">
+          {tabs.map((tab, i) => {
+            const isActive = i === active;
+            return (
+              <button
+                key={tab.label}
+                ref={(el) => {
+                  tabRefs.current[i] = el;
+                }}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                tabIndex={isActive ? 0 : -1}
+                onClick={() => select(i)}
+                onKeyDown={(event) => onTabKeyDown(event, i)}
+                className={clsx(
+                  "flex flex-col gap-[5px] text-micro font-semibold",
+                  "transition-colors duration-120 ease-standard motion-reduce:transition-none",
+                  isActive ? "text-bg" : "text-bg/60 hover:text-bg",
+                )}
+              >
+                {tab.label}
+                <span
+                  aria-hidden="true"
+                  className={clsx(
+                    "h-0.5 w-full",
+                    isActive ? "bg-link" : "bg-transparent",
+                  )}
+                />
+              </button>
+            );
+          })}
+        </div>
+        {/* Figma master (Stage 5): labeled Copy pill; ✓ Copied turns success */}
+        <button
+          type="button"
+          aria-label={copied ? "Copied" : "Copy commands"}
+          onClick={copy}
+          className={clsx(
+            "flex h-7 shrink-0 items-center gap-1.5 rounded-pill border px-3 text-micro font-semibold",
+            "transition-colors duration-120 ease-standard motion-reduce:transition-none",
+            copied
+              ? "border-success text-success"
+              : "border-bg/30 text-bg hover:bg-bg/10",
+          )}
+        >
+          {copied ? (
+            <Check
+              size={14}
+              data-testid="copied-check"
+              className="text-success"
+            />
+          ) : (
+            <Copy size={14} />
+          )}
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      <div className="flex flex-col gap-1 overflow-x-auto px-5 pb-3.5 pt-3 font-mono text-body text-bg">
+        {tabs[active].code.split("\n").map((line) => (
+          <code key={line} className="whitespace-nowrap">
+            <span className="select-none text-bg/50">$ </span>
+            {line}
+          </code>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- A7c self-host snippet is now the user-approved tabbed block (Figma proposal 415:2): **Docker Compose | Helm**, mirrored two-line commands — `git clone https://github.com/cuesoftinc/apparule` shared; `cd apparule && docker compose up --build -d` (the repo's `make up`) vs `cd apparule && helm install apparule deploy/helm` (the real chart at `deploy/helm`).
- New `CodeSnippetTabs` in the §8.2b marketing kit beside `CodeSnippetBlock`, whose copy-pill grammar (Copy → ✓ Copied morph) it reuses. Tab grammar per the frame: Micro/12 Semi Bold labels on the dark block, active = 2px `link` underline, inactive at 60%.
- Copy targets the ACTIVE tab's full block — rendered `$ ` prompts are decorative (select-none) and stay out of the payload. Tablist semantics: roving tabindex + Arrow/Home/End. Both tabs are two lines, so switching never shifts layout (apparule carries no extra caption — user decision; the what-ships lines stay).
- `min-w-0` on the section's flex column so the nowrap commands scroll inside the block's own rail at 390 (container canon).
- Dev gallery cell + web-implementation.md as-built note.

## Tests
- Unit (`CodeSnippetTabs.test.tsx` + updated `sections.test.tsx`): tab state, per-tab copy payload, roving focus, copied-morph reset.
- e2e (`home.spec.ts`): switch to Helm → copy → clipboard equals the full two-line helm block; block box stable across the switch; in-viewport at 1440/390.

## Gates
prettier ✓ eslint ✓ boundaries ✓ typecheck ✓ vitest ✓ next build ✓ playwright (full suite) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)