### PR TITLE
fix(web): a11y blockers — Sheet focus restore + aria-modal

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -388,6 +388,15 @@ Arrow/Home/End. Both tabs are two lines, so switching never shifts layout
 focus, copied-morph reset); e2e: `home.spec.ts` pins helm-tab copy → the
 clipboard payload plus the 1440/390 container fit.
 
+**Sheet focus-restore as-built (2026-07-21 a11y audit).** `Sheet` owns the
+overlay focus contract: it is announced `aria-modal`, and because sheets are
+controlled dialogs with no `RadixDialog.Trigger`, the component captures the
+opener element on open (`onOpenAutoFocus`, before Radix moves focus into the
+panel) and returns focus to it on close — Radix's default would target a
+null trigger and drop focus on `<body>`. Callers never manage focus restore
+themselves. Locked by `Sheet.test.tsx` (unit) and `e2e/focus-restore.spec.ts`
+(open → Tab inside → Escape → trigger refocused), the org P4 probe shape.
+
 ## 3. Token mapping — design.md §2 → `web/src/design/tokens.css`
 
 One custom property per Figma variable in the `apparule/tokens` collection

--- a/web/e2e/focus-restore.spec.ts
+++ b/web/e2e/focus-restore.spec.ts
@@ -1,0 +1,58 @@
+// Overlay focus-restore canon (2026-07-21 a11y audit, fleet finding P4):
+// closing any Sheet/modal must return focus to the element that opened it.
+// The Sheets are controlled Radix dialogs without a RadixDialog.Trigger, so
+// before the fix Escape dropped focus on <body> — invisible to keyboard and
+// screen-reader users. Probe shape: open → move focus inside → Escape →
+// dialog closed AND focus is back on the trigger.
+import { expect, test, type Page } from "@playwright/test";
+
+async function signIn(page: Page) {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: /continue with google/i }).click();
+  await page.waitForURL("**/dashboard");
+  await page.waitForSelector('[data-testid="feed-list"]');
+}
+
+test("post-options sheet returns focus to its trigger on Escape", async ({
+  page,
+}) => {
+  await signIn(page);
+  const trigger = page
+    .getByTestId("post-card")
+    .first()
+    .getByRole("button", { name: "More options" });
+  await trigger.click();
+
+  const dialog = page.getByRole("dialog", { name: "Post options" });
+  await expect(dialog).toBeVisible();
+  // The dialog is announced as modal (audit: ariaModal was null).
+  await expect(dialog).toHaveAttribute("aria-modal", "true");
+
+  // Move focus deeper into the sheet before dismissing — restore must not
+  // depend on focus still sitting on the initially-focused element.
+  await page.keyboard.press("Tab");
+  await page.keyboard.press("Escape");
+
+  await expect(dialog).toBeHidden();
+  await expect(trigger).toBeFocused();
+});
+
+test("request stepper sheet returns focus to its trigger on Escape", async ({
+  page,
+}) => {
+  await signIn(page);
+  const trigger = page
+    .getByTestId("post-card")
+    .first()
+    .getByRole("button", { name: "Request this outfit" });
+  await trigger.click();
+
+  const dialog = page.getByRole("dialog", { name: "Request this outfit" });
+  await expect(dialog).toBeVisible();
+
+  await page.keyboard.press("Tab");
+  await page.keyboard.press("Escape");
+
+  await expect(dialog).toBeHidden();
+  await expect(trigger).toBeFocused();
+});

