### PR TITLE
fix(web): cross-check pass — date-popover anatomy per master, band balance per frames; C2 verified clean

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -311,7 +311,7 @@ Stage 5 and non-blocking; everything else feeds Stages 1–4.
 | --- | --- |
 | GoogleAuthButton | the single auth CTA (X-1): Google 'G' mark + "Continue with Google" · state: default / pressed / loading / disabled · theme ×2 |
 | Select / OptionRow | trigger: default / focus / error / disabled · OptionRow: default / selected (radio · check) · contexts: decline-reason enum, dispute reason picker, NG-state, bank (KYC), language · theme ×2 |
-| DateInput | state: default / focus / error / disabled · calendar popover · min-date rules (due_at ≥ today+1; target date ≥ today+turnaround soft-warn) · theme ×2 · **as built (2026-07-17):** the calendar popover is a standalone `DatePickerPopover` component |
+| DateInput | state: default / focus / error / disabled · calendar popover · min-date rules (due_at ≥ today+1; target date ≥ today+turnaround soft-warn) · theme ×2 · **as built (2026-07-17):** the calendar popover is a standalone `DatePickerPopover` component — per the 87:1035 master: Sunday-first week, blank outside-month cells, border-ring on today (2026-07-20) |
 | Input (extends §8.2) | + kind: textarea (multiline, 0–500 counter) / currency (₦ prefix, tabular numerals) · state: default / focus / error / disabled · theme ×2 |
 | MediaDropzone | state: empty (drop target) / uploading (progress) / error (size · type) · MediaUploadTile: thumb ×≤10 · drag-reorder handle · alt-text indicator · remove · theme ×2 |
 | Banner / InlineAlert | tone: info / warn / error / success · persistent / dismissable · action-link slot (Retry, support, explainer) · theme ×2 |

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -340,6 +340,35 @@ every data-driven screen ships default, empty, and loading states — the
 three-frame rule applies to the implementation exactly as it does to the
 Figma templates, and the QA loop checks all three.
 
