### PR TITLE
fix(web): landing type matches the Figma Home frame — Inter via next/font + ramp tracking

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -42,10 +42,16 @@
 
 ### Type
 
-- Family: system stack (`-apple-system, Roboto, …`) on app surfaces; a display
-  serif/geometric (brand pass) only on the public home page hero. **[Proposed]**
+- Family: **Inter** on app and marketing surfaces — the family the Figma
+  library's type styles render, so live type weight/width match the canvas on
+  every platform (web self-hosts it via `next/font` with the system stack as
+  fallback). A display serif/geometric for the public home hero remains a
+  brand-pass option. **[Decided 2026-07-20 — font-weight audit vs the Home
+  frame; sibling products already ship Inter]**
 - Scale: 12 / 13 / 14 (base) / 16 / 20 / 24 / 32. Weights 400/600/700.
-  Usernames 600; numerals tabular for measurements and money.
+  Tracking: Title/24 −0.25px, Display/32 −0.5px, all smaller sizes 0 (the
+  type styles pin these). Usernames 600; numerals tabular for measurements
+  and money.
 
 ### Layout
 

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -380,6 +380,20 @@ on gradient/destructive fills (exception: on-media capture UI, by design).
 Tabular numerals (`font-variant-numeric: tabular-nums`) apply wherever the
 design.md §7 `tnum` note applies — measurement values and money.
 
+**Type as-built (2026-07-20, font-weight audit vs the Figma Home frame).**
+Inter loads via `next/font` in `layout.tsx` (variable font — the ramp's
+400/600/700 are real faces, no synthetic bolding) and reaches components as
+`--ap-font-sans` = `var(--font-inter)` + the system stack as fallback; the
+computed family therefore matches the Figma type styles on every platform.
+The Tailwind ramp utilities pin the styles' tracking — `text-title-lg`
+−0.25px, `text-display` −0.5px, all smaller sizes 0 — so components never
+hand-set `tracking-*` for ramp roles. Font smoothing stays `antialiased` on
+`<html>` (expendit sets the same pair in CSS; grayscale AA is also how the
+canvas rasterizes, keeping weights visually comparable). The home e2e
+journey carries the regression lock: per-role computed
+family/weight/size/line-height/letter-spacing plus a `document.fonts.check`
+that the three ramp weights loaded as real Inter faces.
+
 ## 4. Route map — pages.md Part A/B → app routes
 
 pages.md writes Part B routes with an `/app` shorthand prefix "relative to"

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -577,3 +577,114 @@ test.describe("cursor affordance", () => {
     expect(linkCursor).toBe("pointer");
   });
 });
+
+// Type contract — the landing's key roles render the Figma Home frame's
+// (186:2) computed type: Inter (next/font, variable — real 400/600/700, no
+// synthetic bolding) at the ramp's size/line-height, with the type styles'
+// tracking pinned by the utilities (Title/24 −0.25px · Display/32 −0.5px).
+// Regression lock for the font-weight audit (2026-07-20).
+test.describe("type contract — Figma Home frame roles", () => {
+  test("per-role computed font-family/weight/size/tracking match the ramp", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const rail = page.getByTestId("walkthrough-rail");
+    const roles = [
+      {
+        role: "hero H1 (Display/32 Bold)",
+        locator: page.getByRole("heading", {
+          name: "Two photos. A perfect fit.",
+        }),
+        weight: "700",
+        size: "32px",
+        lineHeight: "40px",
+        letterSpacing: "-0.5px",
+      },
+      {
+        role: "stat-band heading (Title/24 Bold)",
+        locator: page.getByRole("heading", {
+          name: "Made-to-measure, without the guesswork",
+        }),
+        weight: "700",
+        size: "24px",
+        lineHeight: "30px",
+        letterSpacing: "-0.25px",
+      },
+      {
+        role: "walkthrough heading (Title/24 Bold)",
+        locator: page.getByRole("heading", { name: "How it works" }),
+        weight: "700",
+        size: "24px",
+        lineHeight: "30px",
+        letterSpacing: "-0.25px",
+      },
+      {
+        role: "stat value (Display/32 Bold)",
+        locator: page.getByText("±2 cm", { exact: true }),
+        weight: "700",
+        size: "32px",
+        lineHeight: "40px",
+        letterSpacing: "-0.5px",
+      },
+      {
+        role: "stat caption (Body/14 Regular)",
+        locator: page.getByText(
+          "target accuracy vs a professional tape measure",
+        ),
+        weight: "400",
+        size: "14px",
+        lineHeight: "20px",
+        letterSpacing: "normal",
+      },
+      {
+        role: "step title (Body/16 Semi Bold)",
+        locator: rail.getByText("Capture", { exact: true }),
+        weight: "600",
+        size: "16px",
+        lineHeight: "22px",
+        letterSpacing: "normal",
+      },
+      {
+        role: "step caption (Body/14 Regular)",
+        locator: rail.getByText(
+          "Two photos — your measurements, automatically",
+        ),
+        weight: "400",
+        size: "14px",
+        lineHeight: "20px",
+        letterSpacing: "normal",
+      },
+    ] as const;
+
+    for (const r of roles) {
+      const cs = await r.locator.evaluate((el) => {
+        const s = getComputedStyle(el);
+        return {
+          fontFamily: s.fontFamily,
+          fontWeight: s.fontWeight,
+          fontSize: s.fontSize,
+          lineHeight: s.lineHeight,
+          letterSpacing: s.letterSpacing,
+        };
+      });
+      expect.soft(cs.fontFamily, `${r.role} family`).toMatch(/^Inter\b/);
+      expect.soft(cs.fontWeight, `${r.role} weight`).toBe(r.weight);
+      expect.soft(cs.fontSize, `${r.role} size`).toBe(r.size);
+      expect.soft(cs.lineHeight, `${r.role} line-height`).toBe(r.lineHeight);
+      expect
+        .soft(cs.letterSpacing, `${r.role} letter-spacing`)
+        .toBe(r.letterSpacing);
+    }
+
+    // The ramp's three weights are real Inter faces (variable font loaded)
+    // — a missing weight would silently fall back to synthetic bolding.
+    const weightsReal = await page.evaluate(async () => {
+      await document.fonts.ready;
+      return ["400 14px Inter", "600 16px Inter", "700 24px Inter"].map((f) =>
+        document.fonts.check(f),
+      );
+    });
+    expect(weightsReal).toEqual([true, true, true]);
+  });
+});

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -32,7 +32,10 @@
   --ease-exit: var(--ap-ease-exit);
 
   /* Type scale 12/13/14(base)/16/20/24/32 — names mirror the Figma styles:
-     Micro/12 · Caption/13 · Body/14 · Body/16 · Title/20 · Title/24 · Display/32 */
+     Micro/12 · Caption/13 · Body/14 · Body/16 · Title/20 · Title/24 · Display/32.
+     The two largest sizes carry the styles' negative tracking (Title/24
+     −0.25px · Display/32 −0.5px) so the utilities pin it — every other
+     ramp entry is 0 (Figma type styles, design.md §2). */
   --text-micro: 12px;
   --text-micro--line-height: 16px;
   --text-caption: 13px;
