### PR TITLE
fix(web): audit-ledger closeout — MI-11 plain profile avatars, boot-reachable low-confidence chip, copy-parity nits

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -319,12 +319,13 @@ from the Figma ↔ code divergence audit (seed-side details live in §6):
   frame's "58.0 cm" idiom) via `formatCm` — MeasurementCard, SessionRow,
   snapshot chips and the request stepper share the single formatter, so
   tnum columns stay aligned.
-- The OWN avatar wears the measurement-freshness ring (MI-11 / the C9
-  construction) on the profile header — both the regular-user and
-  designer-self branches — while other designers keep the B6 gradient
-  story ring. The fresh/aging/stale → gradient/amber/gray mapping is one
-  helper (`freshnessRing` on the Avatar atom) shared by the vault header,
-  the feed freshness card and the profile.
+- Profile avatars render PLAIN — the measurement-freshness ring is a
+  vault-header affordance (MI-11 **[Decided 2026-07-20]**, design.md §2);
+  own profiles (regular-user and designer-self branches) carry no ring
+  and fetch no vault, while other designers keep the B6 gradient story
+  ring. The fresh/aging/stale → gradient/amber/gray mapping is one helper
+  (`freshnessRing` on the Avatar atom) shared by the vault header and the
+  feed freshness card.
 - ModerationQueueRow anatomy matches the B7a canvas: headline carries the
   content author when known ("Reported post by @amara.designs"),
   reporters are @-prefixed, and actioned rows render the audit line

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -353,7 +353,7 @@ test("B5/B8: creator upsell → onboarding with Paystack resolution states → p
   await expect(page.getByTestId("profile-grid").locator("li")).toHaveCount(1);
 });
 
