### PR TITLE
fix(web): a11y closeout — inert mocks, skip link, landmarks, P16 key

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -74,6 +74,9 @@
   local SVGs per the §8.1 icon note), and math/format utilities (d3-scale,
   date-fns, clsx). Fidelity is verified against the Figma file in the stage
   QA loops (screenshot comparison + token/geometry checks).
+- **Command palette**: Apparule ships none — per-product scope, not fleet
+  drift (parity review P12, 2026-07-21). The fleet ⌘K canon applies when
+  one exists.
 
 ## 2. Stage plan — W0 foundations → W3 dashboards
 

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -511,7 +511,9 @@ on it:
 
 1. **Auth**: the `AuthProvider` resolves to `TestModeAuthProvider` —
    GoogleAuthButton navigates straight to `/dashboard` as the seeded test
-   user (§6), no Firebase SDK loaded, no popup. The interface is identical
+   user (§6), no Firebase SDK loaded, no popup. Session stickiness within
+   the tab is a sessionStorage flag keyed `apparule.test-session` (fleet
+   P16 key convention: `<product>.test-session`). The interface is identical
    to the future `FirebaseAuthProvider` (X-1 Google-only, bearer-token
    shape preserved), so backend integration swaps the provider, not the
    views.

--- a/web/e2e/axe-home.spec.ts
+++ b/web/e2e/axe-home.spec.ts
@@ -1,0 +1,31 @@
+// axe gate for the marketing home (2026-07-21 a11y audit): the decorative
+// MiniScreen phone/dashboard mocks compose real, focusable component
+// instances under aria-hidden — without the real `inert` attribute they
+// shipped 8 serious axe `aria-hidden-focus` violations (keyboard focus
+// landing inside invisible mock UI). The gate pins the class at zero: no
+// critical violations, and specifically no aria-hidden-focus, ever again.
+// (Serious-level light-theme color-contrast is token work tracked
+// separately — not gated here.)
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test("home has zero critical axe violations and zero aria-hidden-focus", async ({
+  page,
+}) => {
+  await page.goto("/");
+  // Hero mock rendered — the surface the ×8 finding came from.
+  await expect(page.getByTestId("hero-phone")).toBeVisible();
+
+  const results = await new AxeBuilder({ page }).analyze();
+  const critical = results.violations.filter(
+    (violation) => violation.impact === "critical",
+  );
+  expect(
+    critical.map((violation) => `${violation.id} ×${violation.nodes.length}`),
+  ).toEqual([]);
+  expect(
+    results.violations.find(
+      (violation) => violation.id === "aria-hidden-focus",
+    ),
+  ).toBeUndefined();
+});

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -54,7 +54,9 @@ test("semantic landmarks: every dashboard screen renders one <main> and the prim
       1,
     );
     await expect(
-      page.locator('nav[aria-label="Primary"]:visible'),
+      // Prefix match: rail labels are distinct per instance
+      // ("Primary" / "Primary, compact" — landmark rules).
+      page.locator('nav[aria-label^="Primary"]:visible'),
       `${route} shows the primary nav`,
     ).toHaveCount(1);
   }

--- a/web/e2e/nav-rail-states.spec.ts
+++ b/web/e2e/nav-rail-states.spec.ts
@@ -51,8 +51,10 @@ async function settle(page: Page, route: string) {
   await page.waitForTimeout(400);
 }
 
+// Prefix match: the two rails carry distinct landmark labels
+// ("Primary" expanded / "Primary, compact" collapsed — landmark rules).
 const visibleRail = (page: Page) =>
