### PR TITLE
docs(mobile): M-7 — two flavors, sandbox is production

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -280,3 +280,14 @@ before public launch. Alternative: commission the brand pass first.
   `mediapipe_2d_v2` height-scale correction, capture-qc.md's
   first-failure-only QC surfacing, and a manual-entry fallback; results
   save into the vault (C7). ☑
+- **M-7 Flavor model — two flavors, sandbox is production (RATIFIED
+  2026-07-22, user directive)**: mobile ships exactly `dev` (fake
+  repositories, `applicationIdSuffix ".dev"`) and `prod` (bare
+  `io.cuesoft.apparule`, Firebase `sandbox-e306a`, Doppler `stg`
+  config) — the CueLABS environment model treats the sandbox account
+  as production, so a `prd`-vs-`stg` split encodes an environment
+  that does not exist (X-6). The generic dev/stg/prd trio from the
+  industry-standard research is explicitly rejected. A third flavor
+  appears only if a separate production environment is ratified;
+  the bare application id already rides `prod` so identity migrates
+  cleanly. ☑

--- a/docs/mobile-implementation.md
+++ b/docs/mobile-implementation.md
@@ -63,17 +63,27 @@ unauthorized independent of this doc (roadmap.md).
   goes read-only 2026-12-02, so no new CocoaPods dependency is added; the
   existing iOS shell (salvaged per §11) migrates its dependency graph to
   SwiftPM as part of the restructure, not deferred to a later cleanup.
-- **Flavors**: `dev` / `stg` / `prd` — `applicationIdSuffix` (Android) and
-  matching iOS schemes/xcconfigs, an `appFlavor` constant, flavor-scoped
-  assets, three `main_<flavor>.dart` entrypoints (`main.dart` = `prd`).
+- **Flavors — exactly two (M-7)**: `dev` and `prod`. The CueLABS
+  environment model has ONE real environment: the sandbox account is
+  production for these projects (user directive 2026-07-22; X-6). `dev`
+  carries `applicationIdSuffix ".dev"` and rides the fake repositories;
+  `prod` carries the bare `io.cuesoft.apparule` id and runs on
+  `sandbox-e306a`. Two `main_<flavor>` entrypoints (`main.dart` =
+  `prod`, the default; `main_dev.dart` = fakes). A third flavor appears
+  only if a separate production environment is ever ratified — the bare
+  id already sits on `prod`, so identity would migrate cleanly.
 - **Env from Doppler**: secrets reach the app via
-  `--dart-define-from-file=env/<flavor>.json`, generated from the `apparule`
-  Doppler project's `dev`/`stg`/`prd` configs (X-5) and gitignored — no
-  `envied` or build-time obfuscation stands in for real secret handling.
+  `--dart-define-from-file=env/<flavor>.json`, generated from the
+  `apparule` Doppler project (X-5) and gitignored — `dev` reads the
+  `dev` config; `prod` reads the **`stg` config** (the Doppler config
+  name stays `stg`; the account it configures is CueLABS production).
+  No `envied` or build-time obfuscation stands in for real secret
+  handling.
 - **Firebase per flavor**: `flutterfire configure` run once per flavor
-  against `sandbox-e306a`, producing three registrations →
-  `firebase_options_{dev,stg,prd}.dart` (committed; no secrets live in these
-  files beyond the public API key model Firebase already ships with).
+  against `sandbox-e306a`, producing two registrations →
+  `firebase_options_dev.dart` + `firebase_options.dart` (prod)
+  (committed; no secrets live in these files beyond the public API key
+  model Firebase already ships with).
 - Icons/splash: `flutter_launcher_icons` + `flutter_native_splash`, one
   config block per flavor. Version stamp `x.y.z+build` — humans own
   `x.y.z`, CI stamps the build number from `GITHUB_RUN_NUMBER`.