-test("B6 own profile: the avatar wears the measurement-freshness ring (MI-11)", async ({
+test("B6 own profile: the avatar renders plain — no freshness ring (MI-11, Decided 2026-07-20)", async ({
   page,
 }) => {
   await signIn(page);
@@ -361,10 +361,10 @@ test("B6 own profile: the avatar wears the measurement-freshness ring (MI-11)", 
   await page.goto("/dashboard/profile");
   await page.waitForURL("**/dashboard/kiki.adeyemi");
   const avatar = page.locator("header [data-ring]").first();
-  // Seeded vault freshness drives the band — any of the three ring states
-  // is valid here (earlier serial tests may add fresh captures), but the
-  // ring must be present ("none" would be the audited regression).
-  await expect(avatar).toHaveAttribute("data-ring", /^(gradient|amber|gray)$/);
+  // The freshness ring is a vault-header affordance (design.md §2 MI-11;
+  // Figma B6-own 386:8321 ring=none) — a ringed profile avatar here would
+  // be the audited regression.
+  await expect(avatar).toHaveAttribute("data-ring", "none");
 });
 
 test("B7: notification prefs persist across reload; consent history renders", async ({

--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -371,7 +371,7 @@ export function ComponentGallery() {
           <Input placeholder="Display name" aria-label="Text input" />
           <Input
             kind="search"
-            placeholder="Search designers, styles…"
+            placeholder="Search designers, styles, tags…"
             aria-label="Search"
           />
           <Input

--- a/web/src/components/dashboard/profile/ProfileView.test.tsx
+++ b/web/src/components/dashboard/profile/ProfileView.test.tsx
@@ -1,6 +1,8 @@
-// B6 profile header — MI-11: the OWN avatar wears the measurement-
-// freshness ring (C9 construction); other people's designer avatars keep
-// the B6 story-ring (gradient).
+// B6 profile header — MI-11 [Decided 2026-07-20]: the measurement-freshness
+// ring is a VAULT-HEADER affordance. Profile avatars — including the
+// viewer's own (regular user or designer) — render plain; other people's
+// designer avatars keep the B6 story-ring (gradient). Locks the ratified
+// construction (design.md §2 MI-11; Figma B6-own 386:8321 ring=none).
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "@testing-library/react";
 import type { PublicProfile } from "@/models";
@@ -96,29 +98,16 @@ beforeEach(() => {
   useVaultMock.mockReturnValue({ freshness: "aging", loading: false });
 });
 
-describe("ProfileView — own-profile freshness ring (MI-11)", () => {
-  it("own regular-user profile wears the freshness ring (aging → amber)", () => {
-    const { container } = renderProfile(ownUserProfile, "kiki.adeyemi");
-    expect(container.querySelector('[data-ring="amber"]')).not.toBeNull();
-  });
-
-  it.each([
-    ["fresh", "gradient"],
-    ["stale", "gray"],
-  ] as const)("freshness %s renders ring=%s", (freshness, ring) => {
-    useVaultMock.mockReturnValue({ freshness, loading: false });
-    const { container } = renderProfile(ownUserProfile, "kiki.adeyemi");
-    expect(container.querySelector(`[data-ring="${ring}"]`)).not.toBeNull();
-  });
-
-  it("no ring while the vault is still loading", () => {
-    useVaultMock.mockReturnValue({ freshness: null, loading: true });
+describe("ProfileView — profile avatars render plain (MI-11, ring = vault affordance)", () => {
+  it("own regular-user profile renders a plain avatar (no freshness ring)", () => {
     const { container } = renderProfile(ownUserProfile, "kiki.adeyemi");
     expect(container.querySelector('[data-ring="none"]')).not.toBeNull();
+    expect(container.querySelector('[data-ring="amber"]')).toBeNull();
+    expect(container.querySelector('[data-ring="gradient"]')).toBeNull();
   });
 
-  it("someone else's regular-user profile never fetches the vault", () => {
-    renderProfile(
+  it("someone else's regular-user profile renders plain too", () => {
+    const { container } = renderProfile(
       {
         ...ownUserProfile,
         account: { ...ownUserProfile.account, username: "ada.eze" },
@@ -126,20 +115,26 @@ describe("ProfileView — own-profile freshness ring (MI-11)", () => {
       },
       "ada.eze",
     );
-    expect(useVaultMock).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-ring="none"]')).not.toBeNull();
   });
 
-  it("own designer profile wears the freshness ring too", () => {
+  it("own designer profile renders a plain avatar (no freshness ring)", () => {
     const { container } = renderProfile(designerProfile(true), "kiki.adeyemi");
-    expect(container.querySelector('[data-ring="amber"]')).not.toBeNull();
+    expect(container.querySelector('[data-ring="none"]')).not.toBeNull();
+    expect(container.querySelector('[data-ring="amber"]')).toBeNull();
   });
 
-  it("other designers keep the gradient story ring (B6)", () => {
+  it("other designers keep the gradient story ring (B6 anatomy)", () => {
     const { container } = renderProfile(
       designerProfile(false),
       "amara.designs",
     );
     expect(container.querySelector('[data-ring="gradient"]')).not.toBeNull();
+  });
+
+  it("no profile render ever fetches the vault (ring gone → fetch gone)", () => {
+    renderProfile(ownUserProfile, "kiki.adeyemi");
+    renderProfile(designerProfile(true), "kiki.adeyemi");
     expect(useVaultMock).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/dashboard/profile/ProfileView.tsx
+++ b/web/src/components/dashboard/profile/ProfileView.tsx
@@ -16,8 +16,7 @@ import {
   useFollowList,
   usePublicProfile,
 } from "@/controllers/use-public-profile";
-import { useVault } from "@/controllers/use-vault";
-import { Avatar, freshnessRing } from "@/components/ui/Avatar";
+import { Avatar } from "@/components/ui/Avatar";
 import { Button } from "@/components/ui/Button";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { GridTile } from "@/components/ui/GridTile";
@@ -101,33 +100,6 @@ function FollowListSheet({
   );
 }
 
-/**
- * Own-profile avatar (MI-11 / C9 construction): the viewer's own avatar
- * carries the measurement-freshness ring — same Avatar ring canon as the
- * vault header and the feed freshness card. Mounted only for self so the
- * vault fetch never runs on other people's profiles.
- */
-function OwnProfileAvatar({
-  name,
-  src,
-  verified,
-}: {
-  name: string;
-  src?: string | null;
-  verified?: boolean;
-}) {
-  const vault = useVault();
-  return (
-    <Avatar
-      size={96}
-      name={name}
-      src={src}
-      verified={verified}
-      ring={vault.loading ? "none" : freshnessRing(vault.freshness)}
-    />
-  );
-}
-
 export function ProfileView({ username }: { username: string }) {
   const { account } = useAuth();
   const router = useRouter();
@@ -168,11 +140,10 @@ export function ProfileView({ username }: { username: string }) {
     return (
       <div className="mx-auto flex max-w-4xl flex-col gap-6 px-4 py-6">
         <header className="flex items-center gap-6">
-          {self ? (
-            <OwnProfileAvatar name={profile.account.display_name} />
-          ) : (
-            <Avatar size={96} name={profile.account.display_name} />
-          )}
+          {/* MI-11 [Decided 2026-07-20]: the freshness ring is a
+              vault-header affordance — profile avatars (own included)
+              render plain. */}
+          <Avatar size={96} name={profile.account.display_name} />
           <div className="flex min-w-0 flex-col gap-1">
             <h1 className="text-title-lg font-bold text-text">
               {profile.account.username}
@@ -272,9 +243,11 @@ export function ProfileView({ username }: { username: string }) {
     <div className="mx-auto flex max-w-4xl flex-col gap-6 px-4 py-6">
       <header className="flex items-start gap-6">
         {self ? (
-          // MI-11: the OWN avatar wears the freshness ring; others keep the
+          // MI-11 [Decided 2026-07-20]: own profile renders PLAIN (the
+          // freshness ring is a vault-header affordance); others keep the
           // B6 story-ring construction (gradient).
-          <OwnProfileAvatar
+          <Avatar
+            size={96}
             name={d.display_name}
             src={d.avatar_url}
             verified={d.verified}

--- a/web/src/components/home/sections.test.tsx
+++ b/web/src/components/home/sections.test.tsx
@@ -83,7 +83,7 @@ describe("DesignersSection (A6)", () => {
     ).toBeInTheDocument();
     expect(screen.getByTestId("balance-card")).toHaveTextContent("₦82,500");
     expect(screen.getByTestId("pending-card")).toHaveTextContent("₦45,000");
-    expect(screen.getByText("Payout to GTBank •••• 4521")).toBeInTheDocument();
+    expect(screen.getByText("Payout to GTBank ••• 4521")).toBeInTheDocument();
     expect(
       screen.getByText("Escrow held · order #APR-1042"),
     ).toBeInTheDocument();

--- a/web/src/components/ui/EarningsSummary.tsx
+++ b/web/src/components/ui/EarningsSummary.tsx
@@ -51,7 +51,7 @@ export interface TransactionRowProps {
   entry: EarningsEntry;
   /**
    * Optional label override — the enriched-landing instances (186:140/150)
-   * carry free-text first lines ("Payout to GTBank •••• 4521"); defaults to
+   * carry free-text first lines ("Payout to GTBank ••• 4521"); defaults to
    * the derived `{kind} · {order_number}` line.
    */
   label?: string;

--- a/web/src/controllers/home-demo.ts
+++ b/web/src/controllers/home-demo.ts
@@ -344,7 +344,9 @@ export const designerEarningsDemo: {
         provider_ref: "PSK-8843763",
         created_at: daysAgo(4), // Jul 14 on the canvas
       },
-      label: "Payout to GTBank •••• 4521",
+      // "••• last4" is the one masked-account idiom (store display,
+      // EarningsView payout card, Figma A6/B9 rows) — was a stray "••••".
+      label: "Payout to GTBank ••• 4521",
     },
     {
       entry: {

--- a/web/src/mocks/seed.ts
+++ b/web/src/mocks/seed.ts
@@ -953,7 +953,11 @@ export const seedSessions: MeasurementSession[] = [
         name: "hip_width",
         value_cm: 36.8,
         source: "pipeline",
-        confidence: 0.88,
+        // Low confidence (<0.7) so the MeasurementCard low-confidence chip
+        // (B4 canvas exemplar "Low confidence · 0.62") is reachable from
+        // boot — audit 2026-07-20 found the variant unreachable from seed.
+        // Plausible: the older 2-D scan already scored hips at 0.64.
+        confidence: 0.62,
       },
     ],
     pipeline_meta: { model_version: "mp2d-v2.3", qc: "pass" },

--- a/web/src/mocks/store.test.ts
+++ b/web/src/mocks/store.test.ts
@@ -49,6 +49,16 @@ describe("seed narrative", () => {
     expect(shoulder?.value_cm).toBe(42.5);
   });
 
+  it("boot vault carries a low-confidence (<0.7) measurement — the B4 chip is reachable from seed (audit 2026-07-20)", () => {
+    const sessions = store.sessionsFor("kiki.adeyemi");
+    const newest = sessions[0];
+    expect(
+      newest.measurements.some(
+        (m) => m.confidence !== null && m.confidence < 0.7,
+      ),
+    ).toBe(true);
+  });
+
   it("designer posts_count matches the actually seeded posts (system QA)", () => {
     for (const designer of store.designers) {
       const actual = store.posts.filter(


### PR DESCRIPTION
## Summary

Code-side closeout of the remaining open rows of the 2026-07-20 Figma ↔ code convergence ledger (verify-then-fix pass against current canvas + main).

- **MI-11 — own-profile avatar renders plain** (ledger: own-profile freshness ring, minor). PR #111 ratified the freshness ring as a *vault-header* affordance — profile avatars, including the viewer's own B6 profile, render plain (design.md §2 [Decided 2026-07-20]; Figma B6-own frame 386:8321 carries `ring=none`). PR #113 crossed mid-flight and shipped the opposite construction. `ProfileView` drops `OwnProfileAvatar` and its per-profile vault fetch; other designers keep the B6 gradient story ring. Unit + e2e locks now assert the plain construction; the web-implementation.md as-built note describes the current system.
- **Boot vault carries a low-confidence measurement** (ledger: B4 vault dataset, minor — split adjudication). Every seeded value scored ≥0.7, so the MeasurementCard low-confidence chip (B4 canvas exemplar "Low confidence · 0.62") was unreachable from boot. The recent scan's `hip_width` now scores 0.62 (plausible beside the older 2-D scan's 0.64 hips) with a store unit lock. The canvas half (B4 frame adopts the 4-measurement booted dataset) is queued in the design pass.
- **Copy-parity nits**: `/dev/components` gallery Input exemplar adopts the shipped B2 placeholder "Search designers, styles, tags…" (adjudicated: richer variant is the ratified copy); the landing A6 demo payout label joins the app-wide "••• last4" masked-account idiom (was a stray "••••").

All other ledger majors verified already-closed by the 2026-07-20 design wave + PRs #111–#120; Figma-side ops (transaction metas, security affordance, snapshot strip, annotations, B1 dataset sync, leftover sub-screen headings) are adjudicated and queued in the ledger's closeout queue.

## Test plan

- [x] `npm run lint` (prettier + eslint + boundaries) — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 80 files / 495 tests pass (new locks: plain own-profile avatar ×5, boot low-confidence reachability)
- [x] `PW_PORT=4412 npx playwright test` — 60 pass (MI-11 e2e flipped to assert `data-ring="none"` on the own profile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)