### PR TITLE
fix(web): signin legal links point at the canonical Cuesoft policies

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -484,7 +484,7 @@ feed at the base itself.
 | --- | --- | --- |
 | Part A (A1–A10 + A4b/A7b/A7c/A9b/A9c) | `/` | Public home page |
 | B2 permalink note | `/p/{post_id}` | Public post detail (MI-9 share target; request CTA for signed-in users) |
-| flows/auth.md §5 | `/signin` | Single auth screen — GoogleAuthButton + legal links **[Decided 2026-07-18, route canon]** |
+| flows/auth.md §5 | `/signin` | Single auth screen — GoogleAuthButton + legal links (Terms/Privacy open the canonical https://terms.cuesoft.io / https://privacy.cuesoft.io in a new tab) **[Decided 2026-07-18, route canon]** |
 | F0-8 / APP-004 | `/docs/api` | Public API reference — Scalar embed rendering `docs/api/openapi.yaml` (served at `/docs/api/openapi.yaml`); marketing nav chrome, minimal legal strip **[Ratified 2026-07-20]** |
 | B1 | `/dashboard` | Feed (story rail, PostCard column, freshness + suggestions) |
 | B2 | `/dashboard/explore` | Discover (masonry, filters, search-results state) |

--- a/web/e2e/signin.spec.ts
+++ b/web/e2e/signin.spec.ts
@@ -22,6 +22,19 @@ test.describe("TEST_MODE auth smoke", () => {
     );
   });
 
+  test("legal links point at the canonical Cuesoft policies", async ({
+    page,
+  }) => {
+    await page.goto("/signin");
+    await expect(page.getByRole("link", { name: "Terms" })).toHaveAttribute(
+      "href",
+      "https://terms.cuesoft.io",
+    );
+    await expect(
+      page.getByRole("link", { name: "Privacy Policy" }),
+    ).toHaveAttribute("href", "https://privacy.cuesoft.io");
+  });
+
   test("mock server serves the seeded feed", async ({ request }) => {
     const res = await request.get("/api/mock/v1/feed");
     expect(res.status()).toBe(200);

--- a/web/src/app/signin/page.tsx
+++ b/web/src/app/signin/page.tsx
@@ -25,11 +25,21 @@ export default function SignInPage() {
 
         <footer className="text-center text-micro text-text-2">
           By continuing you agree to our{" "}
-          <a href="/terms" className="text-link">
+          <a
+            href="https://terms.cuesoft.io"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-link"
+          >
             Terms
           </a>{" "}
           and{" "}
-          <a href="/privacy" className="text-link">
+          <a
+            href="https://privacy.cuesoft.io"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-link"
+          >
             Privacy Policy
           </a>
           .


### PR DESCRIPTION
## Summary
- `/signin`'s consent line linked dead internal `/terms` and `/privacy` routes; both now open the canonical **https://terms.cuesoft.io** and **https://privacy.cuesoft.io** in a new tab (`target="_blank" rel="noopener noreferrer"` — MarketingFooter's external-link idiom, same URLs the footer already ships).
- LOCK: `web/e2e/signin.spec.ts` now asserts both legal links exist with exactly the canonical hrefs.
- Docs: `/signin` route-map row in `docs/web-implementation.md` notes the canonical targets (current-system voice).

## Test plan
- CI e2e: new "legal links point at the canonical Cuesoft policies" assertion in the signin spec.
- Grep sweep: no remaining `href="/terms"` / `href="/privacy"` anywhere in `web/src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)