### PR TITLE
chore(web): retire dead NEXT_PUBLIC_GOOGLE_CLIENT_ID plumbing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,5 +12,3 @@ GOOGLE_CLOUD_PROJECT=apparule-local
 # ── web (Next.js) ──
 # Base URL of the api-common service as seen from the browser.
 NEXT_PUBLIC_BASE_URL=http://localhost:8080
-# Google OAuth client id (leave blank to disable Google sign-in locally).
-NEXT_PUBLIC_GOOGLE_CLIENT_ID=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,6 @@ services:
       # NEXT_PUBLIC_* are inlined into the standalone build, so pass them here.
       args:
         NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-http://localhost:8080}
-        NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${NEXT_PUBLIC_GOOGLE_CLIENT_ID:-}
     ports:
       - "3000:3000"
     depends_on:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -17,7 +17,6 @@ Configuration comes from the root `.env` (copy `.env.example`).
 | `GOOGLE_CLOUD_PROJECT` | `api/common` | GCP / Firebase project id (auth). |
 | `FIREBASE_CONFIG_PATH` | `api/common` | Optional path to a mounted Firebase service-account JSON. |
 | `NEXT_PUBLIC_BASE_URL` | `web` | Base URL of `api-common` as seen from the browser. |
-| `NEXT_PUBLIC_GOOGLE_CLIENT_ID` | `web` | Google OAuth client id (optional locally). |
 
 ## Quick start (Docker)
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,4 +1,3 @@
 # Native-run config for web (compose users: use the root .env instead).
 # NEXT_PUBLIC_* are inlined at build time.
 NEXT_PUBLIC_BASE_URL=http://localhost:8080
-NEXT_PUBLIC_GOOGLE_CLIENT_ID=

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -19,9 +19,7 @@ COPY web/ ./
 COPY docs/api/openapi.yaml /app/docs/api/openapi.yaml
 # NEXT_PUBLIC_* are inlined at build time, so they must be provided here.
 ARG NEXT_PUBLIC_BASE_URL
-ARG NEXT_PUBLIC_GOOGLE_CLIENT_ID
 ENV NEXT_PUBLIC_BASE_URL=$NEXT_PUBLIC_BASE_URL
-ENV NEXT_PUBLIC_GOOGLE_CLIENT_ID=$NEXT_PUBLIC_GOOGLE_CLIENT_ID
 RUN npm run build
 
 # ---- runner ----


### PR DESCRIPTION
## Summary

Fleet-level dead-env cleanup (converged from the three per-repo sweeps: #122, expendit#247, upstat#190). Apparule catch-up: #122 removed the `env.ts` reader for `NEXT_PUBLIC_GOOGLE_CLIENT_ID`, but the build/deploy plumbing rows stayed. This lands the same removal shape expendit ratified in a094c33 (expendit#247), so the three repos mirror.

## Evidence — no reader exists

- `git grep NEXT_PUBLIC_GOOGLE_CLIENT_ID web/src/` → no hits; the only `NEXT_PUBLIC_*` readers in web are `NEXT_PUBLIC_BASE_URL` (`web/src/config/env.ts` → `apiBaseUrl`) and `NEXT_PUBLIC_TEST_MODE`.
- Auth is Firebase Google sign-in (X-1) behind the `AuthProvider` seam — a raw OAuth client id has no consumer.
- Apparule has no api-side `GOOGLE_CLIENT_ID` (grep across repo, non-`NEXT_PUBLIC`, is empty), so nothing backend is affected.

## Removals (per row)

| File | Row removed |
| --- | --- |
| `web/Dockerfile` | `ARG NEXT_PUBLIC_GOOGLE_CLIENT_ID` + `ENV NEXT_PUBLIC_GOOGLE_CLIENT_ID=$NEXT_PUBLIC_GOOGLE_CLIENT_ID` |
| `docker-compose.yml` | web build arg `NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${NEXT_PUBLIC_GOOGLE_CLIENT_ID:-}` |
| `.env.example` | `NEXT_PUBLIC_GOOGLE_CLIENT_ID=` + its comment line |
| `web/.env.example` | `NEXT_PUBLIC_GOOGLE_CLIENT_ID=` |
| `docs/setup.md` | env-table row for `NEXT_PUBLIC_GOOGLE_CLIENT_ID` |

## Not touched (fleet item 2 finding)

`NEXT_PUBLIC_BASE_URL` is **genuinely read** in apparule (`web/src/config/env.ts:5`), unlike expendit/upstat where it is unread naming drift — so all its rows stay here.

## Gates

- `npm run lint` (prettier check + eslint + boundaries) — clean
- `npm run typecheck` — clean
- `npm test` — 80 files / 495 tests passed
- `npm run build` (next build) — success
- `docker compose config -q` — OK

No runtime behavior changes — deletions of unread configuration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)