--- a/web/src/components/ui/Sheet.test.tsx
+++ b/web/src/components/ui/Sheet.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import { Sheet } from "./Sheet";
 
 describe("Sheet (§8.2)", () => {
@@ -66,6 +67,40 @@ describe("Sheet (§8.2)", () => {
     const wide = screen.getByRole("dialog").className;
     expect(wide).not.toContain("md:w-[480px]");
     expect(wide).toContain("md:w-[min(56rem,calc(100vw-4rem))]");
+  });
+
+  it("is announced as modal (aria-modal)", () => {
+    render(
+      <Sheet open onOpenChange={() => {}} title="Request">
+        <p>Body</p>
+      </Sheet>,
+    );
+    expect(screen.getByRole("dialog")).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("returns focus to the opener on close (2026-07-21 a11y audit)", async () => {
+    // Sheets are controlled with no RadixDialog.Trigger, so Radix's default
+    // close autofocus has no trigger to return to — the Sheet must capture
+    // and restore the opener itself, even after focus moved inside.
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>Open sheet</button>
+          <Sheet open={open} onOpenChange={setOpen} title="Request">
+            <button>Inside action</button>
+          </Sheet>
+        </>
+      );
+    }
+    render(<Harness />);
+    const opener = screen.getByRole("button", { name: "Open sheet" });
+    await userEvent.click(opener);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    await userEvent.tab();
+    await userEvent.keyboard("{Escape}");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(opener).toHaveFocus();
   });
 
   it("close affordance fires onOpenChange(false)", async () => {

--- a/web/src/components/ui/Sheet.tsx
+++ b/web/src/components/ui/Sheet.tsx
@@ -7,7 +7,7 @@
 import * as RadixDialog from "@radix-ui/react-dialog";
 import clsx from "clsx";
 import { X } from "lucide-react";
-import { type ReactNode } from "react";
+import { useRef, type ReactNode } from "react";
 
 export interface SheetStepper {
   steps: string[];
@@ -51,11 +51,31 @@ export function Sheet({
   children,
   className,
 }: SheetProps) {
+  // Sheets are controlled dialogs with no RadixDialog.Trigger, so Radix's
+  // default close autofocus targets a null triggerRef and focus falls to
+  // <body> (2026-07-21 a11y audit). Capture the opener ourselves —
+  // onOpenAutoFocus fires before Radix moves focus into the panel — and
+  // send focus back on close.
+  const returnFocusRef = useRef<HTMLElement | null>(null);
   return (
     <RadixDialog.Root open={open} onOpenChange={onOpenChange}>
       <RadixDialog.Portal>
         <RadixDialog.Overlay className="fixed inset-0 z-30 bg-black/50 motion-reduce:animate-none" />
         <RadixDialog.Content
+          aria-modal="true"
+          onOpenAutoFocus={() => {
+            returnFocusRef.current =
+              document.activeElement instanceof HTMLElement
+                ? document.activeElement
+                : null;
+          }}
+          onCloseAutoFocus={(event) => {
+            // preventDefault also skips Radix's own (null-trigger) handler.
+            event.preventDefault();
+            const opener = returnFocusRef.current;
+            returnFocusRef.current = null;
+            if (opener?.isConnected) opener.focus();
+          }}
           className={clsx(
             // z-40 sheet/modal layer; bottom sheet <md, centered modal ≥md
             "fixed z-40 flex max-h-[85vh] w-full flex-col overflow-hidden bg-bg-elev",


### PR DESCRIPTION
## What

Fleet a11y-blocker wave (adjudicated 2026-07-21 audit), apparule slice — fleet finding **P4** (focus restore after dialog close).

| Fix | Where | Before (audit probe) | After |
|---|---|---|---|
| Sheet returns focus to its opener on close | `web/src/components/ui/Sheet.tsx` | Escape on "Post options" / "Request this outfit" left `activeElement = BODY` | focus lands back on the trigger (e2e-locked) |
| Sheet announced as modal | same | `ariaModal: null` | `aria-modal="true"` |

Root cause: sheets are **controlled** Radix dialogs with no `RadixDialog.Trigger`, so Radix's default `onCloseAutoFocus` focused a null `triggerRef` → `<body>`. The component now captures the opener in `onOpenAutoFocus` (fires before Radix moves focus into the panel) and restores it on close, `preventDefault()`-ing Radix's null-trigger default. Fixed once at the component layer — all sheet callsites (feed, orders, vault, profile, settings) inherit it; callers stay focus-unaware.

## Evidence

- Audit ledger row: "All sheets (feed, orders, vault) — Focus NOT restored to trigger on close; `aria-modal` absent" (major, canon-level `ui/Sheet.tsx`).
- axe: apparule had **0 critical** before and after — this row was a Playwright dialog-probe finding, not an axe count; the aria-modal attribute now also satisfies the probe's `ariaModal` check.
- New locks verified **failing against the unfixed component** (both specs red on `aria-modal` + `toBeFocused`), then green with the fix.

## Locks

- Unit: `Sheet.test.tsx` — aria-modal present; open → Tab inside → Escape → opener refocused (jsdom).
- e2e: `web/e2e/focus-restore.spec.ts` — org P4 probe shape (open → move focus inside → Escape closes → focus back on trigger) for the post-options and request-stepper sheets.

## Gates (all green)

prettier ✓ · eslint ✓ · boundaries ✓ (315 files) · typecheck ✓ · vitest 497/497 ✓ · next build ✓ · Playwright **62/62** ✓ (PW_PORT=4426)

Docs: `docs/web-implementation.md` — Sheet focus-restore as-built note (focus contract now owned by the component).

🤖 Generated with [Claude Code](https://claude.com/claude-code)