### PR TITLE
fix(web): contrast-token canon — AA `-text` variants for the tinted-chip recipe

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -38,6 +38,8 @@
 | `link` | #00376B | #E0F1FF | usernames, links |
 | `like` | #ED4956 | #ED4956 | heart active |
 | `success/warn/error` | #2E7D32 / #B26A00 / #C62828 | brightened equivalents | order states, payment states |
+| `accent-text` | #DB2967 | #E73771 | AA text variant — readable text in the accent binds this (final-CTA pill on `on-accent`, active measure value); gradient fills/rings/icons keep `accent-start`/`accent-end`. Derived in OKLCH (L only) from `accent-start` to clear 4.5:1 on `bg`/`bg-elev` |
+| `success-text/warn-text/text-2-text` | #27772C / #985A02 / #696969 | #4ECB71 / #FFB020 / #A8A8A8 | AA text variants for the chip/pill recipe (`text-X` on `bg-X/14`) and plain status text — readable text binds the `-text` variant, fills/borders/icons keep the base hue. Light values darken the base in OKLCH until ≥4.5:1 on the hue's 14% tint; dark base values already clear it, so the dark variants alias them. `error` needs no variant (4.50 on its light tint) |
 | Afrocentric pattern | 4–6% opacity geometric line pattern | — | section backgrounds on home page + empty states only (PRD §2 nuance without noise) |
 
 ### Type

