### PR TITLE
docs(mobile): legacy quarantine pattern — staged removal

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -237,18 +237,23 @@ before public launch. Alternative: commission the brand pass first.
   `StatefulShellRoute` driving the Home·Explore·➕·Orders·Profile tab
   shell (pages.md Part C) with one top-level auth `redirect` off the
   session provider. ☑
-- **M-3 Legacy auth deletion — X-1 execution (RATIFIED 2026-07-21)**: the
-  entire legacy `lib/src/features/auth/` (9 files: password + phone/SMS +
-  email-OTP flows, the `sms_autofill` dependency, `form_provider`) is
-  **deleted, not migrated** — canon-violation CV-1 in the legacy audit
-  ledger. Replacement is the Google-only Firebase flow (§9 of
-  mobile-implementation.md); the exact screen-removal list already
-  ratified for the web auth surface applies here to its Flutter
-  equivalents, per **flows/auth.md §5**: `login_page` becomes the single
-  auth screen, and `sign_up_form`, `sign_up_screen`, `forgot_password`,
-  `reset_password`, `verify_email`, `sms_verification`, `verify_account`
-  are retired by name. `models/user.dart` (prefs-string identity, CV-2)
-  drops with it. ☑
+- **M-3 Legacy auth retirement — X-1 execution via the quarantine
+  pattern (RATIFIED 2026-07-21, revised same day per user directive)**:
+  the entire legacy `lib/src/features/auth/` (9 files: password +
+  phone/SMS + email-OTP flows, the `sms_autofill` dependency,
+  `form_provider`) is **quarantined into `lib/legacy/` at the auth
+  cutover, never migrated** — canon-violation CV-1 in the legacy audit
+  ledger — and actually removed only after the Google-only replacement
+  ships AND the user gives an explicit removal go (the web legacy
+  pattern: route-by-route replacement, end-of-program authorized
+  sweeps). Replacement is the Google-only Firebase flow (§9 of
+  mobile-implementation.md); the retirement list per **flows/auth.md
+  §5**: `login_page` becomes the single auth screen, and
+  `sign_up_form`, `sign_up_screen`, `forgot_password`, `reset_password`,
+  `verify_email`, `sms_verification`, `verify_account` are retired by
+  name. `models/user.dart` (prefs-string identity, CV-2) quarantines
+  with it. Quarantined code is excluded from assets, analysis, CI, and
+  builds (mobile-implementation.md §11). ☑
 - **M-4 Android API floor (RATIFIED 2026-07-21)**: **minSdkVersion 24**
   (the legacy value, confirmed against the ratified standard's floor) —
   carried forward, not raised. The Android project is regenerated to

--- a/docs/mobile-implementation.md
+++ b/docs/mobile-implementation.md
@@ -414,20 +414,30 @@ DEBUG-key config); `README.md`/`.metadata`/`.gitignore` (the committed
 `.gitignore` is presently the Flutter *framework* repo's own template, not
 this project's).
 
-**DROP (documented, not migrated)** — `welcome_screen.dart` (no-op icons,
-superseded by the C1 flow); all 9 files under `lib/src/features/auth/` plus
-`form_provider` (password/phone/OTP auth — X-1 violation, CV-1; retired
-**by name** per flows/auth.md §5, same list as §9); `measurement.dart`'s
-menu (empty `onTap`, CV-4); the theme trio (navy/blue "light" theme,
-grey "dark" theme, asymmetric radii — rebuilt from tokens, CV-3);
-`my_back_button.dart`; `number_text_input_formatter.dart`; `models/user.dart`
-(prefs-string identity model, CV-2); the `sq` locale + `Language` class
-(dead — no picker UI ever called `MyApp.setLocale`, CV-6); the tracked
-`flutter/web/` scaffold (unused platform residue — de-registered, not just
-deleted); the outer `mobile/android/.gitkeep` and `mobile/ios/.gitkeep`
-stubs (real platform dirs already live inside `mobile/flutter/`); and the
-following assets: `Blur`, `image2`, `apparule.png`, `howToMeasure`,
-`takeMeasure`, `measurement.jpg`, `arrow.png`, `check.svg`.
+**QUARANTINE → staged removal (the web legacy pattern, user directive
+2026-07-21)** — superseded code is never deleted up front: it moves
+structure-preserved into `mobile/flutter/lib/legacy/` (assets into
+`assets/legacy/`, the old Android tree into `legacy/android-agp7/`, the
+unused web scaffold into `legacy/web-scaffold/`), excluded from
+`pubspec` assets, analysis, CI scope, and builds. A quarantined unit is
+actually removed only when BOTH hold: its replacement has shipped and
+the user gives an explicit removal go (mirroring web's route-by-route
+replacement and end-of-program authorized sweeps). The quarantine set:
+`welcome_screen.dart` (no-op icons, superseded by the C1 flow); all 9
+files under `lib/src/features/auth/` plus `form_provider`
+(password/phone/OTP auth — X-1 violation, CV-1; retired **by name** per
+flows/auth.md §5, same list as §9 — quarantined at the auth cutover,
+removed after C1 ships); `measurement.dart`'s menu (empty `onTap`,
+CV-4); the theme trio (navy/blue "light" theme, grey "dark" theme,
+asymmetric radii — rebuilt from tokens, CV-3); `my_back_button.dart`;
+`number_text_input_formatter.dart`; `models/user.dart` (prefs-string
+identity model, CV-2); the `sq` locale + `Language` class (dead — no
+picker UI ever called `MyApp.setLocale`, CV-6); the tracked
+`flutter/web/` scaffold (platform de-registered in `.metadata`); and
+the assets `Blur`, `image2`, `apparule.png`, `howToMeasure`,
+`takeMeasure`, `measurement.jpg`, `arrow.png`, `check.svg`. The only
+true deletions: the outer `mobile/android/.gitkeep` and
+`mobile/ios/.gitkeep` placeholder stubs (empty markers, not code).
 
 **Toolchain findings folded into the restructure phase (§1)**: Dart
 constraint `>=3.1.2` (Sept 2023) raised to the ratified floor; `.metadata`


### PR DESCRIPTION
User directive: mobile follows the web legacy pattern — superseded code moves to lib/legacy/ (excluded from assets/analysis/CI/builds) and is deleted only after its replacement ships with an explicit removal go. §11 disposition and M-3 revised accordingly; only the empty .gitkeep stubs remain true deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)