+**Floating-layer + band cross-check as-built notes (2026-07-20):** the
+three-class cross-check (date-popover anatomy/overflow · modal-embedded
+select clipping · two-column band balance) verified every instance
+against its Figma master and fixed the hits:
+
+- `DatePickerPopover` now carries the master anatomy (87:1035): 16px
+  panel padding (was 12), 8px row gaps (was 2), Sunday-first
+  `S M T W T F S` header (was Monday-first) at 12 semibold, 36×32 pill
+  day cells at 13px (was 32×32 at 14), blank outside-month cells (was
+  grayed adjacent-month days), a 1px border-token ring on today, and
+  disabled days at `text-2/50` — today stays `text-2` at full opacity
+  when the min-date rule disables it. Bottom-edge behavior verified at
+  1440×900 and 1440×700: Radix flips the panel above the trigger when
+  the space below runs out, never past the viewport and never adding
+  document scroll height (locked in `dashboard.spec.ts`, serial fixture
+  on `post-chromat-look`).
+- Selects inside sheets (decline/dispute/report/stepper-address) came
+  back clean — the W3 portal-at-z-40 + `max-h-72` pattern holds at both
+  heights; now locked (`dashboard.spec.ts` decline,
+  `floating-layers.spec.ts` report).
+- B1 feed band matches the 176:72 frame exactly: 630px feed column +
+  48px gutter + 320px meta rail (`max-w-[1030px]`/`gap-12`; the old
+  `max-w-5xl`/`gap-16` squeezed the feed to 608 and stretched the gutter
+  to 64).
+- The order-detail thread panel fills the band beside the order content
+  on `lg` (capped at 70vh) with the composer pinned to its bottom edge,
+  per 179:536 — a short thread used to hug and leave ~576px of dead band
+  under the card. Both bands locked in `band-balance.spec.ts` (±2px).
+
 **Self-host tabbed snippet as-built (2026-07-20, PR #118).** The A7c
 compose one-liner is now the user-approved Docker Compose | Helm tab pair
 (Figma proposal 415:2), built as `CodeSnippetTabs` in the §8.2b marketing

--- a/web/e2e/band-balance.spec.ts
+++ b/web/e2e/band-balance.spec.ts
@@ -1,0 +1,74 @@
+// C3 — dashboard two-column band balance (cross-check pass, 2026-07-20):
+// the B1 feed band renders the frame's exact column geometry (176:72 —
+// 630px feed · 48px gutter · 320px meta rail), and the order-detail band
+// (179:536) keeps the thread panel spanning the band beside the order
+// content instead of hugging a short thread and leaving the band
+// bottom-heavy. Runs in TEST_MODE against the mock server; read-only.
+import { expect, test, type Page } from "@playwright/test";
+
+async function signIn(page: Page) {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: /continue with google/i }).click();
+  await page.waitForURL("**/dashboard");
+}
+
+test.use({ viewport: { width: 1440, height: 900 } });
+
+test("B1 feed band matches the 176:72 frame: 630px feed · 48px gutter · 320px rail", async ({
+  page,
+}) => {
+  await signIn(page);
+  await page.waitForSelector('[data-testid="feed-list"]');
+  const feed = await page.getByTestId("feed-list").boundingBox();
+  const rail = await page
+    .getByLabel("Your measurements and suggestions")
+    .boundingBox();
+  expect(feed).not.toBeNull();
+  expect(rail).not.toBeNull();
+
+  expect(
+    Math.abs(feed!.width - 630),
+    "feed column is 630px",
+  ).toBeLessThanOrEqual(2);
+  expect(Math.abs(rail!.width - 320), "meta rail is 320px").toBeLessThanOrEqual(
+    2,
+  );
+  const gutter = rail!.x - (feed!.x + feed!.width);
+  expect(Math.abs(gutter - 48), "gutter is 48px").toBeLessThanOrEqual(2);
+});
+
+test("order-detail band: the thread panel fills the band beside the order content (no hugged short card)", async ({
+  page,
+}) => {
+  await signIn(page);
+  // #APR-1058 — seeded delivered order with a short two-message thread:
+  // exactly the case that used to hug and leave ~576px of dead band.
+  await page.goto("/dashboard/orders/req-apr-1058");
+  await page.waitForSelector('[data-testid="order-thread"]');
+  const left = await page.locator("main .grid > div").first().boundingBox();
+  const card = await page.getByTestId("order-thread-panel").boundingBox();
+  expect(left).not.toBeNull();
+  expect(card).not.toBeNull();
+
+  // Tops align across the band.
+  expect(Math.abs(card!.y - left!.y), "columns top-align").toBeLessThanOrEqual(
+    2,
+  );
+  // The card stretches to the band height, capped at 70vh (frame 179:536
+  // shows the panel spanning ~60% of the 1024 frame with the composer
+  // pinned to its bottom edge).
+  const expected = Math.min(left!.height, 0.7 * 900);
+  expect(
+    Math.abs(card!.height - expected),
+    "thread panel fills the band up to the 70vh cap",
+  ).toBeLessThanOrEqual(2);
+
+  // The composer pins to the panel's bottom edge (frame: input row on the
+  // panel's bottom padding), not directly under the last bubble.
+  const composer = await page.getByLabel(/^Message /).boundingBox();
+  expect(composer).not.toBeNull();
+  expect(
+    card!.y + card!.height - (composer!.y + composer!.height),
+    "composer hugs the panel bottom",
+  ).toBeLessThanOrEqual(32);
+});

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -535,3 +535,195 @@ test("designer quote via the UI: the due-date calendar works inside the quote sh
 
 // The 390 overflow sweep moved to e2e/mobile-responsive.spec.ts (P1
 // mobile pass): every route, 390 + 768, plus wide-element containment.
+
+// ---------------------------------------------------------------------------
+// Cross-check pass (2026-07-20) — C1 date-picker geometry + C2 in-sheet
+// select clipping, on a shared fixture order. Lives in this serial file
+// because it mutates the store (kiki's request on post-chromat-look — its
+// only seeded order is closed/cancelled and no journey above touches it),
+// then drives maisonbisi's quote/decline sheets through the actor seam.
+// ---------------------------------------------------------------------------
+
+test.describe("order-sheet floating layers (shared fixture)", () => {
+  let orderId: string;
+
+  test.beforeAll(async ({ request }) => {
+    const res = await request.post(
+      "/api/mock/v1/posts/post-chromat-look/requests",
+      {
+        headers: {
+          "x-mock-actor": "kiki.adeyemi",
+          "idempotency-key": "e2e-order-sheet-geometry-fixture",
+        },
+        data: {
+          session_id: "sess-recent-scan",
+          notes: "Calendar/select geometry fixture",
+          delivery: {
+            recipient_name: "Kiki Adeyemi",
+            phone: "+2348012345678",
+            line1: "14 Adeola Odeku St",
+            city: "Lagos",
+            state: "Lagos",
+            country: "NG",
+          },
+        },
+      },
+    );
+    expect(res.status()).toBe(201);
+    orderId = (await res.json()).id;
+  });
+
+  async function openOrderAsDesigner(page: Page) {
+    await page.addInitScript(() => {
+      window.sessionStorage.setItem("apparule.testmode.actor", "maisonbisi");
+    });
+    await signIn(page);
+    await page.goto(`/dashboard/orders/${orderId}`);
+  }
+
+  async function openDueDatePicker(page: Page) {
+    await openOrderAsDesigner(page);
+    await page.getByRole("button", { name: "Send quote" }).click();
+    await page.getByLabel("Due date").click();
+    const picker = page.getByTestId("date-picker");
+    await expect(picker).toBeVisible();
+    // The panel is the popover content wrapping the grid.
+    return { panel: picker.locator("xpath=.."), picker };
+  }
+
+  async function expectMenuUnclipped(page: Page, height: number) {
+    const menu = page.getByRole("listbox");
+    await expect(menu).toBeVisible();
+    const box = await menu.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.y, "menu top inside viewport").toBeGreaterThanOrEqual(0);
+    expect(
+      box!.y + box!.height,
+      "menu bottom inside viewport",
+    ).toBeLessThanOrEqual(height);
+    // 288px cap (max-h-72) + hairline borders.
+    expect(box!.height).toBeLessThanOrEqual(290);
+    // No clipping: the point just inside the menu's bottom edge hit-tests
+    // to the menu itself, not an overlaying sheet or scrollbox.
+    const hit = await page.evaluate(() => {
+      const lb = document.querySelector('[role="listbox"]')!;
+      const r = lb.getBoundingClientRect();
+      const el = document.elementFromPoint(r.x + r.width / 2, r.bottom - 5);
+      return lb.contains(el);
+    });
+    expect(hit, "menu bottom edge is hit-testable").toBe(true);
+  }
+
+  test("date-picker panel matches the 87:1035 master anatomy", async ({
+    page,
+  }) => {
+    const { panel, picker } = await openDueDatePicker(page);
+
+    const anatomy = await panel.evaluate((el) => {
+      const grid = el.querySelector(".grid-cols-7")!;
+      const dayButtons = [...grid.querySelectorAll("button")];
+      const sample = dayButtons[Math.floor(dayButtons.length / 2)];
+      const scs = getComputedStyle(sample);
+      const weekLabels = [...grid.children]
+        .slice(0, 7)
+        .map((c) => c.textContent);
+      const weekCs = getComputedStyle(grid.children[0]);
+      return {
+        padding: getComputedStyle(el).padding,
+        rowGap: getComputedStyle(grid).rowGap,
+        weekLabels,
+        weekWeight: weekCs.fontWeight,
+        day: {
+          w: (sample as HTMLElement).offsetWidth,
+          h: (sample as HTMLElement).offsetHeight,
+          fontSize: scs.fontSize,
+        },
+        dayCount: dayButtons.length,
+      };
+    });
+    // Master: 16px panel padding — the grid never sits flush to the edges.
+    expect(anatomy.padding).toBe("16px");
+    // Master: rows separated by 8px.
+    expect(anatomy.rowGap).toBe("8px");
+    // Master: Sunday-first S M T W T F S, 12 semibold.
+    expect(anatomy.weekLabels).toEqual(["S", "M", "T", "W", "T", "F", "S"]);
+    expect(Number(anatomy.weekWeight)).toBeGreaterThanOrEqual(600);
+    // Master: 36×32 pill day cells, 13px numerals.
+    expect(anatomy.day.w).toBe(36);
+    expect(anatomy.day.h).toBe(32);
+    expect(anatomy.day.fontSize).toBe("13px");
+    // Master: outside-month cells are blank — exactly the displayed
+    // month's days render as buttons.
+    const title = await panel
+      .getByText(/^[A-Z][a-z]+ \d{4}$/)
+      .first()
+      .textContent();
+    const shown = new Date(`1 ${title}`);
+    const daysInMonth = new Date(
+      shown.getFullYear(),
+      shown.getMonth() + 1,
+      0,
+    ).getDate();
+    expect(anatomy.dayCount).toBe(daysInMonth);
+
+    // Today ring (master: 1px border-token ring) — only when today's month
+    // is on screen.
+    const now = new Date();
+    if (
+      now.getFullYear() === shown.getFullYear() &&
+      now.getMonth() === shown.getMonth()
+    ) {
+      const todayBtn = picker.getByRole("button", {
+        name: String(now.getDate()),
+        exact: true,
+      });
+      const borderWidth = await todayBtn.evaluate(
+        (el) => getComputedStyle(el).borderWidth,
+      );
+      expect(borderWidth).toBe("1px");
+    }
+  });
+
+  for (const height of [900, 700]) {
+    test(`date-picker stays inside the 1440×${height} viewport (flip/clamp, no page scrollbar growth)`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: 1440, height });
+      const scrollHeight = () =>
+        page.evaluate(() => document.documentElement.scrollHeight);
+      const { panel } = await openDueDatePicker(page);
+      const before = await scrollHeight();
+
+      const box = await panel.boundingBox();
+      expect(box, "open calendar has a bounding box").not.toBeNull();
+      expect(box!.y, "top edge inside viewport").toBeGreaterThanOrEqual(0);
+      expect(
+        box!.y + box!.height,
+        "bottom edge inside viewport",
+      ).toBeLessThanOrEqual(height);
+
+      const trigger = await page.getByLabel("Due date").boundingBox();
+      if (trigger!.y + trigger!.height + box!.height + 8 > height) {
+        // Not enough room below the trigger: the panel must flip above it.
+        expect(
+          box!.y + box!.height,
+          "panel flips above the trigger",
+        ).toBeLessThanOrEqual(trigger!.y);
+      }
+      // The open popover never gives the document extra scroll height.
+      expect(await scrollHeight()).toBe(before);
+    });
+  }
+
+  for (const height of [900, 700]) {
+    test(`decline-reason select inside the order sheet is unclipped at 1440×${height}`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: 1440, height });
+      await openOrderAsDesigner(page);
+      await page.getByRole("button", { name: "Decline" }).click();
+      await page.getByLabel("Decline reason").click();
+      await expectMenuUnclipped(page, height);
+    });
+  }
+});

