### PR TITLE
chore(web): deferral-register sweep — rel canon, web manifest, SkipLink parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Changed
+- External links converge on `rel="noreferrer"` (which implies `noopener`) —
+  the fleet legal-link idiom — across anchors and `window.open` feature
+  strings (#137).
+- The skip-to-content link is now the fleet's byte-identical canonical
+  component: visually hidden via `sr-only` until keyboard focus reveals the
+  pill; the first-Tab/Enter-to-`#main` contract is unchanged (#137).
 - `/docs/api`'s Scalar reference now loads on user intent instead of shipping
   eagerly with the route, cutting settled pre-intent JS from ~1.38MB to
   ~223KB decoded (#131).
@@ -26,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `privacy.cuesoft.io` policies instead of dead internal routes (#133).
 
 ### Added
+- Web app manifest at `/manifest.webmanifest`: product identity ("Apparule —
+  Two photos. A perfect fit."), design-token colors, and the committed icon
+  set — locked by the shared SEO spec's generic manifest assertion (#137).
 - Self-host install snippet goes tabbed: Docker Compose and Helm (#118).
 - SEO plumbing: sitemap, `robots.txt`, canonical URLs, an Open Graph card, and
   a real brand favicon in place of the placeholder (#129).

--- a/web/e2e/seo.spec.ts
+++ b/web/e2e/seo.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from "@playwright/test";
 
 /**
  * SEO plumbing lock (fleet, 2026-07-21): sitemap + robots + canonical +
- * og/twitter card + product-branded icons.
+ * og/twitter card + product-branded icons + web manifest.
  *
  * This spec is BYTE-IDENTICAL across apparule/expendit/upstat (tooling
  * canon) — per-product expectations live in the config below keyed by
@@ -151,4 +151,26 @@ test("icons are product-branded and distinct from the sibling products", async (
   const appleRes = await request.get(appleUrl.pathname + appleUrl.search);
   expect(appleRes.status()).toBe(200);
   expect(appleRes.headers()["content-type"]).toContain("image/png");
+});
+
+test("web manifest is served and carries the product identity", async ({
+  request,
+}) => {
+  const res = await request.get("/manifest.webmanifest");
+  expect(res.status()).toBe(200);
+  const manifest = JSON.parse(await res.text()) as {
+    name: string;
+    short_name: string;
+    icons: { src: string }[];
+  };
+  // Identity: this product's own name — never a sibling's or a placeholder.
+  expect(manifest.name.toLowerCase()).toContain(pkgName);
+  expect(manifest.short_name.toLowerCase()).toContain(pkgName);
+  // Icons: at least one, and every listed asset actually resolves.
+  expect(manifest.icons.length).toBeGreaterThan(0);
+  for (const icon of manifest.icons) {
+    const iconUrl = new URL(icon.src, product.base);
+    const iconRes = await request.get(iconUrl.pathname + iconUrl.search);
+    expect(iconRes.status(), `manifest icon ${icon.src} resolves`).toBe(200);
+  }
 });

--- a/web/src/app/docs/api/page.tsx
+++ b/web/src/app/docs/api/page.tsx
@@ -42,7 +42,7 @@ export default function ApiReferencePage() {
             <a
               href="https://cuesoft.io"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noreferrer"
               className="hover:text-text"
             >
               Cuesoft Inc.
@@ -51,7 +51,7 @@ export default function ApiReferencePage() {
             <a
               href="https://cuelabs.cuesoft.io"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noreferrer"
               className="hover:text-text"
             >
               CueLABS™ Division
@@ -60,7 +60,7 @@ export default function ApiReferencePage() {
             <a
               href="https://github.com/cuesoftinc/apparule/blob/main/LICENSE"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noreferrer"
               className="hover:text-text"
             >
               MIT License

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider, themeInitScript } from "@/design/ThemeProvider";
 import { AuthProvider } from "@/auth/AuthContext";
-import { SkipLink } from "@/components/ui/SkipLink";
+import SkipLink from "@/components/ui/SkipLink";
 
 // Design-system type (design.md §2): Inter — the family the Figma library
 // renders — self-hosted via next/font (variable font, so the ramp's

--- a/web/src/app/manifest.ts
+++ b/web/src/app/manifest.ts
@@ -1,0 +1,33 @@
+import type { MetadataRoute } from "next";
+
+// Web app manifest (fleet SEO plumbing): installability identity served at
+// /manifest.webmanifest, linked automatically from every route's <head>.
+// Identity mirrors the home metadata (page.tsx); colors are the design.md §2
+// light tokens — `bg` #ffffff, `accent-start` #e1306c (light-primary
+// product; manifest colors can't bind CSS vars, so the hexes mirror
+// src/design/tokens.css and must move with it). Icons are the committed
+// set: the multi-size favicon.ico plus the 180×180 apple-icon.png.
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "Apparule — Two photos. A perfect fit.",
+    short_name: "Apparule",
+    description:
+      "Apparule turns two phone photos into a complete, private body-measurement profile. Commission Lagos designers who sew to your measurements — no size charts, no guesswork.",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#ffffff",
+    theme_color: "#e1306c",
+    icons: [
+      {
+        src: "/favicon.ico",
+        sizes: "16x16 32x32 48x48 256x256",
+        type: "image/x-icon",
+      },
+      {
+        src: "/apple-icon.png",
+        sizes: "180x180",
+        type: "image/png",
+      },
+    ],
+  };
+}

--- a/web/src/app/signin/page.tsx
+++ b/web/src/app/signin/page.tsx
@@ -35,7 +35,7 @@ export default function SignInPage() {
           <a
             href="https://terms.cuesoft.io"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
             className="text-link underline underline-offset-2"
           >
             Terms
@@ -44,7 +44,7 @@ export default function SignInPage() {
           <a
             href="https://privacy.cuesoft.io"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
             className="text-link underline underline-offset-2"
           >
             Privacy Policy

--- a/web/src/components/dashboard/moderation/ModerationView.tsx
+++ b/web/src/components/dashboard/moderation/ModerationView.tsx
@@ -28,7 +28,7 @@ export function ModerationView() {
             window.open(
               "https://cuesoft.gitbook.io/apparule/system/data-model",
               "_blank",
-              "noopener",
+              "noreferrer",
             )
           }
         >

--- a/web/src/components/dashboard/onboarding/OnboardingView.tsx
+++ b/web/src/components/dashboard/onboarding/OnboardingView.tsx
@@ -274,7 +274,7 @@ export function OnboardingView() {
                     <a
                       href={SUPPORT_URL}
                       target="_blank"
-                      rel="noopener noreferrer"
+                      rel="noreferrer"
                       className="underline"
                     >
                       Contact support

--- a/web/src/components/home/CommunitySection.tsx
+++ b/web/src/components/home/CommunitySection.tsx
@@ -19,7 +19,7 @@ export function CommunitySection() {
           <a
             href="https://cuesoft.gitbook.io/apparule/product/roadmap"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
             className="text-body font-semibold text-link hover:underline"
           >
             Roadmap →

--- a/web/src/components/home/ComparisonSection.tsx
+++ b/web/src/components/home/ComparisonSection.tsx
@@ -32,7 +32,7 @@ export function ComparisonSection() {
             window.open(
               "https://cuesoft.gitbook.io/apparule/system/deployment",
               "_blank",
-              "noopener",
+              "noreferrer",
             );
           }}
         />

--- a/web/src/components/home/DevelopersSection.tsx
+++ b/web/src/components/home/DevelopersSection.tsx
@@ -68,7 +68,7 @@ export function DevelopersSection() {
         <a
           href={`${GITHUB_REPO_URL}/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22`}
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
           onClick={() => {
             track("github_click", { section: "developers" });
             track("contribute_click", { link: "good_first_issues" });
@@ -81,7 +81,7 @@ export function DevelopersSection() {
         <a
           href={`${GITHUB_REPO_URL}/blob/main/CONTRIBUTING.md`}
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
           onClick={() => {
             track("github_click", { section: "developers" });
             track("contribute_click", { link: "contributing" });
@@ -93,7 +93,7 @@ export function DevelopersSection() {
         <a
           href="https://discord.gg/CDfZxxrxbb"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
           onClick={() => track("contribute_click", { link: "discord" })}
           className={LINK_CLASSES}
         >
@@ -103,7 +103,7 @@ export function DevelopersSection() {
         <a
           href={GITHUB_REPO_URL}
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
           data-testid="dev-star-badge"
           onClick={() => track("github_click", { section: "developers" })}
           className="inline-flex h-9 items-center gap-2 rounded-pill border border-border px-4 text-body font-semibold text-text transition-transform duration-120 ease-standard hover:-translate-y-0.5 hover:bg-border/30 motion-reduce:transition-none motion-reduce:hover:translate-y-0"

--- a/web/src/components/home/FeatureDeepDives.tsx
+++ b/web/src/components/home/FeatureDeepDives.tsx
@@ -76,7 +76,7 @@ export function FeatureDeepDives() {
                 <a
                   href={panel.href}
                   target="_blank"
-                  rel="noopener noreferrer"
+                  rel="noreferrer"
                   className="mt-6 inline-block text-body font-semibold text-link hover:underline"
                 >
                   Read more →

--- a/web/src/components/home/SelfHostSection.tsx
+++ b/web/src/components/home/SelfHostSection.tsx
@@ -61,7 +61,7 @@ export function SelfHostSection() {
           <a
             href="https://cuesoft.gitbook.io/apparule/system/deployment"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
             onClick={() => track("self_host_click", { section: "self-host" })}
             className="mt-4 inline-block text-body font-semibold text-link hover:underline"
           >

--- a/web/src/components/home/SmplSection.tsx
+++ b/web/src/components/home/SmplSection.tsx
@@ -22,7 +22,7 @@ export function SmplSection() {
           <a
             href="https://cuesoft.gitbook.io/apparule/system/architecture"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
             className="mt-6 inline-block text-body font-semibold text-link hover:underline"
           >
             Read the deep-dive on GitBook →

--- a/web/src/components/home/interactive.test.tsx
+++ b/web/src/components/home/interactive.test.tsx
@@ -200,7 +200,7 @@ describe("ComparisonSection (A9)", () => {
     expect(open).toHaveBeenCalledWith(
       "https://cuesoft.gitbook.io/apparule/system/deployment",
       "_blank",
-      "noopener",
+      "noreferrer",
     );
     open.mockRestore();
   });

--- a/web/src/components/ui/CommunityCard.tsx
+++ b/web/src/components/ui/CommunityCard.tsx
@@ -57,7 +57,7 @@ export function CommunityCard({
         size="sm"
         aria-label="Join Discord"
         className="shrink-0"
-        onClick={() => window.open(discordHref, "_blank", "noopener")}
+        onClick={() => window.open(discordHref, "_blank", "noreferrer")}
       >
         Join
       </Button>

--- a/web/src/components/ui/MarketingFooter.tsx
+++ b/web/src/components/ui/MarketingFooter.tsx
@@ -115,7 +115,7 @@ export function MarketingFooter({
           <a
             href="https://cuesoft.io"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
             className="hover:text-text"
           >
             Cuesoft Inc.
@@ -124,7 +124,7 @@ export function MarketingFooter({
           <a
             href="https://cuelabs.cuesoft.io"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
             className="hover:text-text"
           >
             CueLABS™ Division
@@ -133,7 +133,7 @@ export function MarketingFooter({
           <a
             href="https://github.com/cuesoftinc/apparule/blob/main/LICENSE"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
             className="hover:text-text"
           >
             MIT License
@@ -147,7 +147,7 @@ export function MarketingFooter({
           <a
             href="https://github.com/cuesoftinc/apparule/blob/main/SECURITY.md"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
             className="flex items-center gap-1 hover:text-text"
           >
             <ShieldCheck size={14} aria-hidden />

--- a/web/src/components/ui/MarketingNav.tsx
+++ b/web/src/components/ui/MarketingNav.tsx
@@ -145,7 +145,7 @@ export function MarketingNav({
           <a
             href={githubHref}
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
             data-testid="star-badge"
             aria-label={githubAriaLabel}
             onClick={onGithubClick}
@@ -212,7 +212,7 @@ export function MarketingNav({
           <a
             href={githubHref}
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
             aria-label={githubAriaLabel}
             onClick={() => {
               onGithubClick?.();

--- a/web/src/components/ui/NavRail.tsx
+++ b/web/src/components/ui/NavRail.tsx
@@ -122,7 +122,7 @@ export function NavRail({
         <a
           href={supportHref}
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
           className={itemClasses(false, expanded)}
         >
           <Info size={24} />

--- a/web/src/components/ui/SkipLink.test.tsx
+++ b/web/src/components/ui/SkipLink.test.tsx
@@ -1,15 +1,15 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { SkipLink } from "./SkipLink";
+import SkipLink from "./SkipLink";
 
-describe("SkipLink (P15 fleet a11y canon)", () => {
-  it("is a link to #main, hidden off-viewport until focused", () => {
+describe("SkipLink (fleet a11y canon)", () => {
+  it("is a link to #main, visually hidden until focused", () => {
     render(<SkipLink />);
     const link = screen.getByRole("link", { name: "Skip to content" });
     expect(link).toHaveAttribute("href", "#main");
-    // Off-viewport via transform until :focus pulls it back in — it must
+    // Visually hidden via sr-only until :focus reveals the pill — it must
     // stay in the tab order (never display:none / visibility:hidden).
-    expect(link.className).toContain("-translate-y-[150%]");
-    expect(link.className).toContain("focus:translate-y-0");
+    expect(link.className).toContain("sr-only");
+    expect(link.className).toContain("focus:not-sr-only");
   });
 });

--- a/web/src/components/ui/SkipLink.tsx
+++ b/web/src/components/ui/SkipLink.tsx
@@ -1,14 +1,17 @@
-// SkipLink — fleet a11y canon (P15): the first focusable element on every
-// route. Sits fixed above the viewport until focus lands on it, then slides
-// into the top-left as a token-styled pill; activating it moves focus to
-// the route's single <main id="main" tabIndex={-1}>.
-export function SkipLink() {
-  return (
-    <a
-      href="#main"
-      className="fixed left-3 top-3 z-50 -translate-y-[150%] rounded-card border border-border bg-bg-elev px-4 py-2 text-sm font-semibold text-text focus:translate-y-0"
-    >
-      Skip to content
-    </a>
-  );
-}
+// SkipLink — fleet canon (SKILL.md a11y closeout canons, 2026-07-21).
+// First focusable on every route; visually hidden until keyboard focus;
+// the pill appearing on :focus IS the focus indication. Byte-identical
+// across products (shared-files canon) — utility names only, no
+// product-specific tokens.
+import React from "react";
+
+const SkipLink: React.FC = () => (
+  <a
+    href="#main"
+    className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:block focus:rounded-md focus:border focus:border-border focus:bg-bg-elev focus:px-4 focus:py-2 focus:text-[13px] focus:font-medium focus:text-text"
+  >
+    Skip to content
+  </a>
+);
+
+export default SkipLink;


### PR DESCRIPTION
Deferral-register sweep for the web program — closes the four parked items in one pass.

## What's here

1. **`rel="noreferrer"` convergence** — `noopener noreferrer` (and `noopener`-only `window.open` feature strings) converge on the fleet idiom `noreferrer`, which implies `noopener`. Grep-verified: zero `noopener` remains under `web/`.
2. **Web app manifest** — `app/manifest.ts` serves `/manifest.webmanifest`: identity from the home metadata ("Apparule — Two photos. A perfect fit."), design.md §2 light tokens (`bg` #ffffff, `accent-start` #e1306c), and the committed icon set (multi-size `favicon.ico` + 180×180 `apple-icon.png`). `seo.spec.ts` gains the fleet's generic manifest lock (200 + product-named identity + every listed icon resolves); the spec stays byte-identical across the three products.
3. **SkipLink byte-parity** — the component is now the shared-files canonical (sha256 `907bb788…`): `sr-only` until focus, default export. Consumers and the unit lock adapted; the e2e contract (first Tab → link, Enter → `#main`) is unchanged.
4. **live-TTFB waive check** — verified against this PR's CI route table: see the PR discussion/report for the `/` static-vs-dynamic verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
