### PR TITLE
chore(web): pipe Playwright webServer output for CI post-mortems

### DIFF
--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -28,6 +28,11 @@ export default defineConfig({
       : `npm run dev -- -p ${PORT} --hostname 127.0.0.1`,
     url: `http://127.0.0.1:${PORT}/signin`,
     reuseExistingServer: !process.env.CI,
+    // CI post-mortems: two runner-side server deaths (ERR_ABORTED
+    // mid-suite) left no evidence — Playwright discards webServer
+    // output unless piped; piping lands it in the report artifact.
+    stdout: "pipe",
+    stderr: "pipe",
     timeout: 120_000,
     env: {
       NEXT_PUBLIC_TEST_MODE: "1",


### PR DESCRIPTION
Fleet-parity change ×3. Apparule's CI Playwright job has died mid-suite twice (server ERR_ABORTED across specs the diffs never touched, both green on rerun) with no server output captured — Playwright discards webServer stdout/stderr unless piped. Piping puts the server's last words in the CI log + failure artifact so strike three is a root-cause, not a shrug. No behavior change locally (output interleaves in the terminal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)