--- a/web/e2e/floating-layers.spec.ts
+++ b/web/e2e/floating-layers.spec.ts
@@ -6,7 +6,7 @@
 // so unclamped it would escape the viewport: the canonical edge-anchored
 // probe. /dev/components is served in dev and TEST_MODE builds (the e2e
 // system under test).
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 const VIEWPORTS = [
   { width: 1440, height: 900 },
@@ -40,3 +40,51 @@ for (const viewport of VIEWPORTS) {
     ).toBeLessThanOrEqual(viewport.height);
   });
 }
+
+// ---------------------------------------------------------------------------
+// C2 — a select opened from inside a Sheet/modal: the menu portals to the
+// body (never clips into the sheet's inner scrollbox), stays height-capped
+// and fully inside the viewport, and its bottom edge is really clickable.
+// 700px is the short-viewport case that squeezes the menu.
+// ---------------------------------------------------------------------------
+
+async function expectMenuUnclipped(page: Page, height: number) {
+  const menu = page.getByRole("listbox");
+  await expect(menu).toBeVisible();
+  const box = await menu.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.y, "menu top inside viewport").toBeGreaterThanOrEqual(0);
+  expect(
+    box!.y + box!.height,
+    "menu bottom inside viewport",
+  ).toBeLessThanOrEqual(height);
+  // 288px cap (max-h-72) + hairline borders.
+  expect(box!.height).toBeLessThanOrEqual(290);
+  // No clipping: the point just inside the menu's bottom edge hit-tests to
+  // the menu itself, not an overlaying sheet or scrollbox.
+  const hit = await page.evaluate(() => {
+    const lb = document.querySelector('[role="listbox"]')!;
+    const r = lb.getBoundingClientRect();
+    const el = document.elementFromPoint(r.x + r.width / 2, r.bottom - 5);
+    return lb.contains(el);
+  });
+  expect(hit, "menu bottom edge is hit-testable").toBe(true);
+}
+
+test("report-reason select inside the report sheet is unclipped at 1440×700", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 700 });
+  await page.goto("/signin");
+  await page.getByRole("button", { name: /continue with google/i }).click();
+  await page.waitForURL("**/dashboard");
+  await page.waitForSelector('[data-testid="feed-list"]');
+  await page
+    .getByTestId("post-card")
+    .first()
+    .getByRole("button", { name: "More options" })
+    .click();
+  await page.getByRole("menuitem", { name: "Report post" }).click();
+  await page.getByLabel("Report reason").click();
+  await expectMenuUnclipped(page, 700);
+});