-  page.locator('nav[aria-label="Primary"]:visible');
+  page.locator('nav[aria-label^="Primary"]:visible');
 
 const docOverflow = (page: Page) =>
   page.evaluate(
@@ -116,7 +118,7 @@ test("mobile 390: only the collapsed 72px rail exists — an expanded rail canno
     );
     // the expanded (244px) rail is display-hidden, not merely offscreen
     await expect(
-      page.locator('nav[aria-label="Primary"][data-expanded="true"]'),
+      page.locator('nav[aria-label^="Primary"][data-expanded="true"]'),
     ).toBeHidden();
     // main takes the rest of the viewport — content is never squeezed
     const mainBox = (await page.locator("main").boundingBox())!;

--- a/web/e2e/skip-link.spec.ts
+++ b/web/e2e/skip-link.spec.ts
@@ -1,0 +1,41 @@
+// P15 skip-link lock (fleet a11y canon): the skip link is the FIRST
+// focusable element on every route — one Tab from a fresh load lands on
+// it — and activating it moves focus to the page's single
+// <main id="main" tabIndex={-1}>. Runs in TEST_MODE against the mock
+// server; covers the marketing home and the authed dashboard shell.
+import { expect, test, type Page } from "@playwright/test";
+
+async function expectSkipLinkWorks(page: Page) {
+  await page.keyboard.press("Tab");
+  const link = page.getByRole("link", { name: "Skip to content" });
+  await expect(link, "first Tab lands on the skip link").toBeFocused();
+  await expect(link, "focus reveals the visually-hidden link").toBeInViewport();
+  await page.keyboard.press("Enter");
+  await expect(
+    page.locator("main#main"),
+    "activation moves focus to main",
+  ).toBeFocused();
+}
+
+test("home: first Tab is the skip link; Enter focuses <main>", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.getByTestId("hero-phone")).toBeVisible();
+  await expectSkipLinkWorks(page);
+});
+
+test("dashboard: first Tab is the skip link; Enter focuses <main>", async ({
+  page,
+}) => {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: /continue with google/i }).click();
+  await page.waitForURL("**/dashboard");
+  // Fresh document load: "first Tab" is a fresh-load guarantee (after a
+  // client-side nav Chromium keeps its sequential-focus starting point at
+  // the removed element's position). The reload also exercises session
+  // restore via the P16 sessionStorage flag (`apparule.test-session`).
+  await page.goto("/dashboard");
+  await expect(page.locator("main#main")).toBeVisible();
+  await expectSkipLinkWorks(page);
+});

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,6 +22,7 @@
         "react-dom": "19.2.7"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
@@ -174,6 +175,19 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",

--- a/web/package.json
+++ b/web/package.json
@@ -38,6 +38,7 @@
     "react-dom": "19.2.7"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",