--- a/web/e2e/contrast-tokens.spec.ts
+++ b/web/e2e/contrast-tokens.spec.ts
@@ -1,0 +1,249 @@
+// Contrast-token lock (design.md §2 AA text variants) — recomputes the
+// 2026-07-21 audit's failing pairs from the SERVED CSS (custom-property
+// values off the live document, both themes) and asserts WCAG AA. The
+// tinted-chip recipe (`text-X` on `bg-X/14`) plus plain status text must
+// stay ≥4.5:1; a rendered orders-chip sweep locks the composed result.
+import { expect, test, type Page } from "@playwright/test";
+
+const AA = 4.5;
+
+// ---- WCAG 2.x math over sRGB --------------------------------------------
+type Rgb = { r: number; g: number; b: number };
+
+function hexToRgb(hex: string): Rgb {
+  const h = hex.trim().replace("#", "");
+  const v =
+    h.length === 3
+      ? h
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : h;
+  return {
+    r: parseInt(v.slice(0, 2), 16),
+    g: parseInt(v.slice(2, 4), 16),
+    b: parseInt(v.slice(4, 6), 16),
+  };
+}
+
+function luminance({ r, g, b }: Rgb): number {
+  const lin = (c: number) => {
+    const s = c / 255;
+    return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+function contrast(a: Rgb, b: Rgb): number {
+  const [lo, hi] = [luminance(a), luminance(b)].sort((x, y) => x - y);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/** `bg-X/nn` composited over an opaque base (what the browser paints). */
+function tint(hue: Rgb, alpha: number, base: Rgb): Rgb {
+  const mix = (f: number, g: number) => Math.round(alpha * f + (1 - alpha) * g);
+  return {
+    r: mix(hue.r, base.r),
+    g: mix(hue.g, base.g),
+    b: mix(hue.b, base.b),
+  };
+}
+
+// ---- served-CSS readers ---------------------------------------------------
+async function readTokens(
+  page: Page,
+  theme: "light" | "dark",
+  names: string[],
+): Promise<Record<string, Rgb>> {
+  const raw = await page.evaluate(
+    ({ t, ns }: { t: string; ns: string[] }) => {
+      document.documentElement.setAttribute("data-theme", t);
+      const cs = getComputedStyle(document.documentElement);
+      return Object.fromEntries(
+        ns.map((n) => [n, cs.getPropertyValue(n).trim()]),
+      );
+    },
+    { t: theme, ns: names },
+  );
+  const out: Record<string, Rgb> = {};
+  for (const [name, value] of Object.entries(raw)) {
+    // The dev server may serve minified hex (#fff) — accept both forms.
+    expect(value, `${name} is declared in the served CSS (${theme})`).toMatch(
+      /^#([0-9a-f]{3}|[0-9a-f]{6})$/i,
+    );
+    out[name] = hexToRgb(value);
+  }
+  return out;
+}
+
+const TOKENS = [
+  "--ap-bg",
+  "--ap-bg-elev",
+  "--ap-on-accent",
+  "--ap-link",
+  "--ap-success",
+  "--ap-warn",
+  "--ap-error",
+  "--ap-text-2",
+  "--ap-accent-text",
+  "--ap-success-text",
+  "--ap-warn-text",
+  "--ap-text-2-text",
+];
+
+test("§2 token pairs recomputed from served CSS clear WCAG AA in both themes", async ({
+  page,
+}) => {
+  await page.goto("/");
+  for (const theme of ["light", "dark"] as const) {
+    const t = await readTokens(page, theme, TOKENS);
+    const cases: Array<{ name: string; fg: Rgb; bg: Rgb }> = [];
+
+    // The chip/pill recipe: `-text` label on the base hue's 14% tint
+    // (StatusPill, ModerationQueueRow, CaptureResults, MeasurementCard),
+    // over both surfaces. `error`/`link` labels stay on the base hue —
+    // locked here so a base-value drift can't silently break them.
+    const chip: Array<[string, string]> = [
+      ["--ap-success-text", "--ap-success"],
+      ["--ap-warn-text", "--ap-warn"],
+      ["--ap-text-2-text", "--ap-text-2"],
+      ["--ap-error", "--ap-error"],
+      ["--ap-link", "--ap-link"],
+    ];
+    for (const [fg, hue] of chip) {
+      for (const surface of ["--ap-bg", "--ap-bg-elev"] as const) {
+        cases.push({
+          name: `${fg} on ${hue}/14 over ${surface}`,
+          fg: t[fg],
+          bg: tint(t[hue], 0.14, t[surface]),
+        });
+      }
+    }
+
+    // Banner action links: tone text on the tone's 10% tint over bg.
+    for (const [fg, hue] of [
+      ["--ap-warn-text", "--ap-warn"],
+      ["--ap-success-text", "--ap-success"],
+      ["--ap-error", "--ap-error"],
+      ["--ap-link", "--ap-link"],
+    ] as const) {
+      cases.push({
+        name: `${fg} on ${hue}/10 over --ap-bg (Banner action)`,
+        fg: t[fg],
+        bg: tint(t[hue], 0.1, t["--ap-bg"]),
+      });
+    }
+
+    // Plain status/accent text on the page surfaces.
+    for (const fg of [
+      "--ap-warn-text",
+      "--ap-success-text",
+      "--ap-text-2-text",
+      "--ap-accent-text",
+    ]) {
+      for (const surface of ["--ap-bg", "--ap-bg-elev"] as const) {
+        cases.push({ name: `${fg} on ${surface}`, fg: t[fg], bg: t[surface] });
+      }
+    }
+
+    for (const c of cases) {
+      const ratio = contrast(c.fg, c.bg);
+      expect
+        .soft(ratio, `${theme}: ${c.name} ≥ ${AA} (got ${ratio.toFixed(2)})`)
+        .toBeGreaterThanOrEqual(AA);
+    }
+  }
+
+  // The final-CTA pill is a fixed-light locale: Light `accent-text` on
+  // `on-accent` white in BOTH themes (the section pins data-theme).
+  const light = await readTokens(page, "light", TOKENS);
+  const pill = contrast(light["--ap-accent-text"], light["--ap-on-accent"]);
+  expect(
+    pill,
+    `light --ap-accent-text on --ap-on-accent (final-CTA pill) ≥ ${AA}`,
+  ).toBeGreaterThanOrEqual(AA);
+});
+
+// ---- rendered surface: the audited orders chips, light theme --------------
+test("orders status chips render ≥4.5:1 in light theme (served pages)", async ({
+  page,
+}) => {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: /continue with google/i }).click();
+  await page.waitForURL("**/dashboard");
+  await page.goto("/dashboard/orders");
+  await page.evaluate(() =>
+    document.documentElement.setAttribute("data-theme", "light"),
+  );
+
+  // StatusPill only (RequestCard stamps data-status on the whole card).
+  const pills = page.locator("span.rounded-pill[data-status]");
+  await pills.first().waitFor({ state: "visible", timeout: 15_000 });
+  const count = await pills.count();
+  expect(count, "orders page renders status chips").toBeGreaterThan(0);
+
+  for (let i = 0; i < count; i++) {
+    const pill = pills.nth(i);
+    const result = await pill.evaluate((el) => {
+      type C = { r: number; g: number; b: number; a: number };
+      const parse = (s: string): C => {
+        const m = s.match(/rgba?\(([^)]+)\)/);
+        if (!m) return { r: 0, g: 0, b: 0, a: 0 };
+        const [r, g, b, a = "1"] = m[1].split(/[,/ ]+/).filter(Boolean);
+        return {
+          r: Number(r),
+          g: Number(g),
+          b: Number(b),
+          a: Number(a),
+        };
+      };
+      const over = (top: C, base: C): C => ({
+        r: top.r * top.a + base.r * (1 - top.a),
+        g: top.g * top.a + base.g * (1 - top.a),
+        b: top.b * top.a + base.b * (1 - top.a),
+        a: 1,
+      });
+      // Effective backdrop: walk up compositing every non-transparent
+      // background until an opaque one (body carries the page bg).
+      const layers: C[] = [];
+      let node: Element | null = el;
+      let opaque = false;
+      while (node) {
+        const bg = parse(getComputedStyle(node).backgroundColor);
+        if (bg.a > 0) layers.push(bg);
+        if (bg.a >= 1) {
+          opaque = true;
+          break;
+        }
+        node = node.parentElement;
+      }
+      if (!opaque)
+        layers.push(parse(getComputedStyle(document.body).backgroundColor));
+      let backdrop = layers[layers.length - 1];
+      for (let j = layers.length - 2; j >= 0; j--) {
+        backdrop = over(layers[j], backdrop);
+      }
+      const fg = parse(getComputedStyle(el).color);
+      if (fg.a < 1) return null; // gradient-clip "fresh" pill — text is a fill
+      const lum = (c: C) => {
+        const lin = (v: number) => {
+          const s = v / 255;
+          return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+        };
+        return 0.2126 * lin(c.r) + 0.7152 * lin(c.g) + 0.0722 * lin(c.b);
+      };
+      const [lo, hi] = [lum(fg), lum(backdrop)].sort((x, y) => x - y);
+      return {
+        status: el.getAttribute("data-status"),
+        ratio: (hi + 0.05) / (lo + 0.05),
+      };
+    });
+    if (result === null) continue;
+    expect
+      .soft(
+        result.ratio,
+        `[data-status="${result.status}"] renders ≥ ${AA} (got ${result.ratio.toFixed(2)})`,
+      )
+      .toBeGreaterThanOrEqual(AA);
+  }
+});

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -22,6 +22,12 @@
   --color-success: var(--ap-success);
   --color-warn: var(--ap-warn);
   --color-error: var(--ap-error);