@@ -45,10 +48,12 @@
   --text-title--line-height: 26px;
   --text-title-lg: 24px;
   --text-title-lg--line-height: 30px;
+  --text-title-lg--letter-spacing: -0.25px;
   --text-display: 32px;
   --text-display--line-height: 40px;
+  --text-display--letter-spacing: -0.5px;
 
-  /* Fonts — system stack on app surfaces (design.md §2 Type) */
+  /* Fonts — Inter with system-stack fallback (design.md §2 Type) */
   --font-sans: var(--ap-font-sans);
 }
 

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,7 +1,15 @@
 import type { Metadata } from "next";
+import { Inter } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider, themeInitScript } from "@/design/ThemeProvider";
 import { AuthProvider } from "@/controllers/auth/AuthContext";
+
+// Design-system type (design.md §2): Inter — the family the Figma library
+// renders — self-hosted via next/font (variable font, so the ramp's
+// 400/600/700 are all real weights, no synthetic bolding). Exposed as a CSS
+// variable consumed by the token layer (--ap-font-sans), which keeps the
+// system stack as fallback.
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
 
 export const metadata: Metadata = {
   title: "Apparule",
@@ -17,7 +25,11 @@ export default function RootLayout({
   return (
     // suppressHydrationWarning: the pre-paint script may set data-theme
     // before React hydrates the <html> element.
-    <html lang="en" className="h-full antialiased" suppressHydrationWarning>
+    <html
+      lang="en"
+      className={`${inter.variable} h-full antialiased`}
+      suppressHydrationWarning
+    >
       <head>
         {/* Apply the persisted manual theme override before first paint. */}
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />

--- a/web/src/components/home/FinalCtaBand.tsx
+++ b/web/src/components/home/FinalCtaBand.tsx
@@ -23,7 +23,7 @@ export function FinalCtaBand() {
       <div className="mx-auto flex max-w-[1080px] flex-col items-center gap-5 text-center">
         <h2
           id="final-cta-heading"
-          className="text-display font-bold tracking-[-0.5px] text-on-accent"
+          className="text-display font-bold text-on-accent"
         >
           Get measured once. Dress like it was always made for you.
         </h2>

--- a/web/src/components/home/HeroSection.tsx
+++ b/web/src/components/home/HeroSection.tsx
@@ -19,10 +19,7 @@ export function HeroSection() {
     >
       <div className="flex flex-col items-start gap-12 pb-16 pt-10 md:flex-row md:items-center md:gap-16 md:pb-20 md:pt-16">
         <div className="max-w-[520px]">
-          <h1
-            id="hero-heading"
-            className="text-display font-bold text-text"
-          >
+          <h1 id="hero-heading" className="text-display font-bold text-text">
             Two photos. A perfect fit.
           </h1>
           <p className="mt-6 max-w-[480px] text-body-lg text-text-2">

--- a/web/src/components/home/HeroSection.tsx
+++ b/web/src/components/home/HeroSection.tsx
@@ -21,7 +21,7 @@ export function HeroSection() {
         <div className="max-w-[520px]">
           <h1
             id="hero-heading"
-            className="text-display font-bold tracking-[-0.5px] text-text"
+            className="text-display font-bold text-text"
           >
             Two photos. A perfect fit.
           </h1>

--- a/web/src/design/tokens.css
+++ b/web/src/design/tokens.css
@@ -70,10 +70,13 @@
   --ap-z-sheet: 40;
   --ap-z-toast: 50;
 
-  /* ---- Type: system stack on app surfaces (design.md §2 Type) ---- */
+  /* ---- Type: Inter with system-stack fallback (design.md §2 Type).
+     --font-inter is the next/font variable set on <html> (layout.tsx) —
+     the same family every Figma frame renders, so type weight/width match
+     the canvas on every platform instead of drifting per-OS. ---- */
   --ap-font-sans:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
-    sans-serif;
+    var(--font-inter), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Helvetica, Arial, sans-serif;
 
   color-scheme: light;
 }


### PR DESCRIPTION
## Why

User report: the live landing's type reads **heavier/looser** than the Figma Home frame (186:2). Root-caused with computed values (not visual impressions — the screenshots were at different zooms).

## Root cause

| Role | Figma (Home 186:2) | Web before | Web after |
| --- | --- | --- | --- |
| Hero H1 (`Display/32 Bold`) | Inter 700 · 32/40 · −0.5px | **SF Pro (system)** 700 · 32/40 · −0.5px (inline) | Inter 700 · 32/40 · −0.5px (utility) |
| Section headings ×2 (`Title/24 Bold`) | Inter 700 · 24/30 · −0.25px | SF Pro 700 · 24/30 · **normal** | Inter 700 · 24/30 · −0.25px |
| Stat values (`Display/32 Bold`) | Inter 700 · 32/40 · −0.5px | SF Pro 700 · 32/40 · **normal** | Inter 700 · 32/40 · −0.5px |
| Stat captions (`Body/14 Regular`) | Inter 400 · 14/20 · 0 | SF Pro 400 · 14/20 | Inter 400 · 14/20 |
| Step titles (`Body/16 Semi Bold`) | Inter 600 · 16/22 · 0 | SF Pro 600 · 16/22 | Inter 600 · 16/22 |
| Step captions (`Body/14 Regular`) | Inter 400 · 14/20 · 0 | SF Pro 400 · 14/20 | Inter 400 · 14/20 |

Weights/sizes/line-heights already matched — the "different font weight" was **the family**: the page resolved to the OS system font (SF Pro on macOS — visually heavier at 700, wider small-size rhythm) while every Figma frame renders **Inter**; plus the ramp utilities carried **no letter-spacing** while the Figma type styles pin Title/24 −0.25px and Display/32 −0.5px (only the hero/final-CTA had it, hand-set inline). Not a synthetic-bolding issue (`font-synthesis` never triggered — the stack had real 600/700).

## Fix

- **Inter via `next/font`** (variable font — real 400/600/700), exposed as `--font-inter` → `--ap-font-sans` keeps the system stack as fallback. This is the sibling-repo pattern (expendit/upstat already ship Inter) and makes rendering platform-deterministic.
- **Tracking moves into the ramp utilities** (`--text-title-lg--letter-spacing: -0.25px`, `--text-display--letter-spacing: -0.5px`); the ad-hoc inline `tracking-[-0.5px]` on Hero/FinalCta is dropped.
- **Font smoothing unchanged**: `antialiased` stays on `<html>` — expendit sets the same pair in CSS, and grayscale AA matches how Figma rasterizes (part of why SF+subpixel read "heavier").
- **design.md §2 Type**: the family row still carried the un-ratified `[Proposed]` system-stack wording predating the Figma library — flipped to the as-built **Inter** canon (the entire reviewed canvas renders Inter; both siblings' design.md already say Inter) and the ramp row now names the styles' tracking. Flagging explicitly: this is the one contract-row change in the PR — veto here if system-stack-on-purpose was intended, and the Figma library (11 local styles + every frame) becomes the side to rebuild instead.
- **e2e regression lock** (`home.spec.ts` "type contract"): per-role computed family/weight/size/line-height/letter-spacing + `document.fonts.check` that all three ramp weights loaded as real Inter faces.

## Verification

- Playwright `getComputedStyle` per role: before/after JSON + matched-scale (1080 col) before/Figma/after section renders — AFTER matches Figma letterforms and even caption wrap points.
- Gates: prettier/eslint/boundaries ✓ · typecheck ✓ · vitest 490 ✓ · e2e 52 ✓ · `next build` ✓ (next/font asset inlined at build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)