--- a/web/src/components/dashboard/feed/FeedView.tsx
+++ b/web/src/components/dashboard/feed/FeedView.tsx
@@ -132,7 +132,11 @@ export function FeedView() {
   };
 
   return (
-    <div className="mx-auto flex max-w-5xl justify-center gap-16 px-4 py-6">
+    // B1 frame (176:72): 630px feed column + 48px gutter + 320px meta rail,
+    // centered — 1030 = 630+48+320 plus the 16px side paddings. max-w-5xl
+    // (1024) with gap-16 squeezed the feed to 608 and stretched the gutter
+    // to 64.
+    <div className="mx-auto flex max-w-[1030px] justify-center gap-12 px-4 py-6">
       <div className="flex w-full max-w-[630px] flex-col">
         <h1 className="sr-only">Home feed</h1>
 

--- a/web/src/components/dashboard/orders/OrderDetailView.tsx
+++ b/web/src/components/dashboard/orders/OrderDetailView.tsx
@@ -443,9 +443,16 @@ export function OrderDetailView({ orderId }: { orderId: string }) {
           </section>
         </div>
 
-        {/* Right rail (Figma 179:536): the order thread as a bordered card. */}
+        {/* Right rail (Figma 179:536): the order thread as a bordered card.
+            The frame draws the panel spanning the band beside the order
+            content with the composer pinned to its bottom edge — on lg the
+            card fills the grid row (capped at 70vh) instead of hugging a
+            short thread and leaving the band bottom-heavy on the left. */}
         <aside aria-labelledby="order-thread-h" className="lg:pt-0">
-          <section className="flex max-h-[70vh] flex-col rounded-card border border-border p-4">
+          <section
+            data-testid="order-thread-panel"
+            className="flex max-h-[70vh] flex-col rounded-card border border-border p-4 lg:h-full"
+          >
             <h2
               id="order-thread-h"
               className="pb-3 text-body font-semibold text-text"

--- a/web/src/components/ui/DateInput.test.tsx
+++ b/web/src/components/ui/DateInput.test.tsx
@@ -53,6 +53,34 @@ describe("DateInput (§8.2b)", () => {
     );
   });
 
+  it("month grid is Sunday-first with blank outside-month cells (master 87:1035)", () => {
+    // July 2026: starts Wednesday, 31 days — Sunday-first ⇒ 3 leading and
+    // 1 trailing blank cell, and day 1 lands in the 4th column.
+    render(
+      <DatePickerPopover
+        value={new Date("2026-07-15T00:00:00")}
+        onSelect={() => {}}
+      />,
+    );
+    const grid = screen
+      .getByTestId("date-picker")
+      .querySelector(".grid-cols-7")!;
+    const cells = [...grid.children];
+    expect(cells.slice(0, 7).map((c) => c.textContent)).toEqual([
+      "S",
+      "M",
+      "T",
+      "W",
+      "T",
+      "F",
+      "S",
+    ]);
+    const dayButtons = grid.querySelectorAll("button");
+    expect(dayButtons).toHaveLength(31); // only July renders as buttons
+    expect(grid.querySelectorAll("span[aria-hidden]")).toHaveLength(4);
+    expect(cells[7 + 3].textContent).toBe("1"); // Wednesday column
+  });
+
   it("DatePickerPopover disables days before minDate", async () => {
     const onSelect = vi.fn();
     const base = new Date("2026-07-15T00:00:00");

--- a/web/src/components/ui/DateInput.tsx
+++ b/web/src/components/ui/DateInput.tsx
@@ -17,6 +17,7 @@ import {
   isBefore,
   isSameDay,
   isSameMonth,
+  isToday,
   startOfDay,
   startOfMonth,
   startOfWeek,
@@ -92,7 +93,9 @@ export function DateInput({
             // paints over it and swallows every click, so the due date could
             // never be picked. Same layer as the sheet, later in portal
             // order wins (the same class of fix as Select, W3).
-            className="z-40 rounded-card border border-border bg-bg-elev p-3 shadow-lg"
+            // p-4: the master (87:1035) pads the panel 16px — the grid never
+            // sits flush against the panel edges.
+            className="z-40 rounded-card border border-border bg-bg-elev p-4 shadow-lg"
           >
             <DatePickerPopover
               value={value}
@@ -114,7 +117,14 @@ export function DateInput({
   );
 }
 
-/** DatePickerPopover — the standalone month-grid calendar (bespoke, no kit). */
+/**
+ * DatePickerPopover — the standalone month-grid calendar.
+ *
+ * Anatomy is the Figma master (87:1035): 252px grid on a 16px-padded panel,
+ * Sunday-first S M T W T F S header (12 semibold, text-2), 36×32 pill day
+ * cells (13px, tnum) in rows separated by 8px, outside-month cells blank,
+ * today ringed with the border token, selected = gradient pill.
+ */
 export function DatePickerPopover({
   value,
   minDate,
@@ -126,21 +136,21 @@ export function DatePickerPopover({
 }) {
   const [month, setMonth] = useState(() => startOfMonth(value ?? new Date()));
   const days = eachDayOfInterval({
-    start: startOfWeek(startOfMonth(month), { weekStartsOn: 1 }),
-    end: endOfWeek(endOfMonth(month), { weekStartsOn: 1 }),
+    start: startOfWeek(startOfMonth(month), { weekStartsOn: 0 }),
+    end: endOfWeek(endOfMonth(month), { weekStartsOn: 0 }),
   });
   const min = minDate ? startOfDay(minDate) : undefined;
 
   return (
-    <div data-testid="date-picker" className="w-64 select-none">
+    <div data-testid="date-picker" className="w-[252px] select-none">
       <div className="mb-2 flex items-center justify-between">
         <button
           type="button"
           aria-label="Previous month"
           onClick={() => setMonth((m) => addMonths(m, -1))}
-          className="grid size-8 place-items-center rounded-pill text-text-2 hover:bg-border/40"
+          className="grid size-6 place-items-center rounded-pill text-text-2 hover:bg-border/40"
         >
-          <ChevronLeft size={16} />
+          <ChevronLeft size={18} />
         </button>
         <span className="text-body font-semibold">
           {format(month, "MMMM yyyy")}
@@ -149,21 +159,28 @@ export function DatePickerPopover({
           type="button"
           aria-label="Next month"
           onClick={() => setMonth((m) => addMonths(m, 1))}
-          className="grid size-8 place-items-center rounded-pill text-text-2 hover:bg-border/40"
+          className="grid size-6 place-items-center rounded-pill text-text-2 hover:bg-border/40"
         >
-          <ChevronRight size={16} />
+          <ChevronRight size={18} />
         </button>
       </div>
-      <div className="grid grid-cols-7 gap-y-0.5 text-center">
-        {["M", "T", "W", "T2", "F", "S", "S2"].map((d) => (
-          <span key={d} className="py-1 text-micro text-text-2">
+      <div className="grid grid-cols-7 gap-y-2 text-center">
+        {["S", "M", "T", "W", "T2", "F", "S2"].map((d) => (
+          <span key={d} className="py-1 text-micro font-semibold text-text-2">
             {d.replace(/\d/, "")}
           </span>
         ))}
         {days.map((day) => {
-          const outside = !isSameMonth(day, month);
+          if (!isSameMonth(day, month)) {
+            // Master leaves outside-month cells empty — no adjacent-month
+            // day numbers.
+            return (
+              <span key={day.toISOString()} aria-hidden className="h-8 w-9" />
+            );
+          }
           const disabled = min !== undefined && isBefore(day, min);
           const selected = value !== null && isSameDay(day, value);
+          const today = isToday(day);
           return (
             <button
               key={day.toISOString()}
@@ -172,13 +189,16 @@ export function DatePickerPopover({
               onClick={() => onSelect(day)}
               aria-pressed={selected || undefined}
               className={clsx(
-                "tnum mx-auto grid size-8 place-items-center rounded-pill text-body",
+                "tnum grid h-8 w-9 place-items-center rounded-pill text-caption",
                 selected
                   ? "bg-accent-gradient font-semibold text-on-accent"
                   : "text-text hover:bg-border/40",
-                outside && !selected && "text-text-2/60",
-                disabled &&
-                  "cursor-not-allowed text-text-2/30 hover:bg-transparent",
+                today && !selected && "border border-border",
+                disabled && "cursor-not-allowed hover:bg-transparent",
+                // Today stays legible even when the min-date rule disables
+                // it (master: text-2 at full opacity); other disabled days
+                // fade to text-2/50.
+                disabled && (today ? "text-text-2" : "text-text-2/50"),
               )}
             >
               {format(day, "d")}


### PR DESCRIPTION
## Summary

Cross-check of the three user-reported finding classes against this repo's own Figma masters (file `34GbYXm8TpxMMUaAGGuwMM`), verified empirically on the TEST_MODE build at 1440×900 **and** 1440×700.

### C1 — date-popover anatomy + Y-overflow → **HIT (anatomy), fixed**
`DatePickerPopover` diverged from its master (**87:1035**) on every anatomy axis: 12px panel padding (master 16), 2px row gaps (master 8), Monday-first header (master Sunday-first `S M T W T F S`, 12 semibold), 32×32/14px day cells (master 36×32/13px pills), grayed adjacent-month days (master blank), no today ring (master 1px border-token ring), disabled at `/30` (master `/50`, today kept legible). Rebuilt to the master — rendered panel is now 286×290 vs the master's 284×288 + borders.
**Y-overflow was clean**: the quote due-date popover fits at 900, and flips above its trigger at 700 (Radix `avoidCollisions` + the earlier `collisionPadding` pass); no document scrollbar growth. Locked anyway.

### C2 — modal-embedded select clipping → **CLEAN (verified + locked)**
Decline-reason, report-reason, and stepper address selects inside sheets: portaled at the sheet layer (W3 pattern), `max-h-72` capped, fully in-viewport at 900/700 with the bottom edge hit-testable. No fixes needed; locks added.

### C3 — dashboard two-column band balance → **2 HITS, fixed**
- **B1 feed (176:72):** `max-w-5xl`+`gap-16` squeezed the feed column to 608px and stretched the gutter to 64 — frame draws **630 + 48 + 320**. Now `max-w-[1030px]`+`gap-12`; at 1440 the band lands on the frame's exact x-positions (343..973 / 1021..1341).
- **Order detail (179:536):** the thread card hugged a short thread (306px beside an 882px column — ~576px dead band). The frame spans the panel beside the order content with the composer pinned to its bottom edge; the card now fills the grid row on `lg`, capped at 70vh.

## Locks
- `web/e2e/dashboard.spec.ts` — serial fixture group (request on `post-chromat-look`, idempotency-keyed): calendar master anatomy, in-viewport/flip at 900+700 with zero scroll-height growth, decline select unclipped at both heights.
- `web/e2e/floating-layers.spec.ts` — report-reason select unclipped at 700 (read-only).
- `web/e2e/band-balance.spec.ts` — B1 column widths/gutter ±2px; order band top-alignment, row-fill height, composer pinning.
- `DateInput.test.tsx` — Sunday-first grid math + blank outside cells on a fixed month.

## Gates
prettier/eslint/boundaries ✅ · `tsc` ✅ · vitest 496/496 ✅ · Playwright 60/60 ✅ · `next build` (TEST_MODE) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)