--- a/docs/mobile-implementation.md
+++ b/docs/mobile-implementation.md
@@ -44,8 +44,8 @@ Four phases, each closing before the next opens (mirrors the audit ledger's
    repositories reading the seed narrative (§6). This is the bulk of the
    work and where the legacy salvage/rewrite/drop ledger (§11) executes.
 4. **API last** — `*Remote` repositories implement the same interfaces the
-   fakes already satisfy; `main.dart` (prd) swaps the provider overrides.
-   No screen or ViewModel changes at this step by construction.
+   fakes already satisfy; `main.dart` (prod, M-7) swaps the provider
+   overrides. No screen or ViewModel changes at this step by construction.
 
 Backend integration timing follows the fleet rule: mobile's API wiring and
 the backend services it calls remain separately gated — this doc covers
@@ -115,12 +115,10 @@ mobile/flutter/
     seed/                     # §6 — dev/stg-flavor-scoped narrative JSON
   android/ ios/                # INSIDE the flutter project root (legacy had them outside — §11)
   lib/
-    main.dart                  # prd entrypoint
-    main_stg.dart
+    main.dart                  # prod entrypoint (sandbox = CueLABS production, M-7)
     main_dev.dart               # fakes wired by default
     firebase_options_dev.dart
-    firebase_options_stg.dart
-    firebase_options_prd.dart
+    firebase_options.dart       # prod
     l10n/
       app_en.arb
       generated/               # gitignored, regenerates on `pub get`
@@ -184,8 +182,8 @@ enforces the conventions in CI. Widgets are `ConsumerWidget`/
 rather than hand-rolled loading-state fields.
 
 DI = **provider overrides per environment** — `main_dev.dart` /
-`main_stg.dart` / `main.dart` each build a `ProviderScope` with the
-repository providers overridden to `*Fake` or `*Remote` accordingly (§6).
+`main.dart` each build a `ProviderScope` with the repository providers
+overridden to `*Fake` or `*Remote` accordingly (§6, M-7).
 No second DI container (`get_it` is not introduced) — Riverpod's provider
 graph is the only injection mechanism, matching the ratified rejection of
 Bloc (boilerplate at this app's size) and GetX (not standards-grade). The
@@ -243,16 +241,14 @@ implementations satisfying the same interface — the compass-app pattern
 (standards-research.md item 7). ViewModels depend only on the abstract
 type; nothing above the repository boundary knows which implementation is
 active. This is the mobile analogue of web's `TEST_MODE` seam
-(web-implementation.md §5): the three entrypoints (`main_dev.dart`,
-`main_stg.dart`, `main.dart`) pick the provider-override set, so `dev`/`stg`
-run entirely on fakes today and `prd` is where `*Remote` is introduced when
-API wiring lands (§1 phase 4) — no `if (kDebugMode)` branching inside
+(web-implementation.md §5): the two entrypoints (`main_dev.dart`,
+`main.dart`) pick the provider-override set (M-7) — both ride fakes
+today; `main.dart` (prod) is where `*Remote` is introduced when API
+wiring lands (§1 phase 4). No `if (kDebugMode)` branching inside
 feature code.
 
-`*Fake` repositories read seeded JSON from `assets/seed/<flavor>/` — flavor
-scoping exists because `dev` and `stg` fakes may want different data
-volumes for local iteration vs. demo/QA use, though both draw from the same
-narrative. Seed files, one per domain (mirrors the mock server's grouping,
+`*Fake` repositories read seeded JSON from `assets/seed/` — the
+dev-flavor asset scope keeps seed data out of prod bundles. Seed files, one per domain (mirrors the mock server's grouping,
 web-implementation.md §6), tell the **same story** as the web dashboard's
 seed so a person moving between the phone and the web app sees one
 coherent world, not two disconnected demos:


### PR DESCRIPTION
User directive: the sandbox account is production for CueLABS projects. Flavors reduce to dev + prod (bare id on prod, Doppler stg config documented as the production config); the generic dev/stg/prd trio is rejected per X-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)