### PR TITLE
docs: closeout currency — changelog catch-up + voice strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- `/docs/api`'s Scalar reference now loads on user intent instead of shipping
+  eagerly with the route, cutting settled pre-intent JS from ~1.38MB to
+  ~223KB decoded (#131).
+- Auth module rehomed from `controllers/auth/` to `src/auth/` for tree-shape
+  parity with the sibling repos (#132).
+
+### Fixed
+- Contrast-token canon: AA-compliant `-text` variants for the tinted-chip
+  recipe (accent/success/warn/text-2) so tinted text clears 4.5:1 in both
+  themes (#128).
+- Signin's legal links now point at the canonical `terms.cuesoft.io` /
+  `privacy.cuesoft.io` policies instead of dead internal routes (#133).
+
 ### Added
 - Self-host install snippet goes tabbed: Docker Compose and Helm (#118).
 - SEO plumbing: sitemap, `robots.txt`, canonical URLs, an Open Graph card, and

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -660,8 +660,7 @@ products; per-product values only):
   `twitter:card = summary_large_image`.
 - **Icons** — `src/app/favicon.ico` (16/32/48/256 PNG-in-ICO) and
   `src/app/apple-icon.png` (180×180): white "A" on the accent gradient
-  tile. Replaces the stock create-next-app icon the repo had shipped since
-  scaffold (byte-identical with upstat's — neither product's mark).
+  tile (byte-identical with upstat's — neither product's mark).
 - **Provenance** — all three binaries are generated from the design tokens
   by `web/scripts/generate-brand-assets.mjs` (byte-identical across repos,
   config keyed by package name; Inter via `INTER_WOFF2` or the official


### PR DESCRIPTION
## Summary
- CHANGELOG: adds the four PRs the 2026-07-21 catch-up (#130) missed — #128 (contrast-token canon, merged 1 min before the catch-up branched), #131 (Scalar first-load diet), #132 (auth tree-shape rehome), #133 (signin legal links).
- docs/web-implementation.md: strips a changelog-archaeology clause from the apple-icon note (docs-current-system voice — describe the current asset, not what it replaced).

## Test plan
- Docs-only change; no code touched. Diff reviewed for accuracy against `gh pr view` titles/bodies for #128/#131/#132/#133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)