### PR TITLE
perf(web): /docs/api ships without Scalar in first-load JS (P10)

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -297,7 +297,9 @@ approved gap implementations:
   hidden and its remote default fonts are disabled (self-host ethos).
   Scalar's developer toolbar is pinned off (`showDeveloperTools:
   "never"` — the `"localhost"` default surfaced author chrome on the
-  public reference in local/TEST_MODE runs).
+  public reference in local/TEST_MODE runs), and Agent Scalar is
+  disabled outright (`agent: { disabled: true }` — it auto-enables on
+  localhost-class hosts, the same leak class).
   Header construction: the sticky marketing nav (h-16) and Scalar's
   sticky layout coexist via `--scalar-custom-header-height: 64px` on the
   embed wrapper (offsets Scalar's sticky sidebar/mobile bar below the
@@ -307,13 +309,26 @@ approved gap implementations:
   pins route 200, a rendered operation from the spec, the served
   document, the footer handoff, the header/scroll sanity and the
   embed-theme sync.
-  Payload: Scalar is the app's heaviest dependency (~1MB encoded route
-  JS), so the page renders it through `ScalarApiReferenceLazy` — a
-  `next/dynamic` `ssr: false` boundary (fleet-uniform, perf audit
-  2026-07-21) whose placeholder reserves the embed's viewport slice
+  Payload: Scalar is the app's heaviest dependency, so the page renders
+  it through `ScalarApiReferenceLazy` — a `next/dynamic` `ssr: false`
+  boundary gated on USER INTENT (fleet-uniform, perf audit + payload
+  diet 2026-07-21). A `ssr: false` boundary alone only moves Scalar out
+  of the first-load chunks (the async group still downloads right after
+  hydration — settled /docs/api JS stayed ~1381K encoded / ~4787K
+  decoded, network-recorded on the TEST_MODE prod build), so the import
+  fires only on the first pointer/key/wheel/touch/scroll gesture or the
+  placeholder's explicit "Load the interactive API reference" button
+  (the screen-reader path). Settled pre-intent JS: 1381K → 223K encoded
+  (4787K → 714K decoded); bots, probes and bounces never pay for
+  Scalar, and any human interacting mounts it within their first
+  gesture. The placeholder reserves the embed's viewport slice
   (`100dvh − --scalar-custom-header-height`) so the swap-in shifts no
-  layout. /docs/api first-load JS 1222K → 204K encoded; the nav/footer
-  chrome stays SSR'd and interactive while the reference streams in.
+  layout; the nav/footer chrome stays SSR'd and interactive throughout.
+  `e2e/docs-api-payload.spec.ts` (byte-identical fleet spec, keyed by
+  package name — the seo.spec.ts pattern) locks the settled pre-intent
+  budget (measured + 20% headroom, CDP-recorded encoded transfer; CI
+  prod build only) AND that intent still mounts the full reference with
+  the spec fetch intact.
 
 **Design-convergence as-built notes (2026-07-20):** the code-side fixes
 from the Figma ↔ code divergence audit (seed-side details live in §6):

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -307,6 +307,13 @@ approved gap implementations:
   pins route 200, a rendered operation from the spec, the served
   document, the footer handoff, the header/scroll sanity and the
   embed-theme sync.
+  Payload: Scalar is the app's heaviest dependency (~1MB encoded route
+  JS), so the page renders it through `ScalarApiReferenceLazy` — a
+  `next/dynamic` `ssr: false` boundary (fleet-uniform, perf audit
+  2026-07-21) whose placeholder reserves the embed's viewport slice
+  (`100dvh − --scalar-custom-header-height`) so the swap-in shifts no
+  layout. /docs/api first-load JS 1222K → 204K encoded; the nav/footer
+  chrome stays SSR'd and interactive while the reference streams in.
 
 **Design-convergence as-built notes (2026-07-20):** the code-side fixes
 from the Figma ↔ code divergence audit (seed-side details live in §6):

--- a/web/e2e/docs-api-payload.spec.ts
+++ b/web/e2e/docs-api-payload.spec.ts
@@ -18,7 +18,7 @@ import { expect, test } from "@playwright/test";
  *
  * Budgets are the measured settled pre-intent encoded JS of the TEST_MODE
  * prod build (network-recorded, 2026-07-21) + 20% headroom. Before the
- * diet the same probe read 1381K (apparule), 1425K (expendit), 1371K
+ * diet the same probe read 1381K (apparule), 1409K (expendit), 1378K
  * (upstat) encoded.
  */
 
@@ -34,8 +34,8 @@ interface PayloadProfile {
 
 const PRODUCTS: Record<string, PayloadProfile> = {
   apparule: { budgetKiB: 268, apiTitle: "Apparule API" },
-  expendit: { budgetKiB: 320, apiTitle: "Expendit API" },
-  upstat: { budgetKiB: 262, apiTitle: "Upstat HTTP API" },
+  expendit: { budgetKiB: 303, apiTitle: "Expendit API" },
+  upstat: { budgetKiB: 264, apiTitle: "Upstat HTTP API" },
 };
 
 const pkgName: string = JSON.parse(

--- a/web/e2e/docs-api-payload.spec.ts
+++ b/web/e2e/docs-api-payload.spec.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+
+/**
+ * Payload-budget lock for /docs/api (perf audit 2026-07-21, fleet P10):
+ * the Scalar reference is ~1.3–1.4MB encoded / ~4.8MB decoded JS in every
+ * product — shipped eagerly it made /docs/api the heaviest page of the
+ * fleet. The diet gates the Scalar import on user intent (first gesture or
+ * the explicit load button), so the settled pre-intent page costs only the
+ * shell. This spec locks both halves: the shell stays under budget, AND
+ * intent still mounts the full reference from the product's OpenAPI
+ * document.
+ *
+ * This spec is BYTE-IDENTICAL across apparule/expendit/upstat (tooling
+ * canon) — per-product expectations live in the config below keyed by
+ * `package.json` name, the seo.spec.ts pattern.
+ *
+ * Budgets are the measured settled pre-intent encoded JS of the TEST_MODE
+ * prod build (network-recorded, 2026-07-21) + 20% headroom. Before the
+ * diet the same probe read 1381K (apparule), 1425K (expendit), 1371K
+ * (upstat) encoded.
+ */
+
+interface PayloadProfile {
+  /**
+   * Encoded (transfer) JS budget in KiB for the settled, pre-intent
+   * /docs/api page.
+   */
+  budgetKiB: number;
+  /** Spec title Scalar must render once intent mounts the reference. */
+  apiTitle: string;
+}
+
+const PRODUCTS: Record<string, PayloadProfile> = {
+  apparule: { budgetKiB: 268, apiTitle: "Apparule API" },
+  expendit: { budgetKiB: 320, apiTitle: "Expendit API" },
+  upstat: { budgetKiB: 262, apiTitle: "Upstat HTTP API" },
+};
+
+const pkgName: string = JSON.parse(
+  readFileSync(path.join(__dirname, "..", "package.json"), "utf8"),
+).name;
+const product = PRODUCTS[pkgName];
+
+test("pre-intent /docs/api stays under the JS budget; intent still mounts the full reference", async ({
+  page,
+}) => {
+  // Budgets are meaningful only against the prod build: CI builds
+  // (TEST_MODE) and serves `next start`; local runs serve `next dev`,
+  // whose unminified chunks would dwarf any production budget.
+  test.skip(
+    !process.env.CI,
+    "payload budget is asserted against the prod build (CI harness)",
+  );
+
+  // Network-record encoded transfer sizes via CDP (chromium project).
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send("Network.enable");
+  const resources = new Map<
+    string,
+    { url: string; type: string; encoded: number }
+  >();
+  cdp.on("Network.responseReceived", (e) => {
+    resources.set(e.requestId, {
+      url: e.response.url,
+      type: e.type,
+      encoded: 0,
+    });
+  });
+  cdp.on("Network.loadingFinished", (e) => {
+    const r = resources.get(e.requestId);
+    if (r) r.encoded = e.encodedDataLength;
+  });
+
+  // Settle WITHOUT any input event — no pointer, key, wheel, touch or
+  // scroll — so the intent gate stays closed, then let stragglers land.
+  await page.goto("/docs/api", { waitUntil: "networkidle" });
+  await page.waitForTimeout(3000);
+
+  const js = [...resources.values()].filter((r) => r.type === "Script");
+  const encodedKiB = js.reduce((sum, r) => sum + r.encoded, 0) / 1024;
+  const worst = js
+    .sort((a, b) => b.encoded - a.encoded)
+    .slice(0, 5)
+    .map((r) => `${(r.encoded / 1024).toFixed(1)}K ${new URL(r.url).pathname}`)
+    .join("\n  ");
+  expect(
+    encodedKiB,
+    `settled pre-intent JS ${encodedKiB.toFixed(1)}KiB must stay under ` +
+      `${product.budgetKiB}KiB — heaviest:\n  ${worst}`,
+  ).toBeLessThan(product.budgetKiB);
+
+  // The gate must not fence off the reference itself: the first gesture
+  // mounts the FULL Scalar reference, fetching the OpenAPI document.
+  const specFetch = page.waitForResponse(
+    (res) => res.url().includes("/docs/api/openapi.yaml") && res.ok(),
+  );
+  await page.mouse.move(12, 12);
+  await specFetch;
+  await expect(
+    page.getByRole("heading", { name: product.apiTitle }),
+  ).toBeVisible({ timeout: 30_000 });
+});

--- a/web/e2e/docs-api.spec.ts
+++ b/web/e2e/docs-api.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 /**
  * Public API reference (F0-8, APP-004) — /docs/api embeds the Scalar
@@ -6,6 +6,23 @@ import { test, expect } from "@playwright/test";
  * document, served at /docs/api/openapi.yaml. Public surface: no auth,
  * marketing nav chrome, reachable from the footer's Docs column.
  */
+
+/**
+ * Payload diet (2026-07-21): Scalar mounts on first user intent (pointer /
+ * key / wheel / touch / scroll, or the explicit load button) — a mouse
+ * nudge is the smallest trusted gesture. Every navigation needs re-arming,
+ * and a gesture racing hydration is inert, so nudge until the placeholder's
+ * Load affordance gives way to the mounting reference.
+ */
+async function armReference(page: Page) {
+  await expect(async () => {
+    await page.mouse.move(12, 12);
+    await page.mouse.move(24, 24);
+    await expect(
+      page.getByRole("button", { name: "Load the interactive API reference" }),
+    ).toHaveCount(0, { timeout: 1_000 });
+  }).toPass({ timeout: 15_000 });
+}
 test.describe("API reference — /docs/api", () => {
   test("route 200s and Scalar renders operations from the spec", async ({
     page,
@@ -18,8 +35,11 @@ test.describe("API reference — /docs/api", () => {
       page.getByRole("link", { name: "Star cuesoftinc/apparule on GitHub" }),
     ).toBeVisible();
 
-    // Scalar hydrates client-side from /docs/api/openapi.yaml: the spec
-    // title and a known operation summary (GET /api/v1/me) must render.
+    // Arm the payload gate (2026-07-21): Scalar mounts on the first user
+    // gesture — a pointer move is the lightest real-visitor signal.
+    // Scalar then hydrates client-side from /docs/api/openapi.yaml: the
+    // spec title and a known operation summary (GET /api/v1/me) render.
+    await armReference(page);
     await expect(
       page.getByRole("heading", { name: "Apparule API" }),
     ).toBeVisible({ timeout: 20_000 });
@@ -31,6 +51,46 @@ test.describe("API reference — /docs/api", () => {
     // reference (showDeveloperTools: "never"; the default leaks it on
     // localhost-class hosts, which is exactly how e2e runs).
     await expect(page.getByText("Developer Tools")).toHaveCount(0);
+  });
+
+  test("payload gate: a bounce never mounts Scalar; the first gesture does", async ({
+    page,
+  }) => {
+    await page.goto("/docs/api");
+    // Pre-gesture: the SSR'd placeholder reserves the embed's viewport
+    // slice and offers the explicit Load affordance — the ~1MB Scalar
+    // chunk group is not on the bounce path.
+    await expect(
+      page.getByRole("button", { name: "Load the interactive API reference" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Apparule API" }),
+    ).toHaveCount(0);
+
+    // First gesture arms the gate; the reference streams in.
+    await armReference(page);
+    await expect(
+      page.getByRole("heading", { name: "Apparule API" }),
+    ).toBeVisible({ timeout: 20_000 });
+  });
+
+  test("payload gate: the explicit Load button serves the gesture-free path", async ({
+    page,
+  }) => {
+    await page.goto("/docs/api");
+    const load = page.getByRole("button", {
+      name: "Load the interactive API reference",
+    });
+    await expect(load).toBeVisible();
+    // SR virtual-cursor activation produces a click with no pointer or
+    // key gesture — dispatch a bare click to walk that exact path (with
+    // a toPass retry: a dispatch racing hydration is inert).
+    await expect(async () => {
+      await load.dispatchEvent("click");
+      await expect(
+        page.getByRole("heading", { name: "Apparule API" }),
+      ).toBeVisible({ timeout: 2_000 });
+    }).toPass({ timeout: 20_000 });
   });
 
   test("the OpenAPI document is served at /docs/api/openapi.yaml", async ({
@@ -47,6 +107,7 @@ test.describe("API reference — /docs/api", () => {
     page,
   }) => {
     await page.goto("/docs/api");
+    await armReference(page);
     await expect(
       page.getByRole("heading", { name: "Apparule API" }),
     ).toBeVisible({ timeout: 20_000 });
@@ -85,6 +146,7 @@ test.describe("API reference — /docs/api", () => {
   }) => {
     await page.emulateMedia({ colorScheme: "light" });
     await page.goto("/docs/api");
+    await armReference(page);
     await expect(
       page.getByRole("heading", { name: "Apparule API" }),
     ).toBeVisible({ timeout: 20_000 });
@@ -124,6 +186,7 @@ test.describe("API reference — /docs/api", () => {
 
     // The choice persists across reload (stored at apparule.theme).
     await page.reload();
+    await armReference(page);
     await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
     await expect(body).toHaveClass(/light-mode/, { timeout: 20_000 });
   });
@@ -137,6 +200,7 @@ test.describe("API reference — /docs/api", () => {
       .getByRole("link", { name: "API reference", exact: true })
       .click();
     await page.waitForURL("**/docs/api");
+    await armReference(page);
     await expect(
       page.getByRole("heading", { name: "Apparule API" }),
     ).toBeVisible({ timeout: 20_000 });

--- a/web/src/app/docs/api/page.tsx
+++ b/web/src/app/docs/api/page.tsx
@@ -6,7 +6,7 @@
 import type { Metadata } from "next";
 import { HomeNavBar } from "@/components/home/HomeNavBar";
 import { PageViewTracker } from "@/components/home/PageViewTracker";
-import { ScalarApiReference } from "@/components/docs/ScalarApiReference";
+import { ScalarApiReferenceLazy } from "@/components/docs/ScalarApiReferenceLazy";
 
 const DESCRIPTION =
   "Interactive reference for the Apparule API — every endpoint, schema and error envelope, rendered live from the repo's OpenAPI document.";
@@ -28,7 +28,7 @@ export default function ApiReferencePage() {
           viewport math to match (one coherent scroll). `isolate` opens a
           stacking context so no Scalar z-index can paint over the nav. */}
       <main className="isolate flex-1 [--scalar-custom-header-height:64px]">
-        <ScalarApiReference />
+        <ScalarApiReferenceLazy />
       </main>
       {/* Minimal footer strip — verbatim legal line only (parity canon). */}
       <footer className="border-t border-border px-6 py-4 text-caption text-text-2">

--- a/web/src/components/docs/ScalarApiReference.tsx
+++ b/web/src/components/docs/ScalarApiReference.tsx
@@ -49,6 +49,10 @@ export function ScalarApiReference() {
         // Public docs surface — never Scalar's dev toolbar (default is
         // "localhost", which leaks it in local + TEST_MODE builds).
         showDeveloperTools: "never",
+        // Same leak class: Agent Scalar auto-enables on localhost-class
+        // hosts (isLocalUrl), surfacing an AI-chat drawer that never exists
+        // on the real deploy — disable outright.
+        agent: { disabled: true },
       }}
     />
   );

--- a/web/src/components/docs/ScalarApiReferenceLazy.tsx
+++ b/web/src/components/docs/ScalarApiReferenceLazy.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+// Lazy boundary for the Scalar embed (perf audit 2026-07-21, P10 —
+// fleet-uniform across apparule/expendit/upstat): @scalar/api-reference-react
+// is the app's single heaviest dependency (~0.9MB encoded / ~3.2MB decoded
+// of route JS), so `next/dynamic` with `ssr: false` splits it out of
+// /docs/api's first-load bundle — the marketing chrome (nav SSR'd by the
+// page) hydrates without downloading or parsing Scalar, and the reference
+// streams in right after. The placeholder reserves the embed's viewport
+// slice (100dvh minus the sticky nav, via --scalar-custom-header-height
+// set by the page on <main>) so the swap-in shifts no layout (audit:
+// CLS 0.169 on this route). Theme forcing, the hidden theme toggle and
+// `showDeveloperTools: "never"` live in ScalarApiReference — unchanged.
+
+import dynamic from "next/dynamic";
+
+export const ScalarApiReferenceLazy = dynamic(
+  () => import("./ScalarApiReference").then((m) => m.ScalarApiReference),
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        role="status"
+        className="flex min-h-[calc(100dvh-var(--scalar-custom-header-height,0px))] items-center justify-center text-caption text-text-2"
+      >
+        Loading API reference…
+      </div>
+    ),
+  },
+);

--- a/web/src/components/docs/ScalarApiReferenceLazy.tsx
+++ b/web/src/components/docs/ScalarApiReferenceLazy.tsx
@@ -2,29 +2,79 @@
 
 // Lazy boundary for the Scalar embed (perf audit 2026-07-21, P10 —
 // fleet-uniform across apparule/expendit/upstat): @scalar/api-reference-react
-// is the app's single heaviest dependency (~0.9MB encoded / ~3.2MB decoded
-// of route JS), so `next/dynamic` with `ssr: false` splits it out of
-// /docs/api's first-load bundle — the marketing chrome (nav SSR'd by the
-// page) hydrates without downloading or parsing Scalar, and the reference
-// streams in right after. The placeholder reserves the embed's viewport
-// slice (100dvh minus the sticky nav, via --scalar-custom-header-height
-// set by the page on <main>) so the swap-in shifts no layout (audit:
-// CLS 0.169 on this route). Theme forcing, the hidden theme toggle and
+// is the app's single heaviest dependency, and `next/dynamic` alone only
+// MOVES it out of the first-load chunks — the async chunk group still
+// downloads right after hydration, so the settled /docs/api payload stayed
+// ~1381KB encoded / ~4787KB decoded JS (network-recorded, TEST_MODE prod
+// build). The payload diet (2026-07-21) therefore gates the import on USER
+// INTENT: the first pointer / key / wheel / touch / scroll gesture, or the
+// explicit "Load" button (the screen-reader path — SR virtual-cursor
+// navigation doesn't always dispatch key events; the button always works).
+// Bots, probes and bounces never pay for Scalar; any human interacting
+// mounts it within their first gesture, and only the page shell ships
+// eagerly. The placeholder reserves the embed's viewport slice (100dvh
+// minus the sticky nav, via --scalar-custom-header-height set by the page
+// on <main>) so the swap-in shifts no layout (audit: CLS 0.169 on this
+// route). Theme forcing, the hidden theme toggle and
 // `showDeveloperTools: "never"` live in ScalarApiReference — unchanged.
 
+import { useEffect, useState } from "react";
 import dynamic from "next/dynamic";
+import { Button } from "@/components/ui/Button";
 
-export const ScalarApiReferenceLazy = dynamic(
+// One reserved box for every pre-mount state — placeholder and loading
+// fallback share the same geometry, so arming the gate shifts nothing.
+const RESERVED_BOX =
+  "flex min-h-[calc(100dvh-var(--scalar-custom-header-height,0px))] flex-col items-center justify-center gap-3 text-caption text-text-2";
+
+const ScalarApiReference = dynamic(
   () => import("./ScalarApiReference").then((m) => m.ScalarApiReference),
   {
     ssr: false,
     loading: () => (
-      <div
-        role="status"
-        className="flex min-h-[calc(100dvh-var(--scalar-custom-header-height,0px))] items-center justify-center text-caption text-text-2"
-      >
+      <div role="status" className={RESERVED_BOX}>
         Loading API reference…
       </div>
     ),
   },
 );
+
+/** First-gesture events that signal a real visitor (all passive). */
+const INTENT_EVENTS = [
+  "pointerdown",
+  "pointermove",
+  "keydown",
+  "wheel",
+  "touchstart",
+  "scroll",
+] as const;
+
+export function ScalarApiReferenceLazy() {
+  const [wanted, setWanted] = useState(false);
+
+  useEffect(() => {
+    if (wanted) return;
+    const arm = () => setWanted(true);
+    const options: AddEventListenerOptions = { once: true, passive: true };
+    for (const event of INTENT_EVENTS) {
+      window.addEventListener(event, arm, options);
+    }
+    return () => {
+      for (const event of INTENT_EVENTS) {
+        window.removeEventListener(event, arm);
+      }
+    };
+  }, [wanted]);
+
+  if (wanted) {
+    return <ScalarApiReference />;
+  }
+
+  return (
+    <div className={RESERVED_BOX}>
+      <Button kind="quiet" size="sm" onClick={() => setWanted(true)}>
+        Load the interactive API reference
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

/docs/api's Scalar reference (`@scalar/api-reference-react`) was statically imported into the page's client graph — the route shipped ~4.2MB decoded JS before anything was interactive, and the embed mounted with no reserved space (CLS 0.169, ~850ms throttled TBT on the audit run).

Two-stage fix (fleet-uniform across apparule/expendit/upstat, audit 2026-07-21 P10):

1. **`ScalarApiReferenceLazy`** — a `next/dynamic` `ssr: false` boundary; the SSR'd placeholder reserves the embed's viewport slice (`100dvh − --scalar-custom-header-height`), so the swap-in shifts no layout. Marketing nav + legal strip stay SSR'd page chrome.
2. **Payload diet** — `ssr: false` alone only moves Scalar out of first-load chunks (the async group still downloads right after hydration), so the import is gated on **user intent**: the first pointer/key/wheel/touch/scroll gesture, or the placeholder's explicit "Load the interactive API reference" button (the SR virtual-cursor path). Bounces, bots and probes never download Scalar.

`ScalarApiReference` itself keeps the whole theme contract — forced resolved theme, hidden Scalar toggle, `showDeveloperTools: "never"` — and now also pins **Agent Scalar off** (`agent: { disabled: true }`, same localhost-leak class as the dev toolbar).

## Numbers (local prod builds)

| /docs/api | Before | After |
|---|---|---|
| First-load JS, HTML-referenced (gzip enc / dec) | 1222.5K / 4226K (19 scripts) | **203.6K / 668K** (13 scripts) |
| Settled pre-intent JS, CDP network-recorded (TEST_MODE build) | 1381K / 4787K | **223.0K / 714K** |
| Post-gesture (reference mounted) | — | 1316.5K / 4538K, full Scalar intact |
| / and /signin | 243.6K / 196.2K | 243.0K / 195.8K (hash noise) |

Note on lighter entries: Scalar's standalone browser build is the same engine at comparable weight, and a CDN would break the self-host ethos — the React wrapper behind an intent gate is the right shape.

## Tests

- `docs-api.spec.ts`: every navigation arms the gate via the `armReference` canon (nudge until the Load affordance gives way); two new tests pin the gate contract — bounce mounts nothing / first gesture mounts, and the explicit Load button serves the gesture-free SR path (bare `dispatchEvent("click")`).
- **New `docs-api-payload.spec.ts`** (byte-identical fleet spec, keyed by package name — the seo.spec.ts pattern): locks the settled pre-intent encoded-JS budget (measured + 20% headroom = 268KiB, CDP-recorded; CI prod build) AND that intent still mounts the full reference with the spec fetch intact.

## Gates

- `npm run lint` (prettier + eslint + boundaries) ✓
- `npm run typecheck` ✓
- `npm test` — 497/497 unit ✓
- `CI=1 NEXT_PUBLIC_TEST_MODE=1 PW_PORT=4438 npx playwright test` — full suite 72/72 ✓ against the TEST_MODE prod build (`next start`), payload lock included

Docs: F0-8 section of `docs/web-implementation.md` updated in-pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