--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -594,8 +594,13 @@ export function ComponentGallery() {
 
       <Section title="NavRail">
         <div className="flex h-96 gap-6 overflow-hidden rounded-card border border-border">
-          <NavRail activeKey="home" />
-          <NavRail activeKey="orders" expanded items={undefined} />
+          <NavRail activeKey="home" ariaLabel="Primary (collapsed demo)" />
+          <NavRail
+            activeKey="orders"
+            expanded
+            items={undefined}
+            ariaLabel="Primary (expanded demo)"
+          />
         </div>
       </Section>
 

--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -331,7 +331,11 @@ export function ComponentGallery() {
   const [payState, setPayState] = useState<PaymentBoxState>("quoted");
 
   return (
-    <main className="mx-auto flex max-w-4xl flex-col px-6 pb-24">
+    <main
+      id="main"
+      tabIndex={-1}
+      className="mx-auto flex max-w-4xl flex-col px-6 pb-24"
+    >
       <h1 className="pt-10 text-display font-bold text-text">
         Component gallery
       </h1>

--- a/web/src/app/docs/api/page.tsx
+++ b/web/src/app/docs/api/page.tsx
@@ -27,7 +27,11 @@ export default function ApiReferencePage() {
           its sticky sidebar/mobile header below the nav and shrinks its
           viewport math to match (one coherent scroll). `isolate` opens a
           stacking context so no Scalar z-index can paint over the nav. */}
-      <main className="isolate flex-1 [--scalar-custom-header-height:64px]">
+      <main
+        id="main"
+        tabIndex={-1}
+        className="isolate flex-1 [--scalar-custom-header-height:64px]"
+      >
         <ScalarApiReferenceLazy />
       </main>
       {/* Minimal footer strip — verbatim legal line only (parity canon). */}

--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -14,7 +14,11 @@ export default function ErrorPage({
   reset: () => void;
 }) {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-bg px-6 text-center">
+    <main
+      id="main"
+      tabIndex={-1}
+      className="flex min-h-screen flex-col items-center justify-center gap-4 bg-bg px-6 text-center"
+    >
       <span className="bg-accent-gradient bg-clip-text text-title font-bold text-transparent">
         Apparule
       </span>

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider, themeInitScript } from "@/design/ThemeProvider";
 import { AuthProvider } from "@/auth/AuthContext";
+import { SkipLink } from "@/components/ui/SkipLink";
 
 // Design-system type (design.md §2): Inter — the family the Figma library
 // renders — self-hosted via next/font (variable font, so the ramp's
@@ -40,6 +41,9 @@ export default function RootLayout({
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
       </head>
       <body className="min-h-full flex flex-col bg-bg text-text">
+        {/* P15 fleet canon: first focusable on every route; targets the
+            route's single <main id="main">. */}
+        <SkipLink />
         <ThemeProvider>
           <AuthProvider>{children}</AuthProvider>
         </ThemeProvider>

--- a/web/src/app/not-found.tsx
+++ b/web/src/app/not-found.tsx
@@ -6,7 +6,11 @@ import { Compass } from "lucide-react";
 
 export default function NotFound() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-bg px-6 text-center">
+    <main
+      id="main"
+      tabIndex={-1}
+      className="flex min-h-screen flex-col items-center justify-center gap-4 bg-bg px-6 text-center"
+    >
       <span className="bg-accent-gradient bg-clip-text text-title font-bold text-transparent">
         Apparule
       </span>

--- a/web/src/app/p/[id]/PostPermalink.tsx
+++ b/web/src/app/p/[id]/PostPermalink.tsx
@@ -38,7 +38,11 @@ export function PostPermalink({ postId }: { postId: string }) {
           )
         }
       />
-      <main className="mx-auto w-full max-w-4xl px-4 py-6">
+      <main
+        id="main"
+        tabIndex={-1}
+        className="mx-auto w-full max-w-4xl px-4 py-6"
+      >
         <h1 className="sr-only">Post</h1>
         <PostDetailView
           postId={postId}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -46,7 +46,7 @@ export default function HomePage() {
     <div className="flex min-h-screen flex-col bg-bg text-text">
       <PageViewTracker path="/" />
       <HomeNavBar />
-      <main className="flex-1">
+      <main id="main" tabIndex={-1} className="flex-1">
         <HeroSection />
         <StatBand />
         <WalkthroughSection />

--- a/web/src/app/signin/page.tsx
+++ b/web/src/app/signin/page.tsx
@@ -23,13 +23,16 @@ export default function SignInPage() {
 
         <GoogleAuthButton />
 
+        {/* Inline links in a text block carry a persistent underline —
+            color alone can't distinguish them (WCAG 1.4.1; axe
+            link-in-text-block, 2026-07-21 audit). */}
         <footer className="text-center text-micro text-text-2">
           By continuing you agree to our{" "}
           <a
             href="https://terms.cuesoft.io"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-link"
+            className="text-link underline underline-offset-2"
           >
             Terms
           </a>{" "}
@@ -38,7 +41,7 @@ export default function SignInPage() {
             href="https://privacy.cuesoft.io"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-link"
+            className="text-link underline underline-offset-2"
           >
             Privacy Policy
           </a>

--- a/web/src/app/signin/page.tsx
+++ b/web/src/app/signin/page.tsx
@@ -10,7 +10,11 @@ export const metadata: Metadata = {
 
 export default function SignInPage() {
   return (
-    <main className="flex flex-1 flex-col items-center justify-center px-6 py-16">
+    <main
+      id="main"
+      tabIndex={-1}
+      className="flex flex-1 flex-col items-center justify-center px-6 py-16"
+    >
       <div className="flex w-full max-w-sm flex-col items-stretch gap-8">
         <header className="flex flex-col items-center gap-2 text-center">
           <h1 className="bg-accent-gradient bg-clip-text text-display font-bold text-transparent">

--- a/web/src/auth/test-mode-auth-provider.ts
+++ b/web/src/auth/test-mode-auth-provider.ts
@@ -5,7 +5,8 @@
 import { accountRepo } from "@/models/repositories/account-repo";
 import type { AuthProviderAdapter, AuthSession, SignInResult } from "./types";
 
-const SESSION_FLAG = "apparule.testmode.signedin";
+// Fleet P16 key convention: `<product>.test-session`.
+const SESSION_FLAG = "apparule.test-session";
 
 export class TestModeAuthProvider implements AuthProviderAdapter {
   readonly name = "test-mode" as const;

--- a/web/src/components/dashboard/DashboardShell.tsx
+++ b/web/src/components/dashboard/DashboardShell.tsx
@@ -81,8 +81,15 @@ export function DashboardShell({ children }: { children: ReactNode }) {
   return (
     <ToastProvider>
       <div className="flex min-h-screen bg-bg">
+        {/* Only one rail is displayed per breakpoint, but both are in the
+            DOM — landmark labels stay distinct (landmark rules,
+            2026-07-21 audit: 2× "Primary"). */}
         <div className="sticky top-0 h-screen shrink-0 min-[1264px]:hidden">
-          <NavRail activeKey={activeKey} items={items} />
+          <NavRail
+            activeKey={activeKey}
+            items={items}
+            ariaLabel="Primary, compact"
+          />
         </div>
         <div className="sticky top-0 hidden h-screen shrink-0 min-[1264px]:block">
           <NavRail activeKey={activeKey} items={items} expanded />

--- a/web/src/components/dashboard/DashboardShell.tsx
+++ b/web/src/components/dashboard/DashboardShell.tsx
@@ -94,7 +94,11 @@ export function DashboardShell({ children }: { children: ReactNode }) {
         <div className="sticky top-0 hidden h-screen shrink-0 min-[1264px]:block">
           <NavRail activeKey={activeKey} items={items} expanded />
         </div>
-        <main className="min-w-0 flex-1">{children}</main>
+        {/* id + tabIndex: the SkipLink (root layout, P15) targets #main and
+            focus must land programmatically. */}
+        <main id="main" tabIndex={-1} className="min-w-0 flex-1">
+          {children}
+        </main>
       </div>
     </ToastProvider>
   );

--- a/web/src/components/home/HeroPhoneMock.tsx
+++ b/web/src/components/home/HeroPhoneMock.tsx
@@ -83,6 +83,7 @@ function FeedScene() {
       <TabBar
         activeKey="home"
         ordersBadge={3}
+        ariaLabel="Tabs (hero feed scene)"
         className="absolute inset-x-0 bottom-0"
       />
     </div>
@@ -131,7 +132,11 @@ function RequestScene() {
           quoteCents={4_500_000}
         />
       </div>
-      <TabBar activeKey="orders" className="absolute inset-x-0 bottom-0" />
+      <TabBar
+        activeKey="orders"
+        ariaLabel="Tabs (hero request scene)"
+        className="absolute inset-x-0 bottom-0"
+      />
     </div>
   );
 }

--- a/web/src/components/home/MiniScreen.tsx
+++ b/web/src/components/home/MiniScreen.tsx
@@ -4,7 +4,11 @@
 // deep-dive thumbs: real component instances composed at natural size and
 // scaled down, exactly how the Figma thumbs are built (mobile screens at
 // 0.4 of 390, dashboard screens at 0.42 of 1440 — canvas 195:2…/264:8…).
-// Decorative: aria-hidden + inert to pointer/tab order. `fluid` previews
+// Decorative: aria-hidden takes the mocks out of the a11y tree and the
+// real `inert` attribute takes their focusable component instances out of
+// the tab order (2026-07-21 audit: aria-hidden alone shipped 8 serious
+// axe aria-hidden-focus — keyboard focus landed inside invisible mock UI).
+// `fluid` previews
 // downscale further to their container below the natural clip width
 // (375-wide adaptation — Figma is a fixed 1440 canvas).
 import clsx from "clsx";
@@ -66,6 +70,7 @@ export function MiniScreen({
     <div
       ref={ref}
       aria-hidden
+      inert
       data-testid="mini-screen"
       className={clsx(
         "pointer-events-none select-none overflow-hidden",

--- a/web/src/components/home/dash-thumbs.tsx
+++ b/web/src/components/home/dash-thumbs.tsx
@@ -57,7 +57,14 @@ function DashShell({
       className="rounded-card border border-border bg-bg"
     >
       <div className="flex h-full bg-bg">
-        <NavRail expanded activeKey={activeKey} className="shrink-0" />
+        {/* Decorative thumb (inert MiniScreen), but landmark labels stay
+            distinct per instance for DOM-level landmark checks. */}
+        <NavRail
+          expanded
+          activeKey={activeKey}
+          ariaLabel={`Primary (${activeKey} thumb)`}
+          className="shrink-0"
+        />
         <div className="min-w-0 flex-1 px-24 py-8">{children}</div>
       </div>
     </MiniScreen>

--- a/web/src/components/home/mobile-thumbs.tsx
+++ b/web/src/components/home/mobile-thumbs.tsx
@@ -148,7 +148,11 @@ export function ExploreThumb() {
             <GridTile key={img.src} src={img.src} alt={img.alt} />
           ))}
         </div>
-        <TabBar activeKey="explore" className="absolute inset-x-0 bottom-0" />
+        <TabBar
+          activeKey="explore"
+          ariaLabel="Tabs (explore thumb)"
+          className="absolute inset-x-0 bottom-0"
+        />
       </div>
     </ThumbShell>
   );
@@ -176,6 +180,7 @@ export function OrdersThumb() {
         <TabBar
           activeKey="orders"
           ordersBadge={2}
+          ariaLabel="Tabs (orders thumb)"
           className="absolute inset-x-0 bottom-0"
         />
       </div>

--- a/web/src/components/home/sections.test.tsx
+++ b/web/src/components/home/sections.test.tsx
@@ -60,6 +60,10 @@ describe("FeatureDeepDives (A4b)", () => {
     expect(screens.length).toBeGreaterThanOrEqual(4);
     for (const node of screens) {
       expect(node).toHaveAttribute("aria-hidden");
+      // Real `inert`, not just aria-hidden: the composed component
+      // instances are focusable, and without inert they enter the tab
+      // order (8× axe aria-hidden-focus, 2026-07-21 audit).
+      expect(node).toHaveAttribute("inert");
     }
   });
 });

--- a/web/src/components/ui/NavRail.test.tsx
+++ b/web/src/components/ui/NavRail.test.tsx
@@ -30,6 +30,19 @@ describe("NavRail (§8.2b)", () => {
     );
   });
 
+  it("landmark label defaults to Primary and is overridable (landmark rules)", () => {
+    const { rerender } = renderRail();
+    expect(screen.getByRole("navigation", { name: "Primary" })).toBeVisible();
+    rerender(
+      <ThemeProvider>
+        <NavRail activeKey="home" ariaLabel="Primary, compact" />
+      </ThemeProvider>,
+    );
+    expect(
+      screen.getByRole("navigation", { name: "Primary, compact" }),
+    ).toBeVisible();
+  });
+
   it("collapsed 72 / expanded 244 widths", () => {
     const { rerender } = renderRail();
     expect(screen.getByRole("navigation")).toHaveAttribute(

--- a/web/src/components/ui/NavRail.tsx
+++ b/web/src/components/ui/NavRail.tsx
@@ -60,6 +60,9 @@ export interface NavRailProps {
   /** collapsed 72 / expanded 244; page shells expand at ≥1264px. */
   expanded?: boolean;
   supportHref?: string;
+  /** Landmark label — instances on one page must be distinct (landmark
+   * rules; 2026-07-21 audit: duplicate "Primary" landmarks). */
+  ariaLabel?: string;
   className?: string;
 }
 
@@ -68,6 +71,7 @@ export function NavRail({
   activeKey,
   expanded = false,
   supportHref = "https://clients.cuesoft.io",
+  ariaLabel = "Primary",
   className,
 }: NavRailProps) {
   const { preference, setPreference } = useTheme();
@@ -76,7 +80,7 @@ export function NavRail({
   return (
     <nav
       data-expanded={expanded}
-      aria-label="Primary"
+      aria-label={ariaLabel}
       className={clsx(
         "flex h-full flex-col border-r border-border bg-bg px-3 py-4",
         expanded ? "w-[244px]" : "w-[72px]",

--- a/web/src/components/ui/SkipLink.test.tsx
+++ b/web/src/components/ui/SkipLink.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SkipLink } from "./SkipLink";
+
+describe("SkipLink (P15 fleet a11y canon)", () => {
+  it("is a link to #main, hidden off-viewport until focused", () => {
+    render(<SkipLink />);
+    const link = screen.getByRole("link", { name: "Skip to content" });
+    expect(link).toHaveAttribute("href", "#main");
+    // Off-viewport via transform until :focus pulls it back in — it must
+    // stay in the tab order (never display:none / visibility:hidden).
+    expect(link.className).toContain("-translate-y-[150%]");
+    expect(link.className).toContain("focus:translate-y-0");
+  });
+});

--- a/web/src/components/ui/SkipLink.tsx
+++ b/web/src/components/ui/SkipLink.tsx
@@ -1,0 +1,14 @@
+// SkipLink — fleet a11y canon (P15): the first focusable element on every
+// route. Sits fixed above the viewport until focus lands on it, then slides
+// into the top-left as a token-styled pill; activating it moves focus to
+// the route's single <main id="main" tabIndex={-1}>.
+export function SkipLink() {
+  return (
+    <a
+      href="#main"
+      className="fixed left-3 top-3 z-50 -translate-y-[150%] rounded-card border border-border bg-bg-elev px-4 py-2 text-sm font-semibold text-text focus:translate-y-0"
+    >
+      Skip to content
+    </a>
+  );
+}

--- a/web/src/components/ui/TabBar.test.tsx
+++ b/web/src/components/ui/TabBar.test.tsx
@@ -28,6 +28,15 @@ describe("TabBar (§8.2)", () => {
     },
   );
 
+  it("landmark label defaults to Tabs and is overridable (landmark rules)", () => {
+    const { rerender } = render(<TabBar activeKey="home" />);
+    expect(screen.getByRole("navigation", { name: "Tabs" })).toBeVisible();
+    rerender(<TabBar activeKey="home" ariaLabel="Tabs (explore thumb)" />);
+    expect(
+      screen.getByRole("navigation", { name: "Tabs (explore thumb)" }),
+    ).toBeVisible();
+  });
+
   it("Orders badge: none by default", () => {
     render(<TabBar activeKey="home" />);
     expect(screen.queryByTestId("tab-badge")).not.toBeInTheDocument();

--- a/web/src/components/ui/TabBar.tsx
+++ b/web/src/components/ui/TabBar.tsx
@@ -43,6 +43,9 @@ export interface TabBarProps {
   activeKey: string;
   /** MI-16: unread Orders count — none / count. */
   ordersBadge?: number;
+  /** Landmark label — instances on one page must be distinct (landmark
+   * rules; 2026-07-21 audit: 4× "Tabs" landmarks on home). */
+  ariaLabel?: string;
   className?: string;
 }
 
@@ -50,11 +53,12 @@ export function TabBar({
   items = DEFAULT_TAB_ITEMS,
   activeKey,
   ordersBadge,
+  ariaLabel = "Tabs",
   className,
 }: TabBarProps) {
   return (
     <nav
-      aria-label="Tabs"
+      aria-label={ariaLabel}
       className={clsx(
         "flex h-14 items-stretch border-t border-border bg-bg",
         className,


### PR DESCRIPTION
## Closeout — apparule a11y ledger gaps (audit 2026-07-21)

Six commits, one per ledger item:

| # | Item | Fix | Lock |
|---|---|---|---|
| 1 | **MAJOR** — MiniScreen mocks shipped `aria-hidden` without real `inert` (8× axe serious `aria-hidden-focus` on home) | `inert` on the MiniScreen outer div (React 19 boolean prop); comment no longer lies | unit: every `mini-screen` asserts `inert`; e2e: new `axe-home.spec.ts` (`@axe-core/playwright`, fleet convention) pins home at zero critical + zero `aria-hidden-focus` |
| 2 | Signin consent links color-only in text block (axe `link-in-text-block` ×2) | persistent `underline underline-offset-2` on Terms/Privacy | — |
| 3 | Duplicate landmarks: 2× `nav[aria-label="Primary"]` per dashboard route; 4× "Tabs" + 4× "Primary" on home | `ariaLabel` prop on NavRail/TabBar; distinct labels per instance ("Primary" / "Primary, compact"; "Tabs (explore thumb)", …) | unit tests for the prop; e2e rail selectors prefix-match |
| 4 | Explore-search focus ring "verify" | **VERIFIED PASS — no change.** Indicator is the Input wrapper's `focus-within:border-2 border-accent-start`: full-perimeter 2px accent border; contrast #e1306c vs adjacent bg = 4.34 (light), 4.84/4.35 (dark bg/bg-elev) — all ≥3:1 (1.4.11), visible per 2.4.7. The audit probe only inspected outline/box-shadow on the input node. Ledger row updated | — |
| 5 | **P15** skip link (fleet canon) | `components/ui/SkipLink.tsx` (token-only, first child of `<body>`, href="#main"); every route `<main>` gains `id="main" tabIndex={-1}` | e2e `skip-link.spec.ts`: fresh-load first Tab lands on it, Enter moves focus to `main#main` (home + authed dashboard) |
| 6 | **P16** TEST_MODE key rename | sessionStorage flag key → `apparule.test-session` (value/semantics unchanged); documented in web-implementation.md §5. No e2e helper read the old key (journeys sign in via UI); skip-link spec exercises restore end-to-end | — |
| 7 | P12 record | web-implementation.md §1: Apparule ships no command palette — per-product scope, not drift; fleet ⌘K canon applies when one exists | — |

## axe (home)

| | aria-hidden-focus | critical |
|---|---|---|
| before (audit @455ba8c) | **8 serious** | 0 |
| after (this branch) | **0** | 0 — gated forever by `e2e/axe-home.spec.ts` |

## Gates (all on this branch, PW port 4442)

- lint (prettier + eslint + boundaries): clean (321 files)
- typecheck (`next typegen && tsc --noEmit`): clean
- vitest: **81 files / 500 tests passed** (incl. new SkipLink + inert + label locks)
- Playwright e2e: **75 passed, 1 skipped** (pre-existing CI-only docs-api payload budget)

Rebased on `origin/main` (post #134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)