+  /* AA text variants — readable text in a hue binds these; fills/borders/
+     icons keep the base hue (design.md §2) */
+  --color-accent-text: var(--ap-accent-text);
+  --color-success-text: var(--ap-success-text);
+  --color-warn-text: var(--ap-warn-text);
+  --color-text-2-text: var(--ap-text-2-text);
 
   /* Radii — 8px cards/sheets, full-round avatars/pills */
   --radius-card: var(--ap-radius-card);
@@ -313,7 +319,8 @@
     0 0 0 3px var(--ap-bg),
     0 0 0 5px var(--ap-accent-start);
 }
-/* active row: the numeric value reads in the accent (MI-13 master) */
+/* active row: the numeric value reads in the accent (MI-13 master) —
+   readable text, so it binds the AA `accent-text` variant (§2) */
 [data-state="active"] input[inputmode="decimal"] {
-  color: var(--ap-accent-start);
+  color: var(--ap-accent-text);
 }

--- a/web/src/components/dashboard/earnings/EarningsView.tsx
+++ b/web/src/components/dashboard/earnings/EarningsView.tsx
@@ -80,7 +80,7 @@ export function EarningsView() {
                       className={
                         payoutAccount.kyc_state === "verified"
                           ? "text-caption font-semibold text-success"
-                          : "text-caption font-semibold text-warn"
+                          : "text-caption font-semibold text-warn-text"
                       }
                     >
                       {payoutAccount.kyc_state === "verified"

--- a/web/src/components/home/FinalCtaBand.tsx
+++ b/web/src/components/home/FinalCtaBand.tsx
@@ -16,6 +16,10 @@ export function FinalCtaBand() {
   return (
     <section
       aria-labelledby="final-cta-heading"
+      // Fixed-light locale (§2 scoping): the band looks identical in both
+      // themes (gradient + on-accent white pills), so accent-as-text on the
+      // white pill re-binds the Light `accent-text` value under a dark root.
+      data-theme="light"
       className="bg-accent-gradient px-6 py-9"
     >
       {/* Canonical 1080 content column (design.md container canon) keeps
@@ -30,7 +34,7 @@ export function FinalCtaBand() {
         <div className="flex flex-wrap justify-center gap-4">
           <button
             type="button"
-            className={`${PILL_BASE} bg-on-accent text-accent-start`}
+            className={`${PILL_BASE} bg-on-accent text-accent-text`}
             onClick={() => {
               track("try_cloud_click", { section: "final-cta" });
               router.push("/signin");

--- a/web/src/components/ui/Banner.tsx
+++ b/web/src/components/ui/Banner.tsx
@@ -29,12 +29,14 @@ const TONE_ICON: Record<BannerTone, typeof Info> = {
   success: CheckCircle2,
 };
 
-// Action links bind to the tone token (Learn more=link, Re-verify=warn…).
+// Action links bind to the tone token (Learn more=link, Re-verify=warn…) —
+// readable text on the /10 tint, so warn/success bind their AA `-text`
+// variants (§2); link/error base values already clear 4.5 there.
 const TONE_ACTION: Record<BannerTone, string> = {
   info: "text-link",
-  warn: "text-warn",
+  warn: "text-warn-text",
   error: "text-error",
-  success: "text-success",
+  success: "text-success-text",
 };
 
 export function Banner({

--- a/web/src/components/ui/CaptureResults.tsx
+++ b/web/src/components/ui/CaptureResults.tsx
@@ -46,8 +46,8 @@ export function CaptureResults({
           className={clsx(
             "inline-flex h-6 items-center rounded-pill px-2 text-micro font-semibold",
             lowCount > 0
-              ? "bg-warn/14 text-warn"
-              : "bg-success/14 text-success",
+              ? "bg-warn/14 text-warn-text"
+              : "bg-success/14 text-success-text",
           )}
         >
           {lowCount > 0 ? `${lowCount} low confidence` : "High confidence"}

--- a/web/src/components/ui/DateInput.tsx
+++ b/web/src/components/ui/DateInput.tsx
@@ -111,7 +111,7 @@ export function DateInput({
       {error ? (
         <span className="text-micro text-error">{error}</span>
       ) : showSoftWarning ? (
-        <span className="text-micro text-warn">{softWarning}</span>
+        <span className="text-micro text-warn-text">{softWarning}</span>
       ) : null}
     </div>
   );

--- a/web/src/components/ui/MeasurementCard.tsx
+++ b/web/src/components/ui/MeasurementCard.tsx
@@ -65,7 +65,7 @@ export function MeasurementCard({
       {lowConfidence ? (
         <span
           data-testid="low-confidence"
-          className="flex h-5 w-fit items-center rounded-pill bg-warn/14 px-2 text-micro font-semibold text-warn"
+          className="flex h-5 w-fit items-center rounded-pill bg-warn/14 px-2 text-micro font-semibold text-warn-text"
         >
           Low confidence · {confidence!.toFixed(2)}
         </span>

--- a/web/src/components/ui/ModerationQueueRow.tsx
+++ b/web/src/components/ui/ModerationQueueRow.tsx
@@ -66,7 +66,7 @@ export function ModerationQueueRow({
             {report.reporter.username} · {formatAgoPhrase(report.created_at)}
           </p>
         </div>
-        <span className="shrink-0 rounded-pill bg-warn/14 px-2 py-0.5 text-micro font-semibold capitalize text-warn">
+        <span className="shrink-0 rounded-pill bg-warn/14 px-2 py-0.5 text-micro font-semibold capitalize text-warn-text">
           {report.reason}
         </span>
       </div>

--- a/web/src/components/ui/SessionRow.tsx
+++ b/web/src/components/ui/SessionRow.tsx
@@ -85,7 +85,7 @@ export function SessionRow({
         {context === "picker" && freshness !== "fresh" ? (
           <p
             data-testid="freshness-warning"
-            className="mt-1 text-micro text-warn"
+            className="mt-1 text-micro text-warn-text"
           >
             {freshness === "aging"
               ? "Measured over a month ago — consider retaking"

--- a/web/src/components/ui/StatusPill.tsx
+++ b/web/src/components/ui/StatusPill.tsx
@@ -13,22 +13,24 @@ import type { Freshness } from "@/models";
 export type StatusPillValue = OrderStatus | Freshness;
 
 // Figma master (47:135): borderless pills — a 14% tint of the status token
-// behind a 12px semibold label. fresh strokes the accent gradient.
+// behind a 12px semibold label (labels bind the AA `-text` variants where
+// the base hue misses 4.5:1 on its own tint, §2). fresh strokes the accent
+// gradient.
 const TOKEN_CLASS: Record<StatusPillValue, string> = {
   quoted: "text-link bg-link/14",
   shipped: "text-link bg-link/14",
-  paid: "text-success bg-success/14",
-  delivered: "text-success bg-success/14",
-  in_progress: "text-warn bg-warn/14",
-  refunded: "text-warn bg-warn/14",
+  paid: "text-success-text bg-success/14",
+  delivered: "text-success-text bg-success/14",
+  in_progress: "text-warn-text bg-warn/14",
+  refunded: "text-warn-text bg-warn/14",
   declined: "text-error bg-error/14",
   disputed: "text-error bg-error/14",
-  requested: "text-text-2 bg-text-2/14",
-  cancelled: "text-text-2 bg-text-2/14",
+  requested: "text-text-2-text bg-text-2/14",
+  cancelled: "text-text-2-text bg-text-2/14",
   fresh:
     "bg-[linear-gradient(135deg,color-mix(in_srgb,var(--ap-accent-start)_14%,transparent),color-mix(in_srgb,var(--ap-accent-end)_14%,transparent))]",
-  aging: "text-warn bg-warn/14",
-  stale: "text-text-2 bg-text-2/14",
+  aging: "text-warn-text bg-warn/14",
+  stale: "text-text-2-text bg-text-2/14",
 };
 
 export interface StatusPillProps {

--- a/web/src/design/tokens.css
+++ b/web/src/design/tokens.css
@@ -31,6 +31,18 @@
   --ap-warn: #b26a00;
   --ap-error: #c62828;
 
+  /* ---- AA text variants (design.md §2) ----
+     Readable text in a hue binds the `-text` variant; fills/borders/icons
+     keep the base hue. Values are the base hue darkened in OKLCH (L only;
+     C/H preserved) until ≥4.5:1 against the hue's 14% tint composited on
+     `bg` — the chip/pill recipe (`text-X` on `bg-X/14`) and plain text both
+     clear WCAG AA with them. `error` needs no variant (base clears 4.5 on
+     its tint in both themes). */
+  --ap-accent-text: #db2967; /* 4.64 on bg */
+  --ap-success-text: #27772c; /* 4.64 on success/14 tint */
+  --ap-warn-text: #985a02; /* 4.64 on warn/14 tint */
+  --ap-text-2-text: #696969; /* 4.61 on text-2/14 tint */
+
   /* The "Apparule gradient" — story rings, primary CTAs, active states */
   --ap-accent-gradient: linear-gradient(
     135deg,
@@ -97,7 +109,42 @@
   --ap-warn: #ffb020;
   --ap-error: #ff6b6e;
 
+  /* AA text variants — dark. success/warn/text-2 base values already clear
+     4.5 on their /14 tints (7.10/7.90/6.28), so the variants alias them;
+     accent lightens (OKLCH L 0.605→0.621) to clear bg-elev (was 4.32). */
+  --ap-accent-text: #e73771; /* 4.62 on bg-elev */
+  --ap-success-text: #4ecb71;
+  --ap-warn-text: #ffb020;
+  --ap-text-2-text: #a8a8a8;
+
   color-scheme: dark;
+}
+
+/* Light re-declaration for nested scoping (same mechanics as the sibling
+   products): a fixed-light locale inside a dark page — the home final-CTA
+   band's on-accent (white) pills — re-binds the same §2 Light values so
+   accent-as-text stays AA on the white fill in both themes. Same
+   collection, no new tokens — scoping only. */
+[data-theme="light"] {
+  --ap-bg: #ffffff;
+  --ap-bg-elev: #ffffff;
+  --ap-border: #dbdbdb;
+  --ap-text: #111111;
+  --ap-text-2: #737373;
+  --ap-accent-start: #e1306c;
+  --ap-accent-end: #f77737;
+  --ap-on-accent: #ffffff;
+  --ap-link: #00376b;
+  --ap-like: #ed4956;
+  --ap-success: #2e7d32;
+  --ap-warn: #b26a00;
+  --ap-error: #c62828;
+  --ap-accent-text: #db2967;
+  --ap-success-text: #27772c;
+  --ap-warn-text: #985a02;
+  --ap-text-2-text: #696969;
+
+  color-scheme: light;
 }
 
 /* Dark mode — system default when no manual override is present.
@@ -117,6 +164,10 @@
     --ap-success: #4ecb71;
     --ap-warn: #ffb020;
     --ap-error: #ff6b6e;
+    --ap-accent-text: #e73771;
+    --ap-success-text: #4ecb71;
+    --ap-warn-text: #ffb020;
+    --ap-text-2-text: #a8a8a8;
 
     color-scheme: dark;
   }


### PR DESCRIPTION
## What

The `text-X on bg-X/14` tinted-chip recipe (and plain warn/accent text) fails WCAG AA in light theme; dark accent is borderline on `bg-elev` (2026-07-21 fleet audit, adjudicated canon fix). §2 gains paired `-text` variants — the base hue darkened (light) / lightened (dark accent) in OKLCH (L only, C/H preserved) until ≥4.5:1 against the hue's 14% tint — and **readable text binds the variant; fills/borders/icons keep the base hue**.

## Token values

| Token | Light | Dark |
|---|---|---|
| `--ap-accent-text` | `#DB2967` | `#E73771` |
| `--ap-success-text` | `#27772C` | `#4ECB71` (base — already AA) |
| `--ap-warn-text` | `#985A02` | `#FFB020` (base — already AA) |
| `--ap-text-2-text` | `#696969` | `#A8A8A8` (base — already AA) |

`error` needs no variant (base clears 4.50 on its light tint; locked in the e2e so drift can't silently break it).

## Before → after (light theme, worst context)

| Pair | Before | After |
|---|---|---|
| warn text on `warn/14` tint (`#F4EADB`) | **3.56** | **4.64** |
| warn text on `bg` | **4.24** | **5.53** |
| success text on `success/14` tint | **4.26** | **4.64** |
| text-2 text on `text-2/14` tint | **3.98** | **4.61** |
| accent as text on `bg` / `on-accent` (final-CTA pill) | **4.34** | **4.64** |
| dark: accent as text on `bg-elev` | **4.32** | **4.62** |

## Code

- `StatusPill` (paid/delivered/in_progress/refunded/requested/cancelled/aging/stale), `ModerationQueueRow`, `CaptureResults`, `MeasurementCard` chip labels → `-text` variants
- `Banner` action links (warn/success) → `-text` variants (readable text on the /10 tint)
- `DateInput` soft-warning, `SessionRow` freshness note, `EarningsView` KYC state → `text-warn-text`
- MI-13 active measure value (`globals.css`) → `var(--ap-accent-text)`
- `FinalCtaBand`: the band is a fixed-light locale (gradient + `on-accent` white pills in both themes) — pins `data-theme="light"` (sibling-product scoping mechanics; new `[data-theme="light"]` re-declaration block in tokens.css) and the pill binds `text-accent-text`
- Kept on base hue deliberately: icons (≥3:1 non-text), 24px-bold earnings stats (AA large-text), the inverted Toast surface (`bg-text`), gradient-clip "fresh" pill

## Docs

`docs/design.md` §2 token table gains the `accent-text` and `success-text/warn-text/text-2-text` rows.

## Lock

`web/e2e/contrast-tokens.spec.ts` recomputes every recipe pair from the **served CSS** (custom properties off the live document, both themes; tint composited over both surfaces) asserting ≥4.5:1, and sweeps the rendered orders status chips (walk-up backdrop compositing) in light theme.

## Gate

prettier ✓ eslint ✓ boundaries ✓ typecheck ✓ vitest ✓ build ✓ Playwright 65/65 ✓ (PW_PORT=4431)

🤖 Generated with [Claude Code](https://claude.com/claude-code)