### PR TITLE
feat(web): two-photo wave — M-10/M-11/M-12 + parity-audit fixes (B4 upload rebuild, create chooser, entity-nav, signin gate, danger ladder, M-9 AppBar)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Web B4 two-photo upload capture (M-10 + M-12): the vault measurement
+  flow is the two-file upload per the dashboard canvas frame — labeled
+  Front/Side dropzones with per-pose states (empty / uploaded thumbnail
+  + Replace / QC-error + hint chip), a Height (cm) row (100–230,
+  prefilled from the latest capture session — never a fabricated
+  default), and the "Get measurements" CTA into the processing
+  constellation and results stagger. QC is per pose: the 422 names the
+  failing pose, only that pose's file re-picks (an accepted pose is
+  never discarded), `QCHintChip` gains the `not_side_profile` code and
+  the side-pose arms copy, and the mock reports the FIRST failure by
+  the capture-qc.md table order (pre-checks before pose rows). The
+  options sheet and upload view carry the "Best experience: guided
+  capture on the Apparule app" hint; `openapi.yaml` POST /me/sessions
+  takes multipart `image_front` + `image_side` + `input_height_cm`.
+- Web Create chooser (M-11 unified create semantics): the rail's Create
+  pillar opens the two-option chooser — "Take measurements" (primary,
+  accent border → B4 capture options via `/dashboard/vault?capture=1`)
+  and "Post an outfit" (→ B5; designers see "Share a look with its fit
+  data", non-designers "Become a designer to post"). NavRail items gain
+  an `onSelect` action form (button + `aria-haspopup`); decorative
+  marketing rails stay inert.
+- Web `Button` kind `quiet-danger` — the danger-ladder row rung (quiet
+  chrome + error-token label, Figma 501:2), with gallery + test
+  coverage.
+
+### Changed
+
+- Web manual entry carries no height: `input_height_cm` is `null` for
+  `method: manual` (nullable ruling; the fabricated 168 default is
+  gone), out-of-range values prompt the flows/vault.md §2 "double-check"
+  advisory (non-blocking), and the `waist_girth` advisory max aligns to
+  the canonical 150.
+- Web AppBar sub/over-media titles center on the FULL bar width (M-9):
+  an absolute, full-width, center-aligned layer over the bar — never an
+  in-flow element between the slots; root's left wordmark exempt.
+  Propagates to order detail, the settings sub-screens, /p/{id}, the
+  marketing phone mocks and the dev gallery.
+- Web B7 Account & data delete-all rides the full danger ladder:
+  quiet-danger row rung → armed sheet with typed-DELETE gate, "Export
+  everything first" escape hatch, and Cancel (filled destructive only
+  on the armed surface).
+
+### Fixed
+
+- Web author links (entity-navigation rule; the web sibling of the
+  user-found mobile PostCard bug): PostCard header avatar+username and
+  the caption's leading username link to the designer profile
+  (prop-gated — marketing mocks stay inert), PostDetailView's header
+  link wraps the avatar (no dead zone), and CommentRow's avatar +
+  username link to the author profile.
+- Web session-restore hardening (flows/auth.md §2): `SignInGate`
+  replaces a signed-in visitor to /dashboard (a signed-in user never
+  sees /signin), the restore effect catches provider rejections as
+  signed-out (no stranded spinner), and the provider contract
+  (resolve null, never reject) is documented on
+  `AuthProviderAdapter.restore()`. e2e adds the cold-start pair.
+- Webcam capture flow REMOVED from web (M-12 — rejected UX:
+  desk-height lens, unreachable controls): `WebcamCaptureSheet`, its
+  idle tips and the webcam-upload option mode are deleted;
+  `CaptureOptionCard` renames the axis to `photo-upload` ("Upload
+  photos · Two photos — we measure automatically"; mobile thumbs keep
+  the C7 camera title). Mobile keeps the live guided camera.
+
 - Mobile real boot flow over fakes (user directive 2026-07-22, web
   TEST_MODE parity): cold start → native splash → session-restore gate →
   C1 when no session / straight into the tab shell when one persisted;

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -49,15 +49,15 @@ paths:
   /api/v1/me/sessions:
     post:
       tags: [vault]
-      summary: Create own measurement session (self-customer alias, data-model §6.1)
+      summary: Create own measurement session (self-customer alias, data-model §6.1; two-photo capture per M-10 — both images ride one request with one Idempotency-Key)
       parameters: [{ $ref: "#/components/parameters/IdempotencyKey" }]
       requestBody:
         content:
           multipart/form-data:
-            schema: { type: object, required: [image], properties: { image: { type: string, format: binary, description: "<=10MB JPEG/PNG/HEIC" }, input_height_cm: { type: number, minimum: 100, maximum: 230 } } }
+            schema: { type: object, required: [image_front, image_side], properties: { image_front: { type: string, format: binary, description: "front pose, <=10MB JPEG/PNG/HEIC" }, image_side: { type: string, format: binary, description: "side pose (right profile), <=10MB JPEG/PNG/HEIC" }, input_height_cm: { type: number, minimum: 100, maximum: 230 } } }
       responses:
         "201": { description: Session with measurements, content: { application/json: { schema: { $ref: "#/components/schemas/MeasurementSession" } } } }
-        "422": { description: "QC failure — capture-qc.md codes (no_body, multiple_bodies, partial_body, undecodable_image, low_resolution, poor_lighting, blurry, not_frontal, camera_tilt, arms_position, too_far)", content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+        "422": { description: "QC failure — per pose (capture-qc.md §2): error.details names the failing pose; first failure by table order within it. Codes (undecodable_image, low_resolution, poor_lighting, blurry, no_body, multiple_bodies, partial_body, not_frontal, not_side_profile, camera_tilt, arms_position, too_far)", content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
         "403": { description: consent_required }
     get: { tags: [vault], summary: Own measurement history, parameters: [{ $ref: "#/components/parameters/Cursor" }, { $ref: "#/components/parameters/Limit" }], responses: { "200": { description: Sessions page } } }
   /api/v1/customers:
@@ -211,7 +211,7 @@ components:
         id: { type: string }
         method: { enum: [mediapipe_2d, mediapipe_2d_v2, smpl_v1, manual] }
         status: { enum: [pending_save, complete, failed] }
-        input_height_cm: { type: number }
+        input_height_cm: { type: [number, "null"], description: "nullable — null for method: manual (data-model §2)" }
         measurements:
           type: array
           items: { type: object, properties: { name: { type: string }, value_cm: { type: number }, source: { enum: [pipeline, manual_correction] }, confidence: { type: number } } }

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -821,3 +821,37 @@ test.describe("order-sheet floating layers (shared fixture)", () => {
     });
   }
 });
+
+// Last in the serial file BY DESIGN: it flips the seeded account to
+// deletion_pending, so no journey may follow it in the shared store.
+test("B7 Account & data: danger ladder — quiet-danger row, typed-DELETE confirm, export-first escape", async ({
+  page,
+}) => {
+  await signIn(page);
+  await page.goto("/dashboard/settings/account");
+
+  // Row rung: the unarmed sub-screen renders quiet-danger, never filled.
+  const row = page.getByTestId("delete-all");
+  await expect(row).toHaveAttribute("data-kind", "quiet-danger");
+  await row.click();
+
+  // Armed rung: filled destructive, gated on the typed token.
+  const confirm = page.getByTestId("confirm-delete-all");
+  await expect(confirm).toHaveAttribute("data-kind", "destructive");
+  await expect(confirm).toBeDisabled();
+
+  // The escape hatch exports before deleting (data-model §4 rights).
+  const download = page.waitForEvent("download");
+  await page.getByTestId("export-first").click();
+  expect((await download).suggestedFilename()).toBe("apparule-export.json");
+
+  await page.getByTestId("delete-confirm-input").fill("delete");
+  await expect(confirm).toBeDisabled(); // exact token, not case-insensitive
+  await page.getByTestId("delete-confirm-input").fill("DELETE");
+  await expect(confirm).toBeEnabled();
+  await confirm.click();
+
+  await expect(page.getByText("Deletion requested").first()).toBeVisible();
+  // The pending state disarms the row (no re-entry while pending).
+  await expect(row).toBeDisabled();
+});

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -246,29 +246,58 @@ test("B2 explore: turnaround chip filters; near-me proximity-ranks without dropp
   await expect(tiles).toHaveCount(total);
 });
 
-test("B4 vault: webcam QC failure → retake → capture → save; history delete", async ({
+test("B4 vault: two-photo upload — per-pose QC failure → re-pick side only → save; history delete", async ({
   page,
 }) => {
   await signIn(page);
   await page.goto("/dashboard/vault");
   await page.getByTestId("vault-retake").click();
-  await page.getByRole("button", { name: /Use your camera/ }).click();
+  await page.getByRole("button", { name: /Upload photos/ }).click();
 
-  // Designated QC fixture: a file name containing a capture-qc code.
-  await page.getByTestId("capture-file").setInputFiles({
+  // The upload view (M-12, Figma 549:2): two labeled dropzones + height +
+  // the mobile-app hint line.
+  const uploadView = page.getByTestId("upload-measurements");
+  await expect(uploadView).toBeVisible();
+  await expect(uploadView).toContainText(
+    "Best experience: guided capture on the Apparule app",
+  );
+
+  // Height prefills from the latest capture session (seed: 168) — never a
+  // fabricated default.
+  const height = page.getByLabel("Height in centimeters");
+  await expect(height).toHaveValue("168");
+  await height.fill("170");
+
+  // Front passes; the side file is a designated QC fixture (a file name
+  // containing a capture-qc code — per-pose QC, M-10).
+  await page.getByTestId("capture-file-front").setInputFiles({
+    name: "front.jpg",
+    mimeType: "image/jpeg",
+    buffer: TINY_JPEG,
+  });
+  await page.getByTestId("capture-file-side").setInputFiles({
     name: "fixture-blurry.jpg",
     mimeType: "image/jpeg",
     buffer: TINY_JPEG,
   });
-  await expect(page.getByRole("alert")).toContainText("Hold steady and retake");
-  await page.getByRole("button", { name: "Retake" }).click();
+  await page.getByTestId("get-measurements").click();
 
-  // Happy path: processing constellation → results → save to vault.
-  await page.getByTestId("capture-file").setInputFiles({
-    name: "photo.jpg",
+  // The 422 names the failing pose: only the side dropzone re-opens, the
+  // accepted front pose keeps its thumbnail (pose 1 is never discarded).
+  await expect(page.getByTestId("pose-error-side")).toBeVisible();
+  await expect(uploadView.getByRole("status")).toContainText(
+    "Hold steady and retake",
+  );
+  await expect(uploadView).toContainText("front.jpg · uploaded");
+
+  // Re-pick the failing pose only → processing constellation → results.
+  await page.getByTestId("capture-file-side").setInputFiles({
+    name: "side.jpg",
     mimeType: "image/jpeg",
     buffer: TINY_JPEG,
   });
+  await expect(page.getByTestId("pose-error-side")).toHaveCount(0);
+  await page.getByTestId("get-measurements").click();
   await expect(page.getByTestId("capture-processing")).toBeVisible();
   await expect(page.getByRole("button", { name: "Save to vault" })).toBeVisible(
     {

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -334,6 +334,37 @@ test("B4 vault: two-photo upload — per-pose QC failure → re-pick side only �
   await expect(history.locator("li")).toHaveCount(before - 1);
 });
 
+test("M-11 create chooser: rail Create opens the two-option chooser → vault capture options", async ({
+  page,
+}) => {
+  await signIn(page);
+  const rail = page.locator('nav[aria-label="Primary"]:visible');
+  // The Create pillar is an action (chooser dialog), not a route (M-11).
+  const create = rail.getByRole("button", { name: "Create" });
+  await expect(create).toHaveAttribute("aria-haspopup", "dialog");
+  await create.click();
+
+  const chooser = page.getByRole("dialog", { name: "Create" });
+  await expect(chooser).toBeVisible();
+  await expect(page.getByTestId("create-choice-measure")).toContainText(
+    "Two photos — about a minute",
+  );
+  // Non-designer arm: the post card routes to become-a-designer (B5 upsell).
+  await expect(page.getByTestId("create-choice-post")).toContainText(
+    "Become a designer to post",
+  );
+
+  // "Take measurements" hands off to B4 with the capture options open.
+  await page.getByTestId("create-choice-measure").click();
+  await page.waitForURL("**/dashboard/vault?capture=1");
+  await expect(
+    page.getByRole("dialog", { name: "Update measurements" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Upload photos/ }),
+  ).toBeVisible();
+});
+
 test("B5/B8: creator upsell → onboarding with Paystack resolution states → publish → profile grid", async ({
   page,
 }) => {

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -189,6 +189,38 @@ test("B1 journey: like/save/follow → request stepper → order → quote → p
   ).toBeVisible();
 });
 
+test("entity-nav: feed author links + detail header + comment authors navigate to profiles", async ({
+  page,
+}) => {
+  await signIn(page);
+
+  // B1 feed card: the header avatar+username is a real anchor to the
+  // designer profile (the web sibling of the mobile PostCard author bug).
+  const firstAuthor = page.getByTestId("post-author-link").first();
+  const href = await firstAuthor.getAttribute("href");
+  expect(href).toMatch(/^\/dashboard\/[a-z0-9._]+$/);
+  await firstAuthor.click();
+  await page.waitForURL(`**${href}`);
+  await expect(page.getByRole("heading", { level: 1 })).toContainText(
+    href!.split("/").pop()!,
+  );
+
+  // Post detail: header link wraps the avatar too (no dead zone), and
+  // comment rows carry author links.
+  await page.goBack();
+  await page
+    .getByRole("button", { name: /View all \d+ comments/ })
+    .first()
+    .click();
+  const detailAuthor = page.getByTestId("detail-author-link");
+  await expect(detailAuthor).toBeVisible();
+  expect(await detailAuthor.getAttribute("href")).toMatch(/^\/dashboard\//);
+  await expect(detailAuthor.locator("span").last()).toBeVisible(); // username inside the link
+  const commentAvatar = page.getByTestId("comment-author-avatar").first();
+  await expect(commentAvatar).toBeVisible();
+  expect(await commentAvatar.getAttribute("href")).toMatch(/^\/dashboard\//);
+});
+
 test("B3: the seeded list covers all ten lifecycle states", async ({
   page,
 }) => {

--- a/web/e2e/signin.spec.ts
+++ b/web/e2e/signin.spec.ts
@@ -42,4 +42,36 @@ test.describe("TEST_MODE auth smoke", () => {
     expect(body.items.length).toBeGreaterThan(0);
     expect(body.items[0].designer.username).toBeTruthy();
   });
+
+  // Cold-start matrix (flows/auth.md §2, ratified 2026-07-22) — the web
+  // sibling of mobile's boot-gate tests: restore resolves before either
+  // surface routes, and each surface guards its wrong-state visitor.
+  test("cold start signed out: /dashboard replaces to /signin with no dashboard paint", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+    await page.waitForURL("**/signin");
+    await expect(
+      page.getByRole("button", { name: /continue with google/i }),
+    ).toBeVisible();
+    // The dashboard never painted content for the signed-out visitor.
+    await expect(page.getByTestId("feed-list")).toHaveCount(0);
+  });
+
+  test("reverse guard: a signed-in visit to /signin is replaced to /dashboard", async ({
+    page,
+  }) => {
+    await page.goto("/signin");
+    await page.getByRole("button", { name: /continue with google/i }).click();
+    await page.waitForURL("**/dashboard");
+
+    // Same tab (TEST_MODE session is sessionStorage-held): /signin is not a
+    // reachable surface while signed in — the gate replaces to the app.
+    await page.goto("/signin");
+    await page.waitForURL("**/dashboard");
+    await expect(page.getByTestId("feed-list")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /continue with google/i }),
+    ).toHaveCount(0);
+  });
 });

--- a/web/src/app/api/mock/v1/me/sessions/route.ts
+++ b/web/src/app/api/mock/v1/me/sessions/route.ts
@@ -1,8 +1,10 @@
 // Mock: GET/POST /api/v1/me/sessions — the vault IS the self-customer's
 // sessions (data-model §6.1). POST accepts JSON manual sessions (web manual
-// entry, MI-13) or multipart image uploads (webcam capture path, B4 — QC
-// failure codes reproducible via designated fixture file names);
-// Idempotency-Key honored (flows/vault.md upload contract).
+// entry, MI-13 — no height: input_height_cm is null for method manual) or
+// multipart two-photo uploads (B4 upload path, M-10/M-12: image_front +
+// image_side + input_height_cm; per-pose QC failure codes reproducible via
+// designated fixture file names); Idempotency-Key honored (flows/vault.md
+// upload contract — both images ride one request with one key).
 import {
   actorUsername,
   handle,
@@ -22,7 +24,6 @@ export async function GET(request: Request) {
 
 interface ManualBody {
   method?: string;
-  input_height_cm?: number;
   measurements?: { name: string; value_cm: number }[];
 }
 
@@ -32,7 +33,8 @@ export async function POST(request: Request) {
     const actor = actorUsername(request);
     const key = request.headers.get("idempotency-key");
 
-    // Webcam capture path — multipart image + input_height_cm (api.md §2).
+    // Two-photo upload path — multipart image_front + image_side +
+    // input_height_cm (api.md §2, M-10).
     if (request.headers.get("content-type")?.includes("multipart/form-data")) {
       const form = await request.formData().catch(() => {
         throw new MockApiError(
@@ -41,22 +43,24 @@ export async function POST(request: Request) {
           422,
         );
       });
-      const image = form.get("image");
-      if (!(image instanceof File)) {
+      const imageFront = form.get("image_front");
+      const imageSide = form.get("image_side");
+      if (!(imageFront instanceof File) || !(imageSide instanceof File)) {
         throw new MockApiError(
           "validation_failed",
-          "image file is required",
+          "image_front and image_side files are required",
           422,
         );
       }
       const height = Number(form.get("input_height_cm"));
       const session = store.idempotent(
         key ? `${actor}:POST/me/sessions:${key}` : null,
-        `${image.name}:${height}`,
+        `${imageFront.name}:${imageSide.name}:${height}`,
         () =>
           store.createCaptureSession(actor, {
             input_height_cm: height,
-            filename: image.name,
+            filenameFront: imageFront.name,
+            filenameSide: imageSide.name,
           }),
       );
       return jsonResponse(session, 201);
@@ -68,7 +72,6 @@ export async function POST(request: Request) {
       JSON.stringify(body),
       () =>
         store.createManualSession(actor, {
-          input_height_cm: body.input_height_cm ?? 0,
           measurements: body.measurements ?? [],
         }),
     );

--- a/web/src/app/dashboard/vault/page.tsx
+++ b/web/src/app/dashboard/vault/page.tsx
@@ -1,4 +1,6 @@
-// B4 — Measurement vault (web-implementation.md §4 route map).
+// B4 — Measurement vault (web-implementation.md §4 route map). The Create
+// chooser (M-11) hands off here with ?capture=1 to open the capture
+// options sheet on landing.
 import type { Metadata } from "next";
 import { VaultView } from "@/components/dashboard/vault/VaultView";
 
@@ -6,6 +8,11 @@ export const metadata: Metadata = {
   title: "Vault — Apparule",
 };
 
-export default function VaultPage() {
-  return <VaultView />;
+export default async function VaultPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ capture?: string }>;
+}) {
+  const { capture } = await searchParams;
+  return <VaultView initialSheet={capture ? "options" : null} />;
 }

--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -349,6 +349,9 @@ export function ComponentGallery() {
           <Button kind="gradient-primary">Request this outfit</Button>
           <Button kind="quiet">Following</Button>
           <Button kind="destructive">Delete session</Button>
+          {/* danger ladder: quiet-danger = row rung; filled destructive
+              only on armed/confirm surfaces (Figma 501:2) */}
+          <Button kind="quiet-danger">Delete all</Button>
           <Button kind="link">View order</Button>
         </Row>
         <Row label="size sm · loading · disabled">

--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -989,7 +989,7 @@ export function ComponentGallery() {
 
       <Section title="CaptureOptionCard">
         <div className="grid max-w-xl gap-3 md:grid-cols-2">
-          <CaptureOptionCard mode="webcam-upload" onClick={() => {}} />
+          <CaptureOptionCard mode="photo-upload" onClick={() => {}} />
           <CaptureOptionCard mode="manual-entry" onClick={() => {}} />
         </div>
       </Section>

--- a/web/src/app/signin/page.tsx
+++ b/web/src/app/signin/page.tsx
@@ -1,8 +1,11 @@
 import type { Metadata } from "next";
+import { SignInGate } from "@/auth/SignInGate";
 import { GoogleAuthButton } from "@/components/ui/GoogleAuthButton";
 
 // Single auth screen per flows/auth.md §5 — Google CTA + legal links only
-// (X-1: no username/password anywhere, product-wide).
+// (X-1: no username/password anywhere, product-wide). SignInGate is the
+// flows/auth.md §2 reverse guard: a signed-in visitor is replaced to
+// /dashboard and never sees this screen.
 export const metadata: Metadata = {
   title: "Sign in — Apparule",
   description: "Sign in to Apparule with Google",
@@ -15,43 +18,45 @@ export default function SignInPage() {
       tabIndex={-1}
       className="flex flex-1 flex-col items-center justify-center px-6 py-16"
     >
-      <div className="flex w-full max-w-sm flex-col items-stretch gap-8">
-        <header className="flex flex-col items-center gap-2 text-center">
-          <h1 className="bg-accent-gradient bg-clip-text text-display font-bold text-transparent">
-            Apparule
-          </h1>
-          <p className="text-body text-text-2">
-            Precision measurement meets social fashion
-          </p>
-        </header>
+      <SignInGate>
+        <div className="flex w-full max-w-sm flex-col items-stretch gap-8">
+          <header className="flex flex-col items-center gap-2 text-center">
+            <h1 className="bg-accent-gradient bg-clip-text text-display font-bold text-transparent">
+              Apparule
+            </h1>
+            <p className="text-body text-text-2">
+              Precision measurement meets social fashion
+            </p>
+          </header>
 
-        <GoogleAuthButton />
+          <GoogleAuthButton />
 
-        {/* Inline links in a text block carry a persistent underline —
+          {/* Inline links in a text block carry a persistent underline —
             color alone can't distinguish them (WCAG 1.4.1; axe
             link-in-text-block, 2026-07-21 audit). */}
-        <footer className="text-center text-micro text-text-2">
-          By continuing you agree to our{" "}
-          <a
-            href="https://terms.cuesoft.io"
-            target="_blank"
-            rel="noreferrer"
-            className="text-link underline underline-offset-2"
-          >
-            Terms
-          </a>{" "}
-          and{" "}
-          <a
-            href="https://privacy.cuesoft.io"
-            target="_blank"
-            rel="noreferrer"
-            className="text-link underline underline-offset-2"
-          >
-            Privacy Policy
-          </a>
-          .
-        </footer>
-      </div>
+          <footer className="text-center text-micro text-text-2">
+            By continuing you agree to our{" "}
+            <a
+              href="https://terms.cuesoft.io"
+              target="_blank"
+              rel="noreferrer"
+              className="text-link underline underline-offset-2"
+            >
+              Terms
+            </a>{" "}
+            and{" "}
+            <a
+              href="https://privacy.cuesoft.io"
+              target="_blank"
+              rel="noreferrer"
+              className="text-link underline underline-offset-2"
+            >
+              Privacy Policy
+            </a>
+            .
+          </footer>
+        </div>
+      </SignInGate>
     </main>
   );
 }

--- a/web/src/auth/AuthContext.test.tsx
+++ b/web/src/auth/AuthContext.test.tsx
@@ -1,0 +1,49 @@
+// AuthContext restore net — flows/auth.md §2: a failed restore reads as
+// signed out (never a stranded aria-busy gate). Providers contract to
+// resolve null; this exercises the second net against a rejecting one.
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+const restore = vi.fn();
+vi.mock("./test-mode-auth-provider", () => ({
+  TestModeAuthProvider: class {
+    name = "test-mode" as const;
+    restore = (...a: unknown[]) => restore(...a);
+    signInWithGoogle = vi.fn();
+    signOut = vi.fn();
+  },
+}));
+vi.mock("@/config/env", () => ({ env: { testMode: true } }));
+
+import { AuthProvider, useAuth } from "./AuthContext";
+
+function Probe() {
+  const { status } = useAuth();
+  return <p data-testid="status">{status}</p>;
+}
+
+describe("AuthContext session restore (flows/auth.md §2)", () => {
+  it("a rejecting restore reads as signed_out, not a permanent loading gate", async () => {
+    restore.mockRejectedValue(new Error("firebase exploded"));
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("status")).toHaveTextContent("signed_out"),
+    );
+  });
+
+  it("a null restore reads as signed_out", async () => {
+    restore.mockResolvedValue(null);
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("status")).toHaveTextContent("signed_out"),
+    );
+  });
+});

--- a/web/src/auth/AuthContext.tsx
+++ b/web/src/auth/AuthContext.tsx
@@ -45,15 +45,24 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     let cancelled = false;
-    provider.restore().then((session) => {
-      if (cancelled) return;
-      if (session) {
-        setAccount(session.account);
-        setStatus("signed_in");
-      } else {
-        setStatus("signed_out");
-      }
-    });
+    provider
+      .restore()
+      .then((session) => {
+        if (cancelled) return;
+        if (session) {
+          setAccount(session.account);
+          setStatus("signed_in");
+        } else {
+          setStatus("signed_out");
+        }
+      })
+      .catch(() => {
+        // flows/auth.md §2: a failed restore reads as SIGNED OUT — never an
+        // error interstitial, never a stranded aria-busy gate. Providers
+        // contract to resolve null (types.ts), so this is the second net
+        // (mirrors mobile's boot gate).
+        if (!cancelled) setStatus("signed_out");
+      });
     return () => {
       cancelled = true;
     };

--- a/web/src/auth/SignInGate.test.tsx
+++ b/web/src/auth/SignInGate.test.tsx
@@ -1,0 +1,60 @@
+// SignInGate — flows/auth.md §2 reverse guard: signed_in replaces to
+// /dashboard (never renders the CTA), loading holds the aria-busy gate,
+// signed_out renders the auth content.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const useAuthMock = vi.fn();
+vi.mock("@/auth/AuthContext", () => ({
+  useAuth: (...a: unknown[]) => useAuthMock(...a),
+}));
+const replace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace, push: vi.fn(), back: vi.fn() }),
+}));
+
+import { SignInGate } from "./SignInGate";
+
+beforeEach(() => {
+  replace.mockReset();
+});
+
+describe("SignInGate (flows/auth.md §2)", () => {
+  it("signed_out renders the auth content", () => {
+    useAuthMock.mockReturnValue({ status: "signed_out" });
+    render(
+      <SignInGate>
+        <p>CTA</p>
+      </SignInGate>,
+    );
+    expect(screen.getByText("CTA")).toBeInTheDocument();
+    expect(screen.queryByTestId("signin-gate")).not.toBeInTheDocument();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("loading holds the aria-busy gate — the CTA never paints pre-restore", () => {
+    useAuthMock.mockReturnValue({ status: "loading" });
+    render(
+      <SignInGate>
+        <p>CTA</p>
+      </SignInGate>,
+    );
+    expect(screen.getByTestId("signin-gate")).toHaveAttribute(
+      "aria-busy",
+      "true",
+    );
+    expect(screen.queryByText("CTA")).not.toBeInTheDocument();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("signed_in replaces to /dashboard — a signed-in user never sees /signin", () => {
+    useAuthMock.mockReturnValue({ status: "signed_in" });
+    render(
+      <SignInGate>
+        <p>CTA</p>
+      </SignInGate>,
+    );
+    expect(replace).toHaveBeenCalledWith("/dashboard");
+    expect(screen.queryByText("CTA")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/auth/SignInGate.tsx
+++ b/web/src/auth/SignInGate.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+// SignInGate — the /signin reverse guard (flows/auth.md §2, ratified
+// 2026-07-22: "session restore resolves before either surface routes; a
+// signed-in user never sees the auth screen"). The web sibling of the
+// mobile router's reverse redirect: signed_in → replace("/dashboard");
+// restore-in-flight → the same aria-busy spinner gate DashboardShell uses
+// (never the CTA); only signed_out renders the auth content. The page
+// stays a server component (metadata intact) and wraps its content here.
+import { useEffect, type ReactNode } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/auth/AuthContext";
+import { Spinner } from "@/components/ui/Spinner";
+
+export function SignInGate({ children }: { children: ReactNode }) {
+  const { status } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (status === "signed_in") {
+      router.replace("/dashboard");
+    }
+  }, [status, router]);
+
+  if (status !== "signed_out") {
+    // Covers both `loading` (restore in flight — TEST_MODE resolves without
+    // network on a sessionStorage miss, so this beat is negligible) and
+    // `signed_in` (the replace above is navigating).
+    return (
+      <div
+        aria-busy="true"
+        className="flex w-full items-center justify-center py-24"
+        data-testid="signin-gate"
+      >
+        <Spinner size={28} kind="gradient" />
+        <span className="sr-only">Loading…</span>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/web/src/auth/types.ts
+++ b/web/src/auth/types.ts
@@ -22,6 +22,11 @@ export interface AuthProviderAdapter {
   /** X-1: Google is the only sign-in method, product-wide. */
   signInWithGoogle(): Promise<SignInResult>;
   signOut(): Promise<void>;
-  /** Restore an existing session on app load (SDK/session cache). */
+  /**
+   * Restore an existing session on app load (SDK/session cache).
+   * Contract (flows/auth.md §2, ratified 2026-07-22): implementations
+   * resolve `null` on any failure and MUST NOT reject — a failed restore
+   * reads as signed out. AuthContext still catches as a second net.
+   */
   restore(): Promise<AuthSession | null>;
 }

--- a/web/src/components/dashboard/CreateChooserSheet.test.tsx
+++ b/web/src/components/dashboard/CreateChooserSheet.test.tsx
@@ -1,0 +1,53 @@
+// Create chooser (M-11, 548:9490): two choice cards — measurements primary
+// (accent border) → B4 capture options; post designer-gated with the
+// become-a-designer subtitle for non-designers.
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const useAuthMock = vi.fn();
+vi.mock("@/auth/AuthContext", () => ({
+  useAuth: (...a: unknown[]) => useAuthMock(...a),
+}));
+
+import { CreateChooserSheet } from "./CreateChooserSheet";
+
+function renderChooser(designerEnabled: boolean) {
+  useAuthMock.mockReturnValue({
+    status: "signed_in",
+    account: {
+      username: "kiki.adeyemi",
+      designer: { enabled: designerEnabled, kyc_complete: false },
+    },
+  });
+  return render(<CreateChooserSheet open onOpenChange={() => {}} />);
+}
+
+describe("CreateChooserSheet (M-11)", () => {
+  it("offers Take measurements (primary → vault capture) + Post an outfit", () => {
+    renderChooser(false);
+    expect(screen.getByRole("dialog", { name: "Create" })).toBeInTheDocument();
+
+    const measure = screen.getByTestId("create-choice-measure");
+    expect(measure).toHaveAttribute("href", "/dashboard/vault?capture=1");
+    expect(measure).toHaveTextContent("Take measurements");
+    expect(measure).toHaveTextContent("Two photos — about a minute");
+    // primary card carries the accent border (548:9490)
+    expect(measure.className).toContain("border-accent-start");
+
+    const post = screen.getByTestId("create-choice-post");
+    expect(post).toHaveAttribute("href", "/dashboard/create");
+    expect(post).toHaveTextContent("Post an outfit");
+  });
+
+  it("gates the post subtitle on designer status", () => {
+    const { unmount } = renderChooser(false);
+    expect(screen.getByTestId("create-choice-post")).toHaveTextContent(
+      "Become a designer to post",
+    );
+    unmount();
+    renderChooser(true);
+    expect(screen.getByTestId("create-choice-post")).toHaveTextContent(
+      "Share a look with its fit data",
+    );
+  });
+});

--- a/web/src/components/dashboard/CreateChooserSheet.tsx
+++ b/web/src/components/dashboard/CreateChooserSheet.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+// Create chooser (M-11, Figma 548:9490): the rail's Create action opens a
+// two-option chooser on both platforms — "Take measurements" (→ B4 capture
+// options) and "Post an outfit" (→ B5; designer-gated — non-designers land
+// on the become-a-designer upsell there). C1b choice-card language: icon +
+// title + subtitle + chevron; the measurements card is primary (accent
+// border, 1.5px per the master).
+import clsx from "clsx";
+import Link from "next/link";
+import { Camera, ChevronRight, Shirt, type LucideIcon } from "lucide-react";
+import { useAuth } from "@/auth/AuthContext";
+import { Sheet } from "@/components/ui/Sheet";
+
+function ChoiceCard({
+  href,
+  icon: Icon,
+  title,
+  subtitle,
+  primary = false,
+  onNavigate,
+}: {
+  href: string;
+  icon: LucideIcon;
+  title: string;
+  subtitle: string;
+  primary?: boolean;
+  onNavigate: () => void;
+}) {
+  return (
+    <Link
+      href={href}
+      onClick={onNavigate}
+      data-testid={`create-choice-${primary ? "measure" : "post"}`}
+      className={clsx(
+        "flex items-center gap-4 rounded-card bg-bg-elev p-4 text-left",
+        "transition-transform duration-120 ease-standard active:scale-[0.99]",
+        "motion-reduce:transition-none motion-reduce:active:scale-100",
+        primary
+          ? "border-[1.5px] border-accent-start"
+          : "border border-border hover:border-text-2/40",
+      )}
+    >
+      <span className="grid size-10 shrink-0 place-items-center rounded-pill bg-accent-start/12 text-accent-start">
+        <Icon size={20} aria-hidden="true" />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="text-body font-semibold text-text">{title}</span>
+        <span className="text-caption text-text-2">{subtitle}</span>
+      </span>
+      <ChevronRight size={16} className="shrink-0 text-text-2" aria-hidden />
+    </Link>
+  );
+}
+
+export function CreateChooserSheet({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { account } = useAuth();
+  const isDesigner = account?.designer.enabled ?? false;
+  const close = () => onOpenChange(false);
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange} title="Create">
+      <div className="flex flex-col gap-3">
+        <ChoiceCard
+          href="/dashboard/vault?capture=1"
+          icon={Camera}
+          title="Take measurements"
+          subtitle="Two photos — about a minute"
+          primary
+          onNavigate={close}
+        />
+        <ChoiceCard
+          href="/dashboard/create"
+          icon={Shirt}
+          title="Post an outfit"
+          subtitle={
+            isDesigner
+              ? "Share a look with its fit data"
+              : "Become a designer to post"
+          }
+          onNavigate={close}
+        />
+      </div>
+    </Sheet>
+  );
+}

--- a/web/src/components/dashboard/DashboardShell.tsx
+++ b/web/src/components/dashboard/DashboardShell.tsx
@@ -2,13 +2,16 @@
 
 // Dashboard shell (pages.md Part B chrome): left NavRail (collapsed 72,
 // expanded 244 at ≥1264px), auth guard, Orders badge (MI-16 — clears on tab
-// visit), and the single <main> landmark every screen renders into.
-import { useEffect, useMemo, type ReactNode } from "react";
+// visit), the Create chooser (M-11: the rail's Create pillar opens the
+// two-option chooser, not a route), and the single <main> landmark every
+// screen renders into.
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { useAuth } from "@/auth/AuthContext";
 import { useNotifications } from "@/controllers/use-notifications";
 import { NavRail, DEFAULT_NAV_ITEMS } from "@/components/ui/NavRail";
 import { Spinner } from "@/components/ui/Spinner";
+import { CreateChooserSheet } from "./CreateChooserSheet";
 import { ToastProvider } from "./toast-context";
 
 function activeKeyFor(pathname: string, ownUsername: string | null): string {
@@ -32,6 +35,7 @@ export function DashboardShell({ children }: { children: ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
   const { ordersBadge, markOrderKindsRead } = useNotifications();
+  const [chooserOpen, setChooserOpen] = useState(false);
 
   // Auth guard: the dashboard is the authenticated app (web-implementation
   // §4) — signed-out visitors land on /signin.
@@ -58,6 +62,10 @@ export function DashboardShell({ children }: { children: ReactNode }) {
         }
         if (item.key === "profile" && account) {
           return { ...item, href: `/dashboard/${account.username}` };
+        }
+        if (item.key === "create") {
+          // M-11: Create opens the two-option chooser (capture / post).
+          return { ...item, onSelect: () => setChooserOpen(true) };
         }
         return item;
       }),
@@ -99,6 +107,7 @@ export function DashboardShell({ children }: { children: ReactNode }) {
         <main id="main" tabIndex={-1} className="min-w-0 flex-1">
           {children}
         </main>
+        <CreateChooserSheet open={chooserOpen} onOpenChange={setChooserOpen} />
       </div>
     </ToastProvider>
   );

--- a/web/src/components/dashboard/feed/FeedView.tsx
+++ b/web/src/components/dashboard/feed/FeedView.tsx
@@ -196,6 +196,7 @@ export function FeedView() {
                   <div className="bg-bg">
                     <PostCard
                       post={post}
+                      authorHref={`/dashboard/${post.designer.username}`}
                       onToggleLike={() => void like(post)}
                       onToggleSave={() => void save(post)}
                       onComment={() => setOpenPostId(post.id)}

--- a/web/src/components/dashboard/post/PostDetailView.tsx
+++ b/web/src/components/dashboard/post/PostDetailView.tsx
@@ -113,17 +113,22 @@ export function PostDetailView({
 
       <div className="flex max-h-[640px] min-w-0 flex-col">
         <header className="flex items-center gap-2 border-b border-border px-4 py-3">
-          <Avatar
-            size={32}
-            name={post.designer.display_name}
-            src={post.designer.avatar_url}
-            verified={post.designer.verified}
-          />
+          {/* Avatar + username share one profile link — the avatar is never
+              a dead zone (entity-navigation rule, Decided 2026-07-22). */}
           <Link
             href={`/dashboard/${post.designer.username}`}
-            className="truncate text-body font-semibold text-text"
+            data-testid="detail-author-link"
+            className="flex min-w-0 items-center gap-2"
           >
-            {post.designer.username}
+            <Avatar
+              size={32}
+              name={post.designer.display_name}
+              src={post.designer.avatar_url}
+              verified={post.designer.verified}
+            />
+            <span className="truncate text-body font-semibold text-text">
+              {post.designer.username}
+            </span>
           </Link>
           {onOverflow ? (
             <IconButton
@@ -161,6 +166,7 @@ export function PostDetailView({
                 <li key={comment.id}>
                   <CommentRow
                     comment={comment}
+                    authorHref={`/dashboard/${comment.author.username}`}
                     posting={comment.id.startsWith("optimistic-")}
                   />
                 </li>

--- a/web/src/components/dashboard/settings/AccountDataView.test.tsx
+++ b/web/src/components/dashboard/settings/AccountDataView.test.tsx
@@ -1,0 +1,80 @@
+// B7 Account & data — danger ladder (Decided 2026-07-22): quiet-danger row
+// rung; armed confirm = typed DELETE gate + export-first escape + Cancel;
+// filled destructive only inside the armed sheet.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const requestDeletion = vi.fn();
+const useSettingsMock = vi.fn();
+vi.mock("@/controllers/use-settings", () => ({
+  useSettings: (...a: unknown[]) => useSettingsMock(...a),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+import { AccountDataView } from "./AccountDataView";
+import { ToastProvider } from "../toast-context";
+
+beforeEach(() => {
+  requestDeletion.mockReset().mockResolvedValue({});
+  useSettingsMock.mockReturnValue({
+    account: { deletion_state: "active" },
+    exporting: false,
+    deleting: false,
+    exportData: vi.fn().mockResolvedValue("blob:mock"),
+    requestDeletion,
+  });
+});
+
+function renderView() {
+  return render(
+    <ToastProvider>
+      <AccountDataView />
+    </ToastProvider>,
+  );
+}
+
+describe("AccountDataView danger ladder", () => {
+  it("row rung renders quiet-danger; filled destructive only in the armed sheet", async () => {
+    renderView();
+    const row = screen.getByTestId("delete-all");
+    expect(row).toHaveAttribute("data-kind", "quiet-danger");
+    await userEvent.click(row);
+    expect(screen.getByTestId("confirm-delete-all")).toHaveAttribute(
+      "data-kind",
+      "destructive",
+    );
+  });
+
+  it("typed DELETE arms the confirm; the export-first escape hatch is present", async () => {
+    renderView();
+    await userEvent.click(screen.getByTestId("delete-all"));
+
+    const confirm = screen.getByTestId("confirm-delete-all");
+    expect(confirm).toBeDisabled();
+    expect(screen.getByTestId("export-first")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+
+    await userEvent.type(screen.getByTestId("delete-confirm-input"), "delete");
+    expect(confirm).toBeDisabled(); // exact token
+
+    await userEvent.clear(screen.getByTestId("delete-confirm-input"));
+    await userEvent.type(screen.getByTestId("delete-confirm-input"), "DELETE");
+    expect(confirm).toBeEnabled();
+    await userEvent.click(confirm);
+    expect(requestDeletion).toHaveBeenCalledOnce();
+  });
+
+  it("closing the sheet disarms the typed token", async () => {
+    renderView();
+    await userEvent.click(screen.getByTestId("delete-all"));
+    await userEvent.type(screen.getByTestId("delete-confirm-input"), "DELETE");
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    // re-open: the gate must be armed again from scratch
+    await userEvent.click(screen.getByTestId("delete-all"));
+    expect(screen.getByTestId("delete-confirm-input")).toHaveValue("");
+    expect(screen.getByTestId("confirm-delete-all")).toBeDisabled();
+  });
+});

--- a/web/src/components/dashboard/settings/AccountDataView.tsx
+++ b/web/src/components/dashboard/settings/AccountDataView.tsx
@@ -2,12 +2,17 @@
 
 // B7 sub-screen — Account & data: export (Download my data) and delete-all
 // with confirm — the B4 rights links resolve here (data-model §4 parity).
+// Danger ladder [Decided 2026-07-22]: the row-level "Delete all" renders
+// quiet-danger; the armed confirm sheet carries the typed-DELETE gate, the
+// "Export everything first" escape hatch, and Cancel (design.md §8.2;
+// mobile sibling account_data_screen.dart).
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useSettings } from "@/controllers/use-settings";
 import { AppBar } from "@/components/ui/AppBar";
 import { Banner } from "@/components/ui/Banner";
 import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
 import { Sheet } from "@/components/ui/Sheet";
 import { useToasts } from "../toast-context";
 
@@ -16,6 +21,12 @@ export function AccountDataView() {
   const router = useRouter();
   const { showToast } = useToasts();
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+  const armed = confirmText.trim() === "DELETE";
+  const closeConfirm = (open: boolean) => {
+    setConfirmOpen(open);
+    if (!open) setConfirmText("");
+  };
 
   const download = async () => {
     try {
@@ -34,7 +45,7 @@ export function AccountDataView() {
   const requestDeletion = async () => {
     try {
       await settings.requestDeletion();
-      setConfirmOpen(false);
+      closeConfirm(false);
       showToast({ kind: "neutral", message: "Deletion requested" });
     } catch {
       showToast({ kind: "error", message: "Couldn't request deletion" });
@@ -87,8 +98,10 @@ export function AccountDataView() {
           grace period.
         </p>
         <div>
+          {/* Row rung: quiet-danger — filled destructive is reserved for
+              the armed confirm below (danger ladder). */}
           <Button
-            kind="destructive"
+            kind="quiet-danger"
             disabled={settings.account?.deletion_state === "deletion_pending"}
             onClick={() => setConfirmOpen(true)}
             data-testid="delete-all"
@@ -100,7 +113,7 @@ export function AccountDataView() {
 
       <Sheet
         open={confirmOpen}
-        onOpenChange={setConfirmOpen}
+        onOpenChange={closeConfirm}
         title="Delete everything?"
       >
         <div className="flex flex-col gap-4">
@@ -108,12 +121,41 @@ export function AccountDataView() {
             This requests permanent deletion of your account and vault. You have
             30 days to change your mind.
           </p>
+          {/* Armed rung: the typed token gates the filled confirm. */}
+          <div className="flex flex-col gap-2">
+            <label
+              htmlFor="delete-confirm-input"
+              className="text-body font-semibold text-text"
+            >
+              Type DELETE to confirm
+            </label>
+            <Input
+              id="delete-confirm-input"
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              placeholder="DELETE"
+              autoComplete="off"
+              data-testid="delete-confirm-input"
+            />
+          </div>
+          {/* Escape hatch: export before deleting (data-model §4 rights). */}
+          <div>
+            <Button
+              kind="link"
+              loading={settings.exporting}
+              onClick={() => void download()}
+              data-testid="export-first"
+            >
+              Export everything first
+            </Button>
+          </div>
           <footer className="flex justify-end gap-2">
-            <Button kind="quiet" onClick={() => setConfirmOpen(false)}>
-              Keep my account
+            <Button kind="quiet" onClick={() => closeConfirm(false)}>
+              Cancel
             </Button>
             <Button
               kind="destructive"
+              disabled={!armed}
               loading={settings.deleting}
               onClick={() => void requestDeletion()}
               data-testid="confirm-delete-all"

--- a/web/src/components/dashboard/vault/CaptureSheets.test.tsx
+++ b/web/src/components/dashboard/vault/CaptureSheets.test.tsx
@@ -1,0 +1,76 @@
+// B4 capture sheets — options (photo upload / manual entry + the M-12
+// mobile-app hint) and manual entry (no height row — input_height_cm is
+// null for method: manual; out-of-range advisory per flows/vault.md §2).
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  CaptureOptionsSheet,
+  ManualEntrySheet,
+  MANUAL_METRICS,
+  manualAdvisory,
+} from "./CaptureSheets";
+
+describe("CaptureOptionsSheet (B4, M-12)", () => {
+  it("offers photo upload + manual entry and carries the app hint", async () => {
+    const onPick = vi.fn();
+    render(
+      <CaptureOptionsSheet open onOpenChange={() => {}} onPick={onPick} />,
+    );
+    expect(
+      screen.getByText("Best experience: guided capture on the Apparule app."),
+    ).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: /Upload photos/ }),
+    );
+    expect(onPick).toHaveBeenCalledWith("photo-upload");
+    await userEvent.click(
+      screen.getByRole("button", { name: /Enter manually/ }),
+    );
+    expect(onPick).toHaveBeenCalledWith("manual-entry");
+  });
+});
+
+describe("ManualEntrySheet (MI-13)", () => {
+  it("advisory table matches the canonical flows/vault.md §2 ranges (waist 150)", () => {
+    expect(MANUAL_METRICS).toEqual([
+      { name: "shoulder_width", min: 25, max: 75 },
+      { name: "hip_width", min: 20, max: 70 },
+      { name: "chest_girth", min: 50, max: 160 },
+      { name: "waist_girth", min: 40, max: 150 },
+    ]);
+  });
+
+  it("out-of-range values prompt the double-check advisory, never a block", () => {
+    expect(manualAdvisory(155, 40, 150)).toBe(
+      "Double-check this one — outside the usual 40–150 cm.",
+    );
+    expect(manualAdvisory(78, 40, 150)).toBeUndefined();
+    expect(manualAdvisory(null, 40, 150)).toBeUndefined();
+  });
+
+  it("collects no height and saves measurements only", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<ManualEntrySheet open onOpenChange={() => {}} onSave={onSave} />);
+
+    // No height field — manual sessions carry input_height_cm: null
+    // (flows/vault.md §2; the fabricated 168 default is gone).
+    expect(screen.queryByLabelText(/height/i)).not.toBeInTheDocument();
+
+    const save = screen.getByRole("button", { name: "Save to vault" });
+    expect(save).toBeDisabled();
+
+    const waist = screen.getByLabelText("Waist Girth value");
+    await userEvent.clear(waist);
+    await userEvent.type(waist, "155");
+    // The advisory renders inline and saving stays possible (non-blocking).
+    expect(
+      screen.getByText("Double-check this one — outside the usual 40–150 cm."),
+    ).toBeInTheDocument();
+    expect(save).toBeEnabled();
+    await userEvent.click(save);
+    expect(onSave).toHaveBeenCalledWith([
+      { name: "waist_girth", value_cm: 155 },
+    ]);
+  });
+});

--- a/web/src/components/dashboard/vault/CaptureSheets.tsx
+++ b/web/src/components/dashboard/vault/CaptureSheets.tsx
@@ -1,26 +1,19 @@
 "use client";
 
-// B4 capture flows in sheets: options (webcam upload / manual entry,
-// CaptureOptionCard) · webcam upload (photo + height → MI-12 processing
-// constellation → results stagger / QC guidance) · manual entry (MI-13
-// ManualMeasureRow set + unit toggle).
-import { useRef, useState } from "react";
-import type { MeasurementSession } from "@/models";
-import { useCapture } from "@/controllers/use-capture";
+// B4 capture flows in sheets: options (photo upload / manual entry,
+// CaptureOptionCard — upload-only per M-12, with the "best experience:
+// guided capture on the mobile app" hint) · manual entry (MI-13
+// ManualMeasureRow set + unit toggle; no height — manual sessions carry
+// input_height_cm: null per flows/vault.md §2). The two-photo upload flow
+// itself is a page takeover (UploadMeasurementsView, Figma 549:2), not a
+// sheet. The webcam capture sheet was DELETED per M-12 (full-body webcam
+// capture is rejected UX: desk-height lens, unreachable controls).
+import { useState } from "react";
 import { Banner } from "@/components/ui/Banner";
 import { Button } from "@/components/ui/Button";
 import { CaptureOptionCard } from "@/components/ui/CaptureOptionCard";
-import { CaptureResults } from "@/components/ui/CaptureResults";
-import { FormRow } from "@/components/ui/FormRow";
-import { Input, type MeasureUnit } from "@/components/ui/Input";
 import { ManualMeasureRow } from "@/components/ui/ManualMeasureRow";
-import { MeasurementCard } from "@/components/ui/MeasurementCard";
-import { ProcessingConstellation } from "@/components/ui/ProcessingConstellation";
-import {
-  QCHintChip,
-  type QcFailCode,
-  QC_GUIDANCE,
-} from "@/components/ui/QCHintChip";
+import type { MeasureUnit } from "@/components/ui/Input";
 import { Sheet } from "@/components/ui/Sheet";
 
 export function CaptureOptionsSheet({
@@ -30,30 +23,52 @@ export function CaptureOptionsSheet({
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onPick: (mode: "webcam-upload" | "manual-entry") => void;
+  onPick: (mode: "photo-upload" | "manual-entry") => void;
 }) {
   return (
     <Sheet open={open} onOpenChange={onOpenChange} title="Update measurements">
-      <div className="grid gap-3 md:grid-cols-2">
-        <CaptureOptionCard
-          mode="webcam-upload"
-          onClick={() => onPick("webcam-upload")}
-        />
-        <CaptureOptionCard
-          mode="manual-entry"
-          onClick={() => onPick("manual-entry")}
-        />
+      <div className="flex flex-col gap-3">
+        <div className="grid gap-3 md:grid-cols-2">
+          <CaptureOptionCard
+            mode="photo-upload"
+            onClick={() => onPick("photo-upload")}
+          />
+          <CaptureOptionCard
+            mode="manual-entry"
+            onClick={() => onPick("manual-entry")}
+          />
+        </div>
+        {/* pages.md B4 (M-12): the options sheet carries the app hint. */}
+        <p className="text-caption text-text-2">
+          Best experience: guided capture on the Apparule app.
+        </p>
       </div>
     </Sheet>
   );
 }
 
-const MANUAL_METRICS = [
+/**
+ * Advisory ranges — flows/vault.md §2, the canonical cross-client table
+ * [Decided 2026-07-22: waist_girth settled at 150, the mobile/canvas
+ * value]. Out-of-range prompts a "double-check" hint, never a hard block
+ * (bodies vary).
+ */
+export const MANUAL_METRICS = [
   { name: "shoulder_width", min: 25, max: 75 },
   { name: "hip_width", min: 20, max: 70 },
   { name: "chest_girth", min: 50, max: 160 },
-  { name: "waist_girth", min: 40, max: 160 },
+  { name: "waist_girth", min: 40, max: 150 },
 ] as const;
+
+/** The non-blocking out-of-range advisory (flows/vault.md §2). */
+export function manualAdvisory(
+  value: number | null,
+  min: number,
+  max: number,
+): string | undefined {
+  if (value === null || (value >= min && value <= max)) return undefined;
+  return `Double-check this one — outside the usual ${min}–${max} cm.`;
+}
 
 export function ManualEntrySheet({
   open,
@@ -62,12 +77,8 @@ export function ManualEntrySheet({
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onSave: (
-    heightCm: number,
-    measurements: { name: string; value_cm: number }[],
-  ) => Promise<void>;
+  onSave: (measurements: { name: string; value_cm: number }[]) => Promise<void>;
 }) {
-  const [height, setHeight] = useState("168");
   const [unit, setUnit] = useState<MeasureUnit>("cm");
   const [values, setValues] = useState<Record<string, number | null>>({});
   const [busy, setBusy] = useState(false);
@@ -76,12 +87,7 @@ export function ManualEntrySheet({
   const entered = MANUAL_METRICS.filter(
     (m) => values[m.name] !== null && values[m.name] !== undefined,
   );
-  const heightCm = Number(height);
-  const valid =
-    Number.isFinite(heightCm) &&
-    heightCm >= 100 &&
-    heightCm <= 230 &&
-    entered.length > 0;
+  const valid = entered.length > 0;
 
   const save = async () => {
     if (!valid) return;
@@ -89,7 +95,6 @@ export function ManualEntrySheet({
     setError(null);
     try {
       await onSave(
-        heightCm,
         entered.map((m) => ({ name: m.name, value_cm: values[m.name]! })),
       );
       setValues({});
@@ -111,16 +116,6 @@ export function ManualEntrySheet({
         }}
       >
         {error ? <Banner tone="error">{error}</Banner> : null}
-        <FormRow label="Your height (cm)" helper="100–230 cm" required>
-          <Input
-            kind="numeric"
-            aria-label="Height in centimeters"
-            value={height}
-            onChange={(e) => setHeight(e.target.value)}
-            unit={unit}
-            onUnitChange={setUnit}
-          />
-        </FormRow>
         <fieldset className="flex flex-col gap-3">
           <legend className="sr-only">Measurements</legend>
           {MANUAL_METRICS.map((metric) => (
@@ -135,6 +130,11 @@ export function ManualEntrySheet({
               onUnitChange={setUnit}
               min={metric.min}
               max={metric.max}
+              error={manualAdvisory(
+                values[metric.name] ?? null,
+                metric.min,
+                metric.max,
+              )}
             />
           ))}
         </fieldset>
@@ -149,136 +149,6 @@ export function ManualEntrySheet({
           </Button>
         </footer>
       </form>
-    </Sheet>
-  );
-}
-
-export function WebcamCaptureSheet({
-  open,
-  onOpenChange,
-  onSaved,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  onSaved: (session: MeasurementSession) => void;
-}) {
-  const capture = useCapture((session) => {
-    onSaved(session);
-    onOpenChange(false);
-  });
-  const [height, setHeight] = useState("168");
-  const [unit, setUnit] = useState<MeasureUnit>("cm");
-  const fileRef = useRef<HTMLInputElement>(null);
-  const heightCm = Number(height);
-  const heightValid =
-    Number.isFinite(heightCm) && heightCm >= 100 && heightCm <= 230;
-
-  const close = (next: boolean) => {
-    if (!next) void capture.retake();
-    onOpenChange(next);
-  };
-
-  return (
-    <Sheet open={open} onOpenChange={close} title="Webcam capture">
-      {capture.phase === "idle" ? (
-        <form
-          className="flex flex-col gap-4"
-          onSubmit={(e) => e.preventDefault()}
-        >
-          <p className="text-body text-text-2">
-            Stand in good light, full body head to ankles, arms slightly away —
-            then upload the photo.
-          </p>
-          <FormRow label="Your height (cm)" helper="100–230 cm" required>
-            <Input
-              kind="numeric"
-              aria-label="Height in centimeters"
-              value={height}
-              onChange={(e) => setHeight(e.target.value)}
-              unit={unit}
-              onUnitChange={setUnit}
-            />
-          </FormRow>
-          <label htmlFor="capture-file" className="sr-only">
-            Upload a full-body photo
-          </label>
-          <input
-            ref={fileRef}
-            id="capture-file"
-            type="file"
-            accept="image/jpeg,image/png,image/webp"
-            className="sr-only"
-            data-testid="capture-file"
-            onChange={(e) => {
-              const file = e.target.files?.[0];
-              if (file && heightValid) void capture.upload(file, heightCm);
-              e.target.value = "";
-            }}
-          />
-          <Button
-            kind="gradient-primary"
-            disabled={!heightValid}
-            onClick={() => fileRef.current?.click()}
-          >
-            Choose photo
-          </Button>
-        </form>
-      ) : null}
-
-      {capture.phase === "processing" ? (
-        <div
-          aria-busy="true"
-          aria-live="polite"
-          className="flex flex-col items-center gap-3 py-4"
-          data-testid="capture-processing"
-        >
-          <ProcessingConstellation
-            state="processing"
-            imageSrc={capture.previewUrl ?? undefined}
-          />
-          <p className="text-body text-text-2">Measuring — hold on…</p>
-        </div>
-      ) : null}
-
-      {capture.phase === "qc_failed" && capture.qcFailure ? (
-        <div className="flex flex-col items-center gap-4 py-4">
-          <ProcessingConstellation
-            state="failed"
-            imageSrc={capture.previewUrl ?? undefined}
-          />
-          {capture.qcFailure.code in QC_GUIDANCE ? (
-            <QCHintChip code={capture.qcFailure.code as QcFailCode} />
-          ) : null}
-          <p role="alert" className="text-center text-body text-text-2">
-            {capture.qcFailure.guidance}
-          </p>
-          <Button kind="quiet" onClick={() => void capture.retake()}>
-            Retake
-          </Button>
-        </div>
-      ) : null}
-
-      {(capture.phase === "results" || capture.phase === "saving") &&
-      capture.pending ? (
-        <CaptureResults
-          confidences={capture.pending.measurements.map(
-            (m) => m.confidence ?? 1,
-          )}
-          onSave={() => void capture.save()}
-          onRetake={() => void capture.retake()}
-          saving={capture.phase === "saving"}
-        >
-          {capture.pending.measurements.map((m) => (
-            <MeasurementCard
-              key={m.id}
-              name={m.name}
-              valueCm={m.value_cm}
-              source="scan"
-              confidence={m.confidence}
-            />
-          ))}
-        </CaptureResults>
-      ) : null}
     </Sheet>
   );
 }

--- a/web/src/components/dashboard/vault/UploadMeasurementsView.test.tsx
+++ b/web/src/components/dashboard/vault/UploadMeasurementsView.test.tsx
@@ -1,0 +1,143 @@
+// B4 upload view (Figma 549:2, M-10/M-12): header + hint line, labeled
+// per-pose dropzones, height prefill (no fabricated default), and the
+// submit gate (both files + valid height). The per-pose QC round-trip is
+// e2e-covered (dashboard.spec.ts).
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("@/models/repositories/vault-repo", () => ({
+  vaultRepo: {
+    createCaptureSession: vi.fn(),
+    saveSession: vi.fn(),
+    deleteSession: vi.fn(),
+  },
+}));
+
+import { UploadMeasurementsView } from "./UploadMeasurementsView";
+
+beforeEach(() => {
+  // jsdom lacks createObjectURL
+  vi.stubGlobal(
+    "URL",
+    Object.assign(URL, {
+      createObjectURL: () => "blob:mock",
+      revokeObjectURL: () => {},
+    }),
+  );
+});
+
+const pickPose = (pose: "front" | "side", name: string) => {
+  const input = screen.getByTestId(`capture-file-${pose}`);
+  fireEvent.change(input, {
+    target: { files: [new File(["x"], name, { type: "image/jpeg" })] },
+  });
+};
+
+describe("UploadMeasurementsView (B4 upload, 549:2)", () => {
+  it("renders the two-photo header, the app hint, and both pose dropzones", () => {
+    render(
+      <UploadMeasurementsView
+        prefillHeightCm={null}
+        onBack={() => {}}
+        onSaved={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole("heading", { name: "Upload measurements" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Two photos — front and side — plus your height. We map 33 landmarks per photo.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Best experience: guided capture on the Apparule app"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Front photo")).toBeInTheDocument();
+    expect(screen.getByText("Side photo")).toBeInTheDocument();
+  });
+
+  it("prefills height from the latest capture session — empty when none", () => {
+    const { unmount } = render(
+      <UploadMeasurementsView
+        prefillHeightCm={168}
+        onBack={() => {}}
+        onSaved={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText("Height in centimeters")).toHaveValue("168");
+    unmount();
+    render(
+      <UploadMeasurementsView
+        prefillHeightCm={null}
+        onBack={() => {}}
+        onSaved={() => {}}
+      />,
+    );
+    // Nullable ruling: no fabricated default.
+    expect(screen.getByLabelText("Height in centimeters")).toHaveValue("");
+  });
+
+  it("gates the CTA on both poses + a valid height (100–230)", async () => {
+    render(
+      <UploadMeasurementsView
+        prefillHeightCm={null}
+        onBack={() => {}}
+        onSaved={() => {}}
+      />,
+    );
+    const cta = screen.getByTestId("get-measurements");
+    expect(cta).toBeDisabled();
+
+    pickPose("front", "front.jpg");
+    pickPose("side", "side.jpg");
+    expect(cta).toBeDisabled(); // still no height
+
+    const height = screen.getByLabelText("Height in centimeters");
+    await userEvent.type(height, "99");
+    expect(cta).toBeDisabled(); // out of range
+    await userEvent.clear(height);
+    await userEvent.type(height, "170");
+    expect(cta).toBeEnabled();
+
+    // Uploaded state shows the file meta + Replace affordance (549:2).
+    expect(screen.getByText(/front\.jpg · uploaded/)).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Replace" })).toHaveLength(2);
+  });
+
+  it("rejects a >10MB photo with an inline error, not a QC state", () => {
+    render(
+      <UploadMeasurementsView
+        prefillHeightCm={null}
+        onBack={() => {}}
+        onSaved={() => {}}
+      />,
+    );
+    const big = new File([new ArrayBuffer(1)], "big.jpg", {
+      type: "image/jpeg",
+    });
+    Object.defineProperty(big, "size", { value: 11 * 1024 * 1024 });
+    fireEvent.change(screen.getByTestId("capture-file-front"), {
+      target: { files: [big] },
+    });
+    expect(
+      screen.getByText("That photo is over 10 MB — try a smaller one."),
+    ).toBeInTheDocument();
+  });
+
+  it("fires onBack from the back link", async () => {
+    const onBack = vi.fn();
+    render(
+      <UploadMeasurementsView
+        prefillHeightCm={null}
+        onBack={onBack}
+        onSaved={() => {}}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /Back to vault/ }),
+    );
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+});

--- a/web/src/components/dashboard/vault/UploadMeasurementsView.tsx
+++ b/web/src/components/dashboard/vault/UploadMeasurementsView.tsx
@@ -1,0 +1,357 @@
+"use client";
+
+// B4 — Upload measurements (Figma 549:2; M-10 two-photo canon + M-12
+// upload-only): labeled Front/Side dropzones with per-pose states (empty /
+// uploaded thumbnail + Replace / QC-error + QCHintChip), a Height (cm)
+// FormRow (100–230, prefilled from the latest capture session — never a
+// fabricated default), the "Get measurements" CTA into the MI-12 processing
+// constellation, and the results stagger → Save to vault. A QC failure
+// re-opens only the failing pose (per-pose QC, capture-qc.md §2) — the
+// accepted pose's file is kept. Renders as a page takeover of the vault
+// content (in-content left-aligned h1 — the IG-desktop idiom, M-9 scope).
+import { useRef, useState } from "react";
+import clsx from "clsx";
+import { AlertTriangle, Camera, ChevronLeft } from "lucide-react";
+import type { MeasurementSession } from "@/models";
+import { useCapture, type CapturePose } from "@/controllers/use-capture";
+import { Button } from "@/components/ui/Button";
+import { CaptureResults } from "@/components/ui/CaptureResults";
+import { FormRow } from "@/components/ui/FormRow";
+import { Input } from "@/components/ui/Input";
+import { MeasurementCard } from "@/components/ui/MeasurementCard";
+import { ProcessingConstellation } from "@/components/ui/ProcessingConstellation";
+import {
+  QCHintChip,
+  QC_GUIDANCE,
+  type QcFailCode,
+} from "@/components/ui/QCHintChip";
+
+/** flows/vault.md upload row: each image ≤ 10 MB, JPEG/PNG/HEIC. */
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+const ACCEPT = "image/jpeg,image/png,image/heic";
+
+const POSE_LABEL: Record<CapturePose, string> = {
+  front: "Front photo",
+  side: "Side photo",
+};
+
+interface PickedImage {
+  file: File;
+  previewUrl: string;
+}
+
+function PoseDropzone({
+  pose,
+  picked,
+  qcCode,
+  localError,
+  onFile,
+}: {
+  pose: CapturePose;
+  picked: PickedImage | null;
+  /** capture-qc.md code when this pose failed QC (error state). */
+  qcCode: string | null;
+  localError: string | null;
+  onFile: (file: File) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const pick = () => inputRef.current?.click();
+  const knownCode =
+    qcCode && qcCode in QC_GUIDANCE ? (qcCode as QcFailCode) : null;
+
+  return (
+    <div className="flex flex-col gap-2" data-pose={pose}>
+      <span
+        id={`pose-label-${pose}`}
+        className="text-body font-semibold text-text"
+      >
+        {POSE_LABEL[pose]}
+      </span>
+
+      {qcCode ? (
+        // Figma 549:2 side-pose exemplar: dashed error dropzone + hint chip.
+        <button
+          type="button"
+          aria-labelledby={`pose-label-${pose}`}
+          onClick={pick}
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={(e) => {
+            e.preventDefault();
+            const file = e.dataTransfer.files[0];
+            if (file) onFile(file);
+          }}
+          data-testid={`pose-error-${pose}`}
+          className="flex aspect-[4/3] w-full flex-col items-center justify-center gap-2 rounded-card border-2 border-dashed border-error p-6"
+        >
+          <AlertTriangle size={24} className="text-error" />
+          <span role="alert" className="text-body font-semibold text-error">
+            Quality check failed
+          </span>
+          <span className="text-micro text-text-2">
+            Follow the hint below, then re-upload this pose
+          </span>
+        </button>
+      ) : picked ? (
+        <div className="flex flex-col gap-2">
+          <div className="relative aspect-[4/3] w-full overflow-hidden rounded-card border border-border bg-bg-elev">
+            {/* eslint-disable-next-line @next/next/no-img-element -- local object URL preview */}
+            <img
+              src={picked.previewUrl}
+              alt={`${POSE_LABEL[pose]} preview`}
+              className="size-full object-cover"
+            />
+          </div>
+          <p className="text-caption text-text-2">
+            {picked.file.name} · uploaded{" "}
+            <button
+              type="button"
+              onClick={pick}
+              className="pl-2 font-semibold text-link underline underline-offset-2"
+            >
+              Replace
+            </button>
+          </p>
+        </div>
+      ) : (
+        <button
+          type="button"
+          aria-labelledby={`pose-label-${pose}`}
+          onClick={pick}
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={(e) => {
+            e.preventDefault();
+            const file = e.dataTransfer.files[0];
+            if (file) onFile(file);
+          }}
+          className={clsx(
+            "flex aspect-[4/3] w-full flex-col items-center justify-center gap-2 rounded-card border-2 border-dashed border-border p-6",
+            "transition-colors duration-120 ease-standard hover:border-text-2 motion-reduce:transition-none",
+          )}
+        >
+          <Camera size={24} className="text-text-2" />
+          <span className="text-body text-text">
+            Drag a photo here or{" "}
+            <span className="font-semibold text-link">browse</span>
+          </span>
+          <span className="text-micro text-text-2">JPEG/PNG/HEIC · 10 MB</span>
+        </button>
+      )}
+
+      {knownCode ? <QCHintChip code={knownCode} pose={pose} /> : null}
+      {localError ? (
+        <p role="alert" className="text-micro text-error">
+          {localError}
+        </p>
+      ) : null}
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept={ACCEPT}
+        hidden
+        data-testid={`capture-file-${pose}`}
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) onFile(file);
+          e.target.value = "";
+        }}
+      />
+    </div>
+  );
+}
+
+export interface UploadMeasurementsViewProps {
+  /**
+   * Latest capture session's `input_height_cm` — the web analogue of
+   * mobile's height prefill. Null when there is none (no fabricated
+   * default; manual sessions carry no height).
+   */
+  prefillHeightCm: number | null;
+  onBack: () => void;
+  onSaved: (session: MeasurementSession) => void;
+}
+
+export function UploadMeasurementsView({
+  prefillHeightCm,
+  onBack,
+  onSaved,
+}: UploadMeasurementsViewProps) {
+  const capture = useCapture(onSaved);
+  const [images, setImages] = useState<Record<CapturePose, PickedImage | null>>(
+    { front: null, side: null },
+  );
+  const [localErrors, setLocalErrors] = useState<
+    Record<CapturePose, string | null>
+  >({ front: null, side: null });
+  const [height, setHeight] = useState(
+    prefillHeightCm === null ? "" : String(prefillHeightCm),
+  );
+
+  const heightCm = Number(height);
+  const heightValid =
+    height.trim() !== "" &&
+    Number.isFinite(heightCm) &&
+    heightCm >= 100 &&
+    heightCm <= 230;
+
+  const pickFile = (pose: CapturePose, file: File) => {
+    if (file.size > MAX_IMAGE_BYTES) {
+      setLocalErrors((prev) => ({
+        ...prev,
+        [pose]: "That photo is over 10 MB — try a smaller one.",
+      }));
+      return;
+    }
+    setLocalErrors((prev) => ({ ...prev, [pose]: null }));
+    setImages((prev) => {
+      const stale = prev[pose];
+      if (stale) URL.revokeObjectURL(stale.previewUrl);
+      return {
+        ...prev,
+        [pose]: { file, previewUrl: URL.createObjectURL(file) },
+      };
+    });
+    // Re-picking the failing pose clears its QC error (the retry re-enters
+    // this pose only — the pose counter never advances, flows/vault.md §1).
+    if (capture.qcFailure?.pose === pose) capture.clearQcFailure();
+  };
+
+  const canSubmit =
+    images.front !== null &&
+    images.side !== null &&
+    heightValid &&
+    capture.qcFailure === null;
+
+  const submit = () => {
+    if (!images.front || !images.side || !heightValid) return;
+    void capture.upload(images.front.file, images.side.file, heightCm);
+  };
+
+  const retake = () => {
+    void capture.retake();
+    setImages((prev) => {
+      for (const picked of Object.values(prev)) {
+        if (picked) URL.revokeObjectURL(picked.previewUrl);
+      }
+      return { front: null, side: null };
+    });
+  };
+
+  // A QC failure discards only the failing pose's file — render that pose's
+  // dropzone in its error state (the accepted pose keeps its thumbnail).
+  const qcPose = capture.qcFailure?.pose ?? null;
+
+  return (
+    <div
+      className="mx-auto flex max-w-2xl flex-col gap-6 px-4 py-6"
+      data-testid="upload-measurements"
+    >
+      <div>
+        <Button kind="link" onClick={onBack} className="-ml-1">
+          <ChevronLeft size={16} aria-hidden />
+          Back to vault
+        </Button>
+      </div>
+
+      {capture.phase === "processing" ? (
+        <div
+          aria-busy="true"
+          aria-live="polite"
+          className="flex flex-col items-center gap-3 py-10"
+          data-testid="capture-processing"
+        >
+          <ProcessingConstellation
+            state="processing"
+            imageSrc={capture.previewUrl ?? undefined}
+          />
+          <p className="text-body text-text-2">Measuring — hold on…</p>
+        </div>
+      ) : capture.phase === "results" || capture.phase === "saving" ? (
+        capture.pending ? (
+          <CaptureResults
+            confidences={capture.pending.measurements.map(
+              (m) => m.confidence ?? 1,
+            )}
+            onSave={() => void capture.save()}
+            onRetake={retake}
+            saving={capture.phase === "saving"}
+          >
+            {capture.pending.measurements.map((m) => (
+              <MeasurementCard
+                key={m.id}
+                name={m.name}
+                valueCm={m.value_cm}
+                source="scan"
+                confidence={m.confidence}
+              />
+            ))}
+          </CaptureResults>
+        ) : null
+      ) : (
+        <form
+          className="flex flex-col gap-6"
+          onSubmit={(e) => {
+            e.preventDefault();
+            submit();
+          }}
+        >
+          {/* Figma 549:2 header block — in-content, left-aligned. */}
+          <header className="flex flex-col gap-1">
+            <h1 className="text-title-lg font-bold text-text">
+              Upload measurements
+            </h1>
+            <p className="text-body text-text-2">
+              Two photos — front and side — plus your height. We map 33
+              landmarks per photo.
+            </p>
+            <p className="text-caption text-text-2">
+              Best experience: guided capture on the Apparule app
+            </p>
+          </header>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <PoseDropzone
+              pose="front"
+              picked={qcPose === "front" ? null : images.front}
+              qcCode={qcPose === "front" ? capture.qcFailure!.code : null}
+              localError={localErrors.front}
+              onFile={(file) => pickFile("front", file)}
+            />
+            <PoseDropzone
+              pose="side"
+              picked={qcPose === "side" ? null : images.side}
+              qcCode={qcPose === "side" ? capture.qcFailure!.code : null}
+              localError={localErrors.side}
+              onFile={(file) => pickFile("side", file)}
+            />
+          </div>
+
+          <FormRow
+            label="Height (cm)"
+            helper="Used to scale your photos — 100–230 cm"
+            required
+            className="max-w-xs"
+          >
+            <Input
+              kind="numeric"
+              aria-label="Height in centimeters"
+              value={height}
+              onChange={(e) => setHeight(e.target.value)}
+            />
+          </FormRow>
+
+          <div>
+            <Button
+              kind="gradient-primary"
+              type="submit"
+              disabled={!canSubmit}
+              data-testid="get-measurements"
+            >
+              Get measurements
+            </Button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/dashboard/vault/VaultView.tsx
+++ b/web/src/components/dashboard/vault/VaultView.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 // B4 — Measurement vault: freshness-ring header (MI-11) + Retake CTA →
-// capture options (webcam upload / manual entry MI-13) · MeasurementCard
-// grid with history sparklines · history sheet (SessionRow + delete) ·
-// consent/retention notice with the rights links (resolve at B7 Account &
-// data). Render-only over useVault.
+// capture options (photo upload / manual entry MI-13 — upload-only, M-12) ·
+// MeasurementCard grid with history sparklines · history sheet (SessionRow
+// + delete) · consent/retention notice with the rights links (resolve at B7
+// Account & data). Picking photo upload takes over the page with the
+// two-photo UploadMeasurementsView (Figma 549:2). Render-only over useVault.
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import { formatAgoPhrase } from "@/lib/format";
@@ -18,20 +19,23 @@ import { MeasurementCard } from "@/components/ui/MeasurementCard";
 import { SessionRow } from "@/components/ui/SessionRow";
 import { Sheet } from "@/components/ui/Sheet";
 import { Skeleton } from "@/components/ui/Skeleton";
-import {
-  CaptureOptionsSheet,
-  ManualEntrySheet,
-  WebcamCaptureSheet,
-} from "./CaptureSheets";
+import { CaptureOptionsSheet, ManualEntrySheet } from "./CaptureSheets";
+import { UploadMeasurementsView } from "./UploadMeasurementsView";
 import { useToasts } from "../toast-context";
 
-export function VaultView() {
+export interface VaultViewProps {
+  /** M-11: the Create chooser hands off with the options sheet open. */
+  initialSheet?: "options" | null;
+}
+
+export function VaultView({ initialSheet = null }: VaultViewProps) {
   const { account } = useAuth();
   const vault = useVault();
   const { showToast } = useToasts();
-  const [sheet, setSheet] = useState<
-    null | "options" | "webcam" | "manual" | "history"
-  >(null);
+  const [sheet, setSheet] = useState<null | "options" | "manual" | "history">(
+    initialSheet,
+  );
+  const [uploading, setUploading] = useState(false);
 
   const sessionById = useMemo(() => {
     const map = new Map<string, MeasurementSession>();
@@ -77,6 +81,27 @@ export function VaultView() {
       );
 
   const latestComplete = vault.sessions.find((s) => s.status === "complete");
+
+  // Height prefill for the upload flow: the latest capture session's
+  // input_height_cm (manual sessions carry null — never fabricate one).
+  const prefillHeightCm =
+    vault.sessions.find(
+      (s) => s.method !== "manual" && s.input_height_cm !== null,
+    )?.input_height_cm ?? null;
+
+  if (uploading) {
+    return (
+      <UploadMeasurementsView
+        prefillHeightCm={prefillHeightCm}
+        onBack={() => setUploading(false)}
+        onSaved={() => {
+          showToast({ kind: "success", message: "Saved to your vault" });
+          setUploading(false);
+          void vault.reload();
+        }}
+      />
+    );
+  }
 
   return (
     <div className="mx-auto flex max-w-2xl flex-col gap-6 px-4 py-6">
@@ -184,23 +209,16 @@ export function VaultView() {
       <CaptureOptionsSheet
         open={sheet === "options"}
         onOpenChange={(open) => setSheet(open ? "options" : null)}
-        onPick={(mode) =>
-          setSheet(mode === "webcam-upload" ? "webcam" : "manual")
-        }
-      />
-      <WebcamCaptureSheet
-        open={sheet === "webcam"}
-        onOpenChange={(open) => setSheet(open ? "webcam" : null)}
-        onSaved={() => {
-          showToast({ kind: "success", message: "Saved to your vault" });
-          void vault.reload();
+        onPick={(mode) => {
+          setSheet(mode === "manual-entry" ? "manual" : null);
+          if (mode === "photo-upload") setUploading(true);
         }}
       />
       <ManualEntrySheet
         open={sheet === "manual"}
         onOpenChange={(open) => setSheet(open ? "manual" : null)}
-        onSave={async (heightCm, measurements) => {
-          await vault.addManualSession(heightCm, measurements);
+        onSave={async (measurements) => {
+          await vault.addManualSession(measurements);
           showToast({ kind: "success", message: "Saved to your vault" });
         }}
       />

--- a/web/src/components/home/mobile-thumbs.tsx
+++ b/web/src/components/home/mobile-thumbs.tsx
@@ -117,7 +117,9 @@ export function VaultThumb() {
           <span className="text-body-lg font-semibold text-text">
             Retake your measurements
           </span>
-          <CaptureOptionCard mode="webcam-upload" />
+          {/* Mobile C7 keeps the live guided camera (M-12) — the thumb
+              renders the mobile title over the shared master copy. */}
+          <CaptureOptionCard mode="photo-upload" title="Use your camera" />
           <CaptureOptionCard mode="manual-entry" />
         </div>
       </div>

--- a/web/src/components/ui/AppBar.test.tsx
+++ b/web/src/components/ui/AppBar.test.tsx
@@ -36,4 +36,29 @@ describe("AppBar (§8.2b)", () => {
     expect(bar.className).not.toContain("border-b");
     expect(bar.className).toContain("to-transparent");
   });
+
+  it.each(["sub", "over-media"] as const)(
+    "%s: title centers on the FULL bar width — absolute layer, not the between-actions remainder (M-9)",
+    (kind) => {
+      render(<AppBar kind={kind} title="Order #APR-1042" onBack={() => {}} />);
+      const layer = screen.getByTestId("appbar-title");
+      // Absolute, full-width, center-aligned, click-through — a hidden
+      // trailing slot can never skew the title off the bar's true center.
+      expect(layer.className).toContain("absolute");
+      expect(layer.className).toContain("inset-x-0");
+      expect(layer.className).toContain("justify-center");
+      expect(layer.className).toContain("pointer-events-none");
+      // px-14 reserves the widest action slot on both sides symmetrically.
+      expect(layer.className).toContain("px-14");
+      expect(layer).toHaveTextContent("Order #APR-1042");
+    },
+  );
+
+  it("root: wordmark stays in-flow left (M-9 exemption)", () => {
+    render(<AppBar kind="root" title="Apparule" />);
+    expect(screen.queryByTestId("appbar-title")).not.toBeInTheDocument();
+    const wordmark = screen.getByText("Apparule");
+    expect(wordmark.className).not.toContain("absolute");
+    expect(wordmark.className).toContain("bg-accent-gradient");
+  });
 });

--- a/web/src/components/ui/AppBar.tsx
+++ b/web/src/components/ui/AppBar.tsx
@@ -2,6 +2,13 @@
 
 // AppBar — design.md §8.2b: kind root (title/logo + action slot) / sub
 // (chevron-left + title + trailing action) / over-media (transparent).
+// Row alignment (M-9, ratified 2026-07-22): sub/over-media titles center on
+// the FULL bar width — an absolute, full-width, center-aligned text layer
+// over the bar, never an in-flow element between the slots (an in-flow
+// title grows into a hidden trailing slot and skews off-center — with a
+// back-only bar the old layout sat ~22px right of true center).
+// Leading/trailing slots stay in-flow at the edges; the title's horizontal
+// padding reserves the widest slot. `root` (left wordmark) is exempt.
 import type { ReactNode } from "react";
 import clsx from "clsx";
 import { ChevronLeft } from "lucide-react";
@@ -29,7 +36,7 @@ export function AppBar({
     <header
       data-kind={kind}
       className={clsx(
-        "flex h-14 items-center gap-2 px-4",
+        "relative flex h-14 items-center gap-2 px-4",
         kind === "over-media"
           ? // On-media capture/photo chrome — raw white on a scrim is the
             // documented token exception (web-implementation.md §3 note).
@@ -52,20 +59,27 @@ export function AppBar({
           <ChevronLeft size={24} />
         </button>
       ) : null}
-      <div
-        className={clsx(
-          "min-w-0 flex-1 truncate font-semibold",
-          // Figma master (85:994): root paints the gradient wordmark;
-          // sub/over-media center a 16px title between the actions.
-          kind === "root"
-            ? "bg-accent-gradient bg-clip-text text-title text-transparent"
-            : "text-center text-body-lg",
-        )}
-      >
-        {title}
-      </div>
+      {kind === "root" ? (
+        // Figma master (85:994): root paints the gradient wordmark, left.
+        <div className="min-w-0 flex-1 truncate bg-accent-gradient bg-clip-text text-title font-semibold text-transparent">
+          {title}
+        </div>
+      ) : (
+        // M-9: the 16px title centers on the full bar width — an absolute
+        // layer over the bar (not the between-actions flex remainder).
+        // px-14 reserves the widest action slot (44px + bar padding);
+        // pointer-events-none keeps the in-flow slots clickable beneath.
+        <div
+          data-testid="appbar-title"
+          className="pointer-events-none absolute inset-x-0 top-0 flex h-full items-center justify-center px-14"
+        >
+          <span className="truncate text-body-lg font-semibold">{title}</span>
+        </div>
+      )}
       {trailing ? (
-        <div className="flex shrink-0 items-center gap-1">{trailing}</div>
+        <div className="ml-auto flex shrink-0 items-center gap-1">
+          {trailing}
+        </div>
       ) : null}
     </header>
   );

--- a/web/src/components/ui/Button.test.tsx
+++ b/web/src/components/ui/Button.test.tsx
@@ -11,13 +11,25 @@ describe("Button (§8.2)", () => {
     );
   });
 
-  it.each(["gradient-primary", "quiet", "destructive", "link"] as const)(
-    "renders kind=%s",
-    (kind) => {
-      render(<Button kind={kind}>Go</Button>);
-      expect(screen.getByRole("button")).toHaveAttribute("data-kind", kind);
-    },
-  );
+  it.each([
+    "gradient-primary",
+    "quiet",
+    "destructive",
+    "link",
+    "quiet-danger",
+  ] as const)("renders kind=%s", (kind) => {
+    render(<Button kind={kind}>Go</Button>);
+    expect(screen.getByRole("button")).toHaveAttribute("data-kind", kind);
+  });
+
+  it("quiet-danger is the danger-ladder row rung: quiet chrome + error label", () => {
+    render(<Button kind="quiet-danger">Delete all</Button>);
+    const button = screen.getByRole("button");
+    // quiet chrome (border + elevated bg), error-toned label — Figma 501:2
+    expect(button.className).toContain("border-border");
+    expect(button.className).toContain("bg-bg-elev");
+    expect(button.className).toContain("text-error");
+  });
 
   it("renders both sizes (md 44 / sm 36)", () => {
     const { rerender } = render(<Button size="md">A</Button>);

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -1,15 +1,20 @@
 "use client";
 
 // Button — design.md §8.2: kind gradient-primary / quiet / destructive /
-// link · size md 44 / sm 36 · state default / pressed / disabled / loading.
-// Figma master (39:66): radius/card corners, px 16/12, label 14/13 semibold,
-// disabled 40%, loading = spinner-only. Pressed = Figma overlay tint +
-// active scale (fast/standard, reduced-motion safe).
+// link / quiet-danger · size md 44 / sm 36 · state default / pressed /
+// disabled / loading. Figma master (39:66): radius/card corners, px 16/12,
+// label 14/13 semibold, disabled 40%, loading = spinner-only. Pressed =
+// Figma overlay tint + active scale (fast/standard, reduced-motion safe).
+// Danger ladder [Decided 2026-07-22]: row-level destructive actions render
+// quiet-danger (quiet chrome, error-toned label — Figma 501:2); the filled
+// destructive kind is reserved for armed/confirm surfaces (delete-confirm
+// sheet, dispute/decline sheets) — never both rungs on one surface.
 import { forwardRef, type ButtonHTMLAttributes } from "react";
 import clsx from "clsx";
 import { Spinner } from "./Spinner";
 
-export type ButtonKind = "gradient-primary" | "quiet" | "destructive" | "link";
+export type ButtonKind =
+  "gradient-primary" | "quiet" | "destructive" | "link" | "quiet-danger";
 export type ButtonSize = "md" | "sm";
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -57,6 +62,9 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
             "bg-error text-on-accent enabled:active:shadow-[inset_0_0_0_999px_rgba(0,0,0,0.16)]",
           kind === "link" &&
             "text-link underline-offset-2 hover:underline enabled:active:bg-[rgba(128,128,128,0.18)]",
+          // Danger-ladder row rung (Figma 501:2): quiet chrome, error label.
+          kind === "quiet-danger" &&
+            "border border-border bg-bg-elev text-error enabled:active:bg-[rgba(128,128,128,0.18)]",
           className,
         )}
         {...rest}
@@ -66,7 +74,11 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           // width (spinner 18 md / 16 sm, on-accent on filled kinds).
           <Spinner
             size={size === "md" ? 18 : 16}
-            kind={kind === "quiet" || kind === "link" ? "neutral" : "on-accent"}
+            kind={
+              kind === "quiet" || kind === "link" || kind === "quiet-danger"
+                ? "neutral"
+                : "on-accent"
+            }
           />
         ) : (
           children

--- a/web/src/components/ui/CaptureOptionCard.test.tsx
+++ b/web/src/components/ui/CaptureOptionCard.test.tsx
@@ -4,13 +4,14 @@ import userEvent from "@testing-library/user-event";
 import { CaptureOptionCard } from "./CaptureOptionCard";
 
 describe("CaptureOptionCard (§8.2b)", () => {
-  it("mode=webcam-upload renders its copy", () => {
-    render(<CaptureOptionCard mode="webcam-upload" />);
+  it("mode=photo-upload renders the upload copy (M-12: no webcam mode)", () => {
+    render(<CaptureOptionCard mode="photo-upload" />);
     const card = screen.getByRole("button");
-    // Figma master (66:696) carries the canonical copy
-    expect(card).toHaveAttribute("data-mode", "webcam-upload");
-    expect(card).toHaveTextContent("Use your camera");
-    expect(card).toHaveTextContent("Full-body photo, we measure automatically");
+    // Figma master (66:721) carries the canonical copy; the title is the
+    // web B4 upload phrasing (per-platform override, canvas ledger).
+    expect(card).toHaveAttribute("data-mode", "photo-upload");
+    expect(card).toHaveTextContent("Upload photos");
+    expect(card).toHaveTextContent("Two photos — we measure automatically");
   });
 
   it("mode=manual-entry renders its copy", () => {
@@ -22,7 +23,7 @@ describe("CaptureOptionCard (§8.2b)", () => {
 
   it("fires onClick", async () => {
     const onClick = vi.fn();
-    render(<CaptureOptionCard mode="webcam-upload" onClick={onClick} />);
+    render(<CaptureOptionCard mode="photo-upload" onClick={onClick} />);
     await userEvent.click(screen.getByRole("button"));
     expect(onClick).toHaveBeenCalledOnce();
   });

--- a/web/src/components/ui/CaptureOptionCard.tsx
+++ b/web/src/components/ui/CaptureOptionCard.tsx
@@ -1,25 +1,34 @@
 "use client";
 
-// CaptureOptionCard — design.md §8.2b: mode webcam-upload / manual-entry —
+// CaptureOptionCard — design.md §8.2b: mode photo-upload / manual-entry —
 // the vault "Retake" options (pages.md B4 header; phone hand-off QR was cut
-// from scope).
+// from scope; the webcam flow was removed per M-12 — web capture is
+// upload-only, mode renamed webcam-upload → photo-upload).
 import clsx from "clsx";
 import { Camera, ChevronRight, PencilRuler } from "lucide-react";
 
-export type CaptureOptionMode = "webcam-upload" | "manual-entry";
+export type CaptureOptionMode = "photo-upload" | "manual-entry";
 
 export interface CaptureOptionCardProps {
   mode: CaptureOptionMode;
+  /**
+   * Title override — the photo-upload master's title is per-platform
+   * ("Use your camera" on mobile C7, upload phrasing on web B4); the
+   * marketing thumbs depicting the mobile app pass the mobile string.
+   */
+  title?: string;
   onClick?: () => void;
   className?: string;
 }
 
-// Figma masters (66:721) carry the canonical copy.
+// Figma masters (66:721) carry the canonical copy; the photo-upload title
+// is the web B4 upload phrasing (the master's "Use your camera" is the
+// mobile C7 string — per-platform override recorded in the canvas ledger).
 const OPTION_COPY: Record<CaptureOptionMode, { title: string; body: string }> =
   {
-    "webcam-upload": {
-      title: "Use your camera",
-      body: "Full-body photo, we measure automatically",
+    "photo-upload": {
+      title: "Upload photos",
+      body: "Two photos — we measure automatically",
     },
     "manual-entry": {
       title: "Enter manually",
@@ -29,11 +38,13 @@ const OPTION_COPY: Record<CaptureOptionMode, { title: string; body: string }> =
 
 export function CaptureOptionCard({
   mode,
+  title,
   onClick,
   className,
 }: CaptureOptionCardProps) {
   const copy = OPTION_COPY[mode];
-  const Icon = mode === "webcam-upload" ? Camera : PencilRuler;
+  const cardTitle = title ?? copy.title;
+  const Icon = mode === "photo-upload" ? Camera : PencilRuler;
   return (
     <button
       type="button"
@@ -51,7 +62,7 @@ export function CaptureOptionCard({
         <Icon size={20} aria-hidden="true" />
       </span>
       <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="text-body font-semibold text-text">{copy.title}</span>
+        <span className="text-body font-semibold text-text">{cardTitle}</span>
         <span className="text-caption text-text-2">{copy.body}</span>
       </span>
       <ChevronRight size={16} className="shrink-0 text-text-2" aria-hidden />

--- a/web/src/components/ui/CommentRow.test.tsx
+++ b/web/src/components/ui/CommentRow.test.tsx
@@ -42,4 +42,26 @@ describe("CommentRow (§8.2b)", () => {
     await userEvent.click(screen.getByRole("button", { name: "Reply" }));
     expect(onReply).toHaveBeenCalledOnce();
   });
+
+  it("authorHref links avatar + username to the profile (entity-nav rule)", () => {
+    render(
+      <CommentRow
+        comment={fixtureComment}
+        authorHref="/dashboard/kiki.adeyemi"
+      />,
+    );
+    expect(screen.getByTestId("comment-author-avatar")).toHaveAttribute(
+      "href",
+      "/dashboard/kiki.adeyemi",
+    );
+    expect(screen.getByRole("link", { name: "kiki.adeyemi" })).toHaveAttribute(
+      "href",
+      "/dashboard/kiki.adeyemi",
+    );
+  });
+
+  it("without authorHref the row stays inert (gallery renders)", () => {
+    render(<CommentRow comment={fixtureComment} />);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
 });

--- a/web/src/components/ui/CommentRow.tsx
+++ b/web/src/components/ui/CommentRow.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-// CommentRow — design.md §8.2b: avatar 32 + username + text + timestamp +
-// like heart · state default / liked / posting-optimistic (MI-18) /
-// reply-indent.
+// CommentRow — design.md §8.2b: avatar 32 + username → author profile +
+// text + timestamp + like heart · state default / liked /
+// posting-optimistic (MI-18) / reply-indent. Entity-navigation rule
+// (Decided 2026-07-22): consumers pass authorHref so the avatar and
+// username are real links; gallery renders omit it.
 import clsx from "clsx";
+import Link from "next/link";
 import { Heart } from "lucide-react";
 import type { Comment } from "@/models";
 import { formatAgo } from "@/lib/format";
@@ -11,6 +14,8 @@ import { Avatar } from "./Avatar";
 
 export interface CommentRowProps {
   comment: Comment;
+  /** Author-profile href — renders avatar + username as the profile link. */
+  authorHref?: string;
   /** MI-18: renders dimmed while the optimistic post is in flight. */
   posting?: boolean;
   replyIndent?: boolean;
@@ -21,6 +26,7 @@ export interface CommentRowProps {
 
 export function CommentRow({
   comment,
+  authorHref,
   posting = false,
   replyIndent = false,
   onToggleLike,
@@ -38,16 +44,37 @@ export function CommentRow({
         className,
       )}
     >
-      <Avatar
-        size={32}
-        name={comment.author.username}
-        src={comment.author.avatar_url}
-      />
+      {authorHref ? (
+        <Link
+          href={authorHref}
+          aria-label={`${comment.author.username}'s profile`}
+          data-testid="comment-author-avatar"
+          className="shrink-0"
+        >
+          <Avatar
+            size={32}
+            name={comment.author.username}
+            src={comment.author.avatar_url}
+          />
+        </Link>
+      ) : (
+        <Avatar
+          size={32}
+          name={comment.author.username}
+          src={comment.author.avatar_url}
+        />
+      )}
       <div className="min-w-0 flex-1">
         {/* Figma master (92:1077): the comment text stays visible while
             posting; the meta line reads "Posting…" */}
         <p className="text-body text-text">
-          <span className="font-semibold">{comment.author.username}</span>{" "}
+          {authorHref ? (
+            <Link href={authorHref} className="font-semibold">
+              {comment.author.username}
+            </Link>
+          ) : (
+            <span className="font-semibold">{comment.author.username}</span>
+          )}{" "}
           {comment.body}
         </p>
         <div className="mt-1 flex items-center gap-4 text-micro text-text-2">

--- a/web/src/components/ui/NavRail.test.tsx
+++ b/web/src/components/ui/NavRail.test.tsx
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "@/design/ThemeProvider";
 import { DEFAULT_NAV_ITEMS, NavRail } from "./NavRail";
 
@@ -80,5 +81,22 @@ describe("NavRail (§8.2b)", () => {
       ),
     });
     expect(screen.getByTestId("nav-badge")).toHaveTextContent("3");
+  });
+
+  it("an onSelect item renders as a dialog-opening button, not a link (M-11 Create)", async () => {
+    const onSelect = vi.fn();
+    renderRail({
+      expanded: true,
+      items: DEFAULT_NAV_ITEMS.map((i) =>
+        i.key === "create" ? { ...i, onSelect } : i,
+      ),
+    });
+    const create = screen.getByRole("button", { name: "Create" });
+    expect(create).toHaveAttribute("aria-haspopup", "dialog");
+    expect(
+      screen.queryByRole("link", { name: "Create" }),
+    ).not.toBeInTheDocument();
+    await userEvent.click(create);
+    expect(onSelect).toHaveBeenCalledOnce();
   });
 });

--- a/web/src/components/ui/NavRail.tsx
+++ b/web/src/components/ui/NavRail.tsx
@@ -31,6 +31,12 @@ export interface NavRailItemSpec {
   icon: LucideIcon;
   /** Orders badge (MI-16): unread count, clears on tab visit. */
   badge?: number;
+  /**
+   * Action items (M-11: Create opens the two-option chooser) render as a
+   * button firing this instead of a Link — the href stays as the fallback
+   * for decorative rails (marketing thumbs) that pass no handler.
+   */
+  onSelect?: () => void;
 }
 
 // Figma master (84:1046): explore = search glyph, create = plain plus.
@@ -154,17 +160,8 @@ export function NavRailItem({
   expanded: boolean;
 }) {
   const Icon = item.icon;
-  return (
-    <Link
-      href={item.href}
-      // Rails also render inside decorative home-page thumbs, where
-      // viewport prefetch 404s against unshipped /dashboard/* routes on
-      // the live landing (W2.1 live-QA).
-      prefetch={false}
-      aria-current={active ? "page" : undefined}
-      data-state={active ? "active" : "default"}
-      className={itemClasses(active, expanded)}
-    >
+  const content = (
+    <>
       <span className="relative">
         {active ? (
           <span
@@ -183,6 +180,34 @@ export function NavRailItem({
         ) : null}
       </span>
       {expanded ? <span>{item.label}</span> : null}
+    </>
+  );
+  if (item.onSelect) {
+    // Action pillar (M-11: Create → chooser dialog), not navigation.
+    return (
+      <button
+        type="button"
+        onClick={item.onSelect}
+        aria-haspopup="dialog"
+        data-state={active ? "active" : "default"}
+        className={clsx("w-full", itemClasses(active, expanded))}
+      >
+        {content}
+      </button>
+    );
+  }
+  return (
+    <Link
+      href={item.href}
+      // Rails also render inside decorative home-page thumbs, where
+      // viewport prefetch 404s against unshipped /dashboard/* routes on
+      // the live landing (W2.1 live-QA).
+      prefetch={false}
+      aria-current={active ? "page" : undefined}
+      data-state={active ? "active" : "default"}
+      className={itemClasses(active, expanded)}
+    >
+      {content}
     </Link>
   );
 }

--- a/web/src/components/ui/PostCard.test.tsx
+++ b/web/src/components/ui/PostCard.test.tsx
@@ -75,4 +75,24 @@ describe("PostCard (§3 anatomy + §8.2)", () => {
     fireEvent.click(media);
     expect(onToggleLike).not.toHaveBeenCalled();
   });
+
+  it("authorHref links the header (avatar + username) and caption username (entity-nav rule)", () => {
+    render(
+      <PostCard post={fixturePost} authorHref="/dashboard/amara.designs" />,
+    );
+    const header = screen.getByTestId("post-author-link");
+    expect(header).toHaveAttribute("href", "/dashboard/amara.designs");
+    expect(header).toHaveTextContent("amara.designs");
+    // header link + caption link — both real anchors
+    const links = screen
+      .getAllByRole("link")
+      .filter((a) => a.getAttribute("href") === "/dashboard/amara.designs");
+    expect(links.length).toBe(2);
+  });
+
+  it("without authorHref the card stays inert (marketing mocks, gallery)", () => {
+    render(<PostCard post={fixturePost} />);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("post-author-link")).not.toBeInTheDocument();
+  });
 });

--- a/web/src/components/ui/PostCard.tsx
+++ b/web/src/components/ui/PostCard.tsx
@@ -2,13 +2,17 @@
 
 // PostCard — design.md §3 anatomy + §8.2: media single / carousel (dots) ·
 // CTA with/without "Request this outfit" · state default / skeleton.
-// Anatomy: header (avatar, username, badge, ⋯) · media carousel (MI-4) ·
-// action row (MI-1/2/3) · like count · caption (2-line clamp, "more") ·
-// request CTA (full-width quiet button — Apparule's one IG addition) ·
-// timestamp. MI-1: double-tap/double-click media → 96px heart burst + like.
+// Anatomy: header (avatar + username → designer profile, badge, ⋯) · media
+// carousel (MI-4) · action row (MI-1/2/3) · like count · caption (2-line
+// clamp, "more") · request CTA (full-width quiet button — Apparule's one IG
+// addition) · timestamp. MI-1: double-tap/double-click media → 96px heart
+// burst + like. Entity-navigation rule (design.md §3, Decided 2026-07-22):
+// product surfaces pass authorHref so the header and caption usernames are
+// real links; marketing mocks / gallery renders omit it and stay inert.
 import { useRef, useState } from "react";
 import clsx from "clsx";
 import Image from "next/image";
+import Link from "next/link";
 import { ChevronLeft, ChevronRight, Heart, MoreHorizontal } from "lucide-react";
 import type { Post } from "@/models";
 import { formatAgo } from "@/lib/format";
@@ -30,6 +34,12 @@ export interface PostCardProps {
   mediaPriority?: boolean;
   /** next/image `sizes` override for scaled contexts (e.g. the hero mock). */
   mediaSizes?: string;
+  /**
+   * Designer-profile href — renders the header avatar+username and the
+   * caption's leading username as real anchors (entity-navigation rule).
+   * Omit in pointer-inert contexts (marketing mocks, dev gallery).
+   */
+  authorHref?: string;
   onToggleLike?: () => void;
   onToggleSave?: () => void;
   onRequest?: () => void;
@@ -44,6 +54,7 @@ export function PostCard({
   skeleton = false,
   mediaPriority = false,
   mediaSizes = "(max-width: 768px) 100vw, 630px",
+  authorHref,
   onToggleLike,
   onToggleSave,
   onRequest,
@@ -83,17 +94,39 @@ export function PostCard({
         className,
       )}
     >
-      {/* header — Figma master (52:462): px 12 / py 8 / gap 8 */}
+      {/* header — Figma master (52:462): px 12 / py 8 / gap 8. Avatar +
+          username are one profile link when authorHref is set (the exact
+          sibling of the mobile PostCard author-tap fix). */}
       <header className="flex items-center gap-2 px-3 py-2">
-        <Avatar
-          size={32}
-          name={post.designer.display_name}
-          src={post.designer.avatar_url}
-          verified={post.designer.verified}
-        />
-        <span className="text-body font-semibold text-text">
-          {post.designer.username}
-        </span>
+        {authorHref ? (
+          <Link
+            href={authorHref}
+            data-testid="post-author-link"
+            className="flex min-w-0 items-center gap-2"
+          >
+            <Avatar
+              size={32}
+              name={post.designer.display_name}
+              src={post.designer.avatar_url}
+              verified={post.designer.verified}
+            />
+            <span className="truncate text-body font-semibold text-text">
+              {post.designer.username}
+            </span>
+          </Link>
+        ) : (
+          <>
+            <Avatar
+              size={32}
+              name={post.designer.display_name}
+              src={post.designer.avatar_url}
+              verified={post.designer.verified}
+            />
+            <span className="text-body font-semibold text-text">
+              {post.designer.username}
+            </span>
+          </>
+        )}
         <IconButton
           aria-label="More options"
           size="sm"
@@ -219,7 +252,12 @@ export function PostCard({
             !captionOpen && "line-clamp-2",
           )}
         >
-          {post.designer.username} {post.caption}
+          {authorHref ? (
+            <Link href={authorHref}>{post.designer.username}</Link>
+          ) : (
+            post.designer.username
+          )}{" "}
+          {post.caption}
           {!captionOpen && post.caption.length > 80 ? (
             <>
               {" "}

--- a/web/src/components/ui/QCHintChip.test.tsx
+++ b/web/src/components/ui/QCHintChip.test.tsx
@@ -1,12 +1,19 @@
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { QCHintChip, QC_GUIDANCE, type QcFailCode } from "./QCHintChip";
+import {
+  QCHintChip,
+  QC_GUIDANCE,
+  QC_GUIDANCE_SIDE,
+  qcGuidance,
+  type QcFailCode,
+} from "./QCHintChip";
 
 const ALL_CODES = Object.keys(QC_GUIDANCE) as QcFailCode[];
 
 describe("QCHintChip (§8.2b)", () => {
-  it("covers the full capture-qc.md §1–2 code set (×11)", () => {
-    expect(ALL_CODES).toHaveLength(11);
+  it("covers the full capture-qc.md §1–2 code set (×12, incl. not_side_profile)", () => {
+    expect(ALL_CODES).toHaveLength(12);
+    expect(ALL_CODES).toContain("not_side_profile");
   });
 
   it.each(ALL_CODES)("renders the canonical guidance line for %s", (code) => {
@@ -20,5 +27,24 @@ describe("QCHintChip (§8.2b)", () => {
     expect(QC_GUIDANCE.no_body).toBe("Make sure your whole body is visible");
     expect(QC_GUIDANCE.too_far).toBe("Move closer — fill more of the frame");
     expect(QC_GUIDANCE.camera_tilt).toBe("Hold the phone upright");
+    expect(QC_GUIDANCE.not_side_profile).toBe(
+      "Turn your right side to the camera",
+    );
+  });
+
+  it("arms_position guidance is per pose (capture-qc.md §2 pose-2 delta)", () => {
+    expect(qcGuidance("arms_position", "front")).toBe(
+      "Keep arms slightly away from your body",
+    );
+    expect(qcGuidance("arms_position", "side")).toBe(
+      "Let your arms hang relaxed at your sides",
+    );
+    expect(QC_GUIDANCE_SIDE.arms_position).toBe(
+      "Let your arms hang relaxed at your sides",
+    );
+    render(<QCHintChip code="arms_position" pose="side" />);
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Let your arms hang relaxed at your sides",
+    );
   });
 });

--- a/web/src/components/ui/QCHintChip.tsx
+++ b/web/src/components/ui/QCHintChip.tsx
@@ -1,6 +1,8 @@
-// QCHintChip — design.md §8.2b: code ×11, one actionable guidance line each.
-// Fail codes from capture-qc.md §1–2; canonical retake copy from the
-// flows/vault.md QC-failures row (the same strings the 422 envelope carries).
+// QCHintChip — design.md §8.2b: code ×12, one actionable guidance line each.
+// Fail codes from capture-qc.md §1–2 (per-pose QC, M-10: the side pose adds
+// `not_side_profile` and swaps the `arms_position` copy); canonical retake
+// copy from the flows/vault.md QC-failures row (the same strings the 422
+// envelope carries).
 import clsx from "clsx";
 import { Camera, Ruler, Search, User, X, type LucideIcon } from "lucide-react";
 
@@ -13,6 +15,7 @@ export type QcFailCode =
   | "poor_lighting"
   | "blurry"
   | "not_frontal"
+  | "not_side_profile"
   | "camera_tilt"
   | "arms_position"
   | "too_far";
@@ -27,10 +30,27 @@ export const QC_GUIDANCE: Record<QcFailCode, string> = {
   poor_lighting: "Find better lighting — avoid strong backlight",
   blurry: "Hold steady and retake",
   not_frontal: "Face the camera straight on",
+  not_side_profile: "Turn your right side to the camera",
   camera_tilt: "Hold the phone upright",
   arms_position: "Keep arms slightly away from your body",
   too_far: "Move closer — fill more of the frame",
 };
+
+/**
+ * Side-pose copy deltas (capture-qc.md §2 pose-2 table): `arms_position`
+ * guidance is per pose — arms hang relaxed on the side pose.
+ */
+export const QC_GUIDANCE_SIDE: Partial<Record<QcFailCode, string>> = {
+  arms_position: "Let your arms hang relaxed at your sides",
+};
+
+/** The pose-aware guidance line (flows/vault.md: arms copy is per pose). */
+export function qcGuidance(
+  code: QcFailCode,
+  pose: "front" | "side" = "front",
+): string {
+  return (pose === "side" && QC_GUIDANCE_SIDE[code]) || QC_GUIDANCE[code];
+}
 
 /** Figma masters (62:634): the leading glyph names the failure family. */
 const QC_ICON: Record<QcFailCode, LucideIcon> = {
@@ -42,6 +62,7 @@ const QC_ICON: Record<QcFailCode, LucideIcon> = {
   poor_lighting: Camera,
   blurry: Camera,
   not_frontal: User,
+  not_side_profile: User,
   camera_tilt: Camera,
   arms_position: User,
   too_far: Search,
@@ -49,10 +70,16 @@ const QC_ICON: Record<QcFailCode, LucideIcon> = {
 
 export interface QCHintChipProps {
   code: QcFailCode;
+  /** Failing pose — selects the per-pose copy (default front). */
+  pose?: "front" | "side";
   className?: string;
 }
 
-export function QCHintChip({ code, className }: QCHintChipProps) {
+export function QCHintChip({
+  code,
+  pose = "front",
+  className,
+}: QCHintChipProps) {
   const Icon = QC_ICON[code];
   return (
     <span
@@ -66,7 +93,7 @@ export function QCHintChip({ code, className }: QCHintChipProps) {
       )}
     >
       <Icon size={16} className="shrink-0" aria-hidden />
-      <span className="truncate">{QC_GUIDANCE[code]}</span>
+      <span className="truncate">{qcGuidance(code, pose)}</span>
     </span>
   );
 }

--- a/web/src/controllers/use-capture.test.ts
+++ b/web/src/controllers/use-capture.test.ts
@@ -1,5 +1,5 @@
-// Capture controller — MI-12 processing beat, QC failure mapping, save /
-// retake semantics (flows/vault.md §1).
+// Capture controller — MI-12 processing beat, per-pose QC failure mapping
+// (M-10 two-photo canon), save / retake semantics (flows/vault.md §1).
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import { ApiError } from "@/lib/api";
@@ -28,7 +28,8 @@ const pendingSession = {
   created_at: new Date().toISOString(),
 };
 
-const file = new File(["x"], "photo.jpg", { type: "image/jpeg" });
+const front = new File(["x"], "front.jpg", { type: "image/jpeg" });
+const side = new File(["x"], "side.jpg", { type: "image/jpeg" });
 
 beforeEach(() => {
   createCaptureSession.mockReset();
@@ -51,7 +52,7 @@ describe("useCapture", () => {
       const { result } = renderHook(() => useCapture(onSaved));
       let uploadPromise: Promise<void>;
       act(() => {
-        uploadPromise = result.current.upload(file, 168);
+        uploadPromise = result.current.upload(front, side, 168);
       });
       expect(result.current.phase).toBe("processing");
       await act(async () => {
@@ -60,12 +61,58 @@ describe("useCapture", () => {
       });
       expect(result.current.phase).toBe("results");
       expect(result.current.pending?.id).toBe("sess-p");
+      // both files + height rode one request with one idempotency key
+      expect(createCaptureSession).toHaveBeenCalledWith(
+        front,
+        side,
+        168,
+        expect.any(String),
+      );
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("maps QC failures to code + guidance", async () => {
+  it("maps QC failures to code + guidance + failing pose (per-pose QC)", async () => {
+    vi.useFakeTimers();
+    try {
+      createCaptureSession.mockRejectedValue(
+        new ApiError(
+          "not_side_profile",
+          "Turn your right side to the camera",
+          422,
+          {
+            guidance: "Turn your right side to the camera",
+            pose: "side",
+          },
+        ),
+      );
+      const { result } = renderHook(() => useCapture(vi.fn()));
+      let uploadPromise: Promise<void>;
+      act(() => {
+        uploadPromise = result.current.upload(front, side, 168);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1900);
+        await uploadPromise!;
+      });
+      // The failure returns to the form (the failing pose re-uploads) —
+      // never a dead-end phase.
+      expect(result.current.phase).toBe("idle");
+      expect(result.current.qcFailure).toEqual({
+        code: "not_side_profile",
+        guidance: "Turn your right side to the camera",
+        pose: "side",
+      });
+      // Re-picking the failing pose clears the error.
+      act(() => result.current.clearQcFailure());
+      expect(result.current.qcFailure).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("defaults an un-posed failure to the front pose", async () => {
     vi.useFakeTimers();
     try {
       createCaptureSession.mockRejectedValue(
@@ -76,17 +123,13 @@ describe("useCapture", () => {
       const { result } = renderHook(() => useCapture(vi.fn()));
       let uploadPromise: Promise<void>;
       act(() => {
-        uploadPromise = result.current.upload(file, 168);
+        uploadPromise = result.current.upload(front, side, 168);
       });
       await act(async () => {
         await vi.advanceTimersByTimeAsync(1900);
         await uploadPromise!;
       });
-      expect(result.current.phase).toBe("qc_failed");
-      expect(result.current.qcFailure).toEqual({
-        code: "blurry",
-        guidance: "Hold steady and retake",
-      });
+      expect(result.current.qcFailure?.pose).toBe("front");
     } finally {
       vi.useRealTimers();
     }
@@ -102,7 +145,7 @@ describe("useCapture", () => {
       const { result } = renderHook(() => useCapture(onSaved));
       let uploadPromise: Promise<void>;
       act(() => {
-        uploadPromise = result.current.upload(file, 168);
+        uploadPromise = result.current.upload(front, side, 168);
       });
       await act(async () => {
         await vi.advanceTimersByTimeAsync(1900);
@@ -116,7 +159,7 @@ describe("useCapture", () => {
 
       // retake path
       act(() => {
-        uploadPromise = result.current.upload(file, 168);
+        uploadPromise = result.current.upload(front, side, 168);
       });
       await act(async () => {
         await vi.advanceTimersByTimeAsync(1900);

--- a/web/src/controllers/use-capture.ts
+++ b/web/src/controllers/use-capture.ts
@@ -1,11 +1,14 @@
 "use client";
 
-// Webcam-capture controller (B4 "Retake" → webcam upload, MI-12): picks a
-// photo + height, uploads to the capture endpoint, and holds the mock's
-// instant answer behind a processing beat (the AFTER_TIMEOUT-style async
-// verification state, design.md §8.4) before showing results. QC failures
-// surface the capture-qc.md code + guidance. Save flips pending_save →
-// complete; Retake purges the session (flows/vault.md §1).
+// Upload-capture controller (B4 "Retake" → photo upload, M-12 upload-only):
+// two files — front + side (right profile) — plus height (M-10) upload to
+// the capture endpoint; the mock's instant answer holds behind a processing
+// beat (the AFTER_TIMEOUT-style async verification state, design.md §8.4)
+// before showing results. QC failures surface the capture-qc.md code +
+// guidance PER POSE (the 422 envelope names the failing pose): the client
+// clears that pose's file only — an accepted pose is never discarded, and a
+// retry never advances a pose counter (flows/vault.md §1). Save flips
+// pending_save → complete; Retake purges the session.
 import { useCallback, useRef, useState } from "react";
 import type { MeasurementSession } from "@/models";
 import { ApiError } from "@/lib/api";
@@ -14,12 +17,15 @@ import { vaultRepo } from "@/models/repositories/vault-repo";
 /** Processing beat so the constellation reads as "AI working" (MI-12). */
 const PROCESSING_MS = 1800;
 
-export type CapturePhase =
-  "idle" | "processing" | "results" | "qc_failed" | "saving";
+export type CapturePose = "front" | "side";
+
+export type CapturePhase = "idle" | "processing" | "results" | "saving";
 
 export interface QcFailure {
   code: string;
   guidance: string;
+  /** capture-qc.md §2: QC reports per pose — the failing pose re-uploads. */
+  pose: CapturePose;
 }
 
 function delay(ms: number): Promise<void> {
@@ -33,34 +39,51 @@ export function useCapture(onSaved: (session: MeasurementSession) => void) {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const keyRef = useRef<string>("");
 
-  const upload = useCallback(async (image: File, heightCm: number) => {
-    // New idempotency key per capture attempt (flows/vault.md upload row).
-    keyRef.current = crypto.randomUUID();
-    setQcFailure(null);
-    setPhase("processing");
-    setPreviewUrl(URL.createObjectURL(image));
-    const [outcome] = await Promise.allSettled([
-      vaultRepo.createCaptureSession(image, heightCm, keyRef.current),
-      delay(PROCESSING_MS),
-    ]);
-    // Both settle together; the delay only paces the constellation.
-    await delay(0);
-    if (outcome.status === "fulfilled") {
-      setPending(outcome.value);
-      setPhase("results");
-      return;
-    }
-    const e = outcome.reason;
-    setQcFailure(
-      e instanceof ApiError
-        ? {
-            code: e.code,
-            guidance: (e.details?.guidance as string) ?? e.message,
-          }
-        : { code: "pipeline_busy", guidance: "Something went wrong — retry." },
-    );
-    setPhase("qc_failed");
-  }, []);
+  const upload = useCallback(
+    async (imageFront: File, imageSide: File, heightCm: number) => {
+      // New idempotency key per capture attempt (flows/vault.md upload row:
+      // both images ride one request with one key).
+      keyRef.current = crypto.randomUUID();
+      setQcFailure(null);
+      setPhase("processing");
+      setPreviewUrl(URL.createObjectURL(imageFront));
+      const [outcome] = await Promise.allSettled([
+        vaultRepo.createCaptureSession(
+          imageFront,
+          imageSide,
+          heightCm,
+          keyRef.current,
+        ),
+        delay(PROCESSING_MS),
+      ]);
+      // Both settle together; the delay only paces the constellation.
+      await delay(0);
+      if (outcome.status === "fulfilled") {
+        setPending(outcome.value);
+        setPhase("results");
+        return;
+      }
+      const e = outcome.reason;
+      setQcFailure(
+        e instanceof ApiError
+          ? {
+              code: e.code,
+              guidance: (e.details?.guidance as string) ?? e.message,
+              pose: e.details?.pose === "side" ? "side" : "front",
+            }
+          : {
+              code: "pipeline_busy",
+              guidance: "Something went wrong — retry.",
+              pose: "front",
+            },
+      );
+      // QC failure returns to the form: the failing pose's dropzone renders
+      // the error state and the user re-picks that pose's file only.
+      setPhase("idle");
+      setPreviewUrl(null);
+    },
+    [],
+  );
 
   const save = useCallback(async () => {
     if (!pending) return;
@@ -90,5 +113,17 @@ export function useCapture(onSaved: (session: MeasurementSession) => void) {
     }
   }, [pending]);
 
-  return { phase, pending, qcFailure, previewUrl, upload, save, retake };
+  /** The failing pose was re-picked — clear the stale QC error. */
+  const clearQcFailure = useCallback(() => setQcFailure(null), []);
+
+  return {
+    phase,
+    pending,
+    qcFailure,
+    previewUrl,
+    upload,
+    save,
+    retake,
+    clearQcFailure,
+  };
 }

--- a/web/src/controllers/use-vault.ts
+++ b/web/src/controllers/use-vault.ts
@@ -59,12 +59,11 @@ export function useVault() {
   }, [sessions]);
 
   const addManualSession = useCallback(
-    async (
-      inputHeightCm: number,
-      measurements: { name: string; value_cm: number }[],
-    ) => {
+    async (measurements: { name: string; value_cm: number }[]) => {
+      // Manual sessions carry no height — input_height_cm is null for
+      // method: manual (flows/vault.md §2, data-model.md §2).
       const session = await vaultRepo.createManualSession(
-        { method: "manual", input_height_cm: inputHeightCm, measurements },
+        { method: "manual", measurements },
         crypto.randomUUID(),
       );
       setSessions((prev) => [session, ...prev]);

--- a/web/src/mocks/seed.ts
+++ b/web/src/mocks/seed.ts
@@ -973,7 +973,9 @@ export const seedSessions: MeasurementSession[] = [
     id: "sess-manual-tape",
     customer_id: "acc-kiki",
     method: "manual",
-    input_height_cm: 168,
+    // null for method: manual (data-model.md §2 — tape values carry no
+    // pipeline height input).
+    input_height_cm: null,
     status: "complete",
     measurements: [
       {

--- a/web/src/mocks/store.test.ts
+++ b/web/src/mocks/store.test.ts
@@ -432,7 +432,6 @@ describe("idempotency (api.md §4)", () => {
   it("replays the original response for the same key + payload", () => {
     const first = store.idempotent("k1", "payload", () =>
       store.createManualSession("kiki.adeyemi", {
-        input_height_cm: 168,
         measurements: [{ name: "shoulder_width", value_cm: 42.7 }],
       }),
     );
@@ -548,20 +547,82 @@ describe("profiles & social lists", () => {
   });
 });
 
-describe("capture path (webcam, B4)", () => {
-  it("QC fixture file names reproduce 422 codes with guidance", () => {
+describe("capture path (two-photo upload, B4 — M-10/M-12)", () => {
+  it("QC fixture file names reproduce 422 codes with guidance + pose", () => {
     expect(() =>
       store.createCaptureSession("kiki.adeyemi", {
         input_height_cm: 168,
-        filename: "fixture-blurry.jpg",
+        filenameFront: "fixture-blurry.jpg",
+        filenameSide: "side.jpg",
       }),
     ).toThrow(expect.objectContaining({ code: "blurry", status: 422 }));
+  });
+
+  it("a side-pose failure names pose=side and keeps its per-pose copy", () => {
+    try {
+      store.createCaptureSession("kiki.adeyemi", {
+        input_height_cm: 168,
+        filenameFront: "front.jpg",
+        filenameSide: "fixture-arms_position.jpg",
+      });
+      expect.unreachable("side QC failure must throw");
+    } catch (e) {
+      expect(e).toMatchObject({
+        code: "arms_position",
+        status: 422,
+        details: {
+          pose: "side",
+          guidance: "Let your arms hang relaxed at your sides",
+        },
+      });
+    }
+  });
+
+  it("side pose swaps frontality for not_side_profile (capture-qc.md §2)", () => {
+    expect(() =>
+      store.createCaptureSession("kiki.adeyemi", {
+        input_height_cm: 168,
+        filenameFront: "front.jpg",
+        filenameSide: "fixture-not_side_profile.jpg",
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        code: "not_side_profile",
+        details: expect.objectContaining({ pose: "side" }),
+      }),
+    );
+  });
+
+  it("multi-code fixtures report the FIRST failure by contract table order (pre-checks before pose rows)", () => {
+    // capture-qc.md §2: "Multiple failures report the first by the table
+    // order above" — undecodable_image (§1 pre-check) outranks no_body.
+    expect(() =>
+      store.createCaptureSession("kiki.adeyemi", {
+        input_height_cm: 168,
+        filenameFront: "fixture-no_body-undecodable_image.jpg",
+        filenameSide: "side.jpg",
+      }),
+    ).toThrow(expect.objectContaining({ code: "undecodable_image" }));
+    // …and the front pose reports before the side pose.
+    expect(() =>
+      store.createCaptureSession("kiki.adeyemi", {
+        input_height_cm: 168,
+        filenameFront: "fixture-too_far.jpg",
+        filenameSide: "fixture-blurry.jpg",
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        code: "too_far",
+        details: expect.objectContaining({ pose: "front" }),
+      }),
+    );
   });
 
   it("upload → pending_save → save flips complete; retake deletes", () => {
     const session = store.createCaptureSession("kiki.adeyemi", {
       input_height_cm: 168,
-      filename: "photo.jpg",
+      filenameFront: "front.jpg",
+      filenameSide: "side.jpg",
     });
     expect(session.status).toBe("pending_save");
     expect(session.measurements.some((m) => (m.confidence ?? 1) < 0.7)).toBe(
@@ -573,6 +634,14 @@ describe("capture path (webcam, B4)", () => {
     expect(() => store.saveSession(session.id, "kiki.adeyemi")).toThrow(
       expect.objectContaining({ code: "invalid_transition" }),
     );
+  });
+
+  it("manual sessions carry no height — input_height_cm is null", () => {
+    const session = store.createManualSession("kiki.adeyemi", {
+      measurements: [{ name: "waist_girth", value_cm: 78.5 }],
+    });
+    expect(session.method).toBe("manual");
+    expect(session.input_height_cm).toBeNull();
   });
 });
 

--- a/web/src/mocks/store.ts
+++ b/web/src/mocks/store.ts
@@ -48,22 +48,43 @@ const USERNAME_RE = /^[a-z0-9._]{3,30}$/;
 
 /**
  * QC failure taxonomy (capture-qc.md §1–2) with the canonical retake copy
- * (flows/vault.md). The webcam capture path reproduces a code when the
- * uploaded file's name contains it (designated fixture images).
+ * (flows/vault.md), ordered EXACTLY as the contract tables run — §1
+ * pre-checks first, then the §2 pose rows — because multiple failures
+ * report the first by table order. QC is per pose (M-10): the front pose
+ * keeps the frontality row; the side pose swaps in `not_side_profile` and
+ * the arms-relaxed copy. The upload path reproduces a code when a pose's
+ * file name contains it (designated fixture images).
  */
-export const QC_FAILURES: Record<string, string> = {
-  no_body: "Make sure your whole body is visible",
-  multiple_bodies: "Make sure you're alone in frame",
-  partial_body: "Include head to ankles",
-  undecodable_image: "That image couldn't be read — try another photo",
-  low_resolution: "Move closer or use a higher-quality camera",
-  poor_lighting: "Find better lighting — avoid strong backlight",
-  blurry: "Hold steady and retake",
-  not_frontal: "Face the camera straight on",
-  camera_tilt: "Hold the phone upright",
-  arms_position: "Keep arms slightly away from your body",
-  too_far: "Move closer — fill more of the frame",
-};
+const QC_PRECHECKS: [code: string, guidance: string][] = [
+  ["undecodable_image", "That image couldn't be read — try another photo"],
+  ["low_resolution", "Move closer or use a higher-quality camera"],
+  ["poor_lighting", "Find better lighting — avoid strong backlight"],
+  ["blurry", "Hold steady and retake"],
+];
+
+export const QC_ORDER_FRONT: [code: string, guidance: string][] = [
+  ...QC_PRECHECKS,
+  ["no_body", "Make sure your whole body is visible"],
+  ["multiple_bodies", "Make sure you're alone in frame"],
+  ["partial_body", "Include head to ankles"],
+  ["not_frontal", "Face the camera straight on"],
+  ["camera_tilt", "Hold the phone upright"],
+  ["arms_position", "Keep arms slightly away from your body"],
+  ["too_far", "Move closer — fill more of the frame"],
+];
+
+export const QC_ORDER_SIDE: [code: string, guidance: string][] = [
+  ...QC_PRECHECKS,
+  ["no_body", "Make sure your whole body is visible"],
+  ["multiple_bodies", "Make sure you're alone in frame"],
+  ["partial_body", "Include head to ankles"],
+  // Profile orientation sits at the frontality row's position (§2 pose 2).
+  ["not_side_profile", "Turn your right side to the camera"],
+  ["camera_tilt", "Hold the phone upright"],
+  // Arms-relaxed replaces the front pose's arms-clearance rule, same slot.
+  ["arms_position", "Let your arms hang relaxed at your sides"],
+  ["too_far", "Move closer — fill more of the frame"],
+];
 
 /** Notification kind → the pref that gates it (pages.md B7 Notifications). */
 const KIND_TO_PREF: Record<NotificationKind, keyof NotificationPrefs> = {
@@ -766,22 +787,10 @@ export class MockStore {
   createManualSession(
     username: string,
     input: {
-      input_height_cm: number;
       measurements: { name: string; value_cm: number }[];
     },
   ): MeasurementSession {
     const account = this.accountByUsername(username);
-    if (
-      !Number.isFinite(input.input_height_cm) ||
-      input.input_height_cm < 100 ||
-      input.input_height_cm > 230
-    ) {
-      throw new MockApiError(
-        "validation_failed",
-        "Height must be 100-230 cm",
-        422,
-      );
-    }
     if (!input.measurements || input.measurements.length === 0) {
       throw new MockApiError(
         "validation_failed",
@@ -794,7 +803,9 @@ export class MockStore {
       id: sessionId,
       customer_id: account.id,
       method: "manual",
-      input_height_cm: input.input_height_cm,
+      // Manual sessions carry no height (flows/vault.md §2; data-model.md
+      // §2: input_height_cm nullable — null for method: manual).
+      input_height_cm: null,
       status: "complete",
       measurements: input.measurements.map((m, i) => ({
         id: `${sessionId}-m${i}`,
@@ -812,13 +823,21 @@ export class MockStore {
   }
 
   /**
-   * Webcam capture path (B4): multipart upload → QC → pending_save session
-   * with per-measurement confidence (api.md §2 v2 schema). QC failures are
-   * reproduced when the file name contains a QC code (designated fixtures).
+   * Two-photo upload path (B4, M-10/M-12): multipart image_front +
+   * image_side + height → per-pose QC → pending_save session with
+   * per-measurement confidence (api.md §2 v2 schema). QC failures are
+   * reproduced when a pose's file name contains a QC code (designated
+   * fixtures); multiple codes report the FIRST by the contract table
+   * order (capture-qc.md §2), the front pose first — a pose-2 failure
+   * never discards the accepted pose 1 (the 422 names the failing pose).
    */
   createCaptureSession(
     username: string,
-    input: { input_height_cm: number; filename: string },
+    input: {
+      input_height_cm: number;
+      filenameFront: string;
+      filenameSide: string;
+    },
   ): MeasurementSession {
     const account = this.accountByUsername(username);
     if (
@@ -832,10 +851,19 @@ export class MockStore {
         422,
       );
     }
-    const name = input.filename.toLowerCase();
-    for (const [code, guidance] of Object.entries(QC_FAILURES)) {
-      if (name.includes(code)) {
-        throw new MockApiError(code, guidance, 422, { guidance });
+    const poses: [
+      pose: "front" | "side",
+      name: string,
+      table: [string, string][],
+    ][] = [
+      ["front", input.filenameFront.toLowerCase(), QC_ORDER_FRONT],
+      ["side", input.filenameSide.toLowerCase(), QC_ORDER_SIDE],
+    ];
+    for (const [pose, name, table] of poses) {
+      for (const [code, guidance] of table) {
+        if (name.includes(code)) {
+          throw new MockApiError(code, guidance, 422, { guidance, pose });
+        }
       }
     }
     const sessionId = id("sess");

--- a/web/src/models/entities/measurement.ts
+++ b/web/src/models/entities/measurement.ts
@@ -19,7 +19,12 @@ export interface MeasurementSession {
   id: string;
   customer_id: string;
   method: MeasurementMethod;
-  input_height_cm: number;
+  /**
+   * Nullable — null for `method: manual` (data-model.md §2, ruled
+   * 2026-07-22): height is a capture-pipeline input, not a property of
+   * tape values.
+   */
+  input_height_cm: number | null;
   status: SessionStatus;
   measurements: Measurement[];
   pipeline_meta: Record<string, unknown>;

--- a/web/src/models/repositories/vault-repo.ts
+++ b/web/src/models/repositories/vault-repo.ts
@@ -5,7 +5,8 @@ import type { Measurement, MeasurementSession } from "../entities/measurement";
 
 export interface ManualSessionCreate {
   method: "manual";
-  input_height_cm: number;
+  // No height field: manual sessions carry `input_height_cm: null`
+  // (flows/vault.md §2 — height is a capture-pipeline input).
   measurements: { name: string; value_cm: number }[];
 }
 
@@ -18,7 +19,7 @@ export const vaultRepo = {
 
   /**
    * POST /api/v1/me/sessions — manual entry from the web vault (MI-13).
-   * Webcam-upload capture posts multipart to the same route; the mock
+   * Photo-upload capture posts multipart to the same route; the mock
    * accepts JSON manual sessions (capture kit is mobile-first).
    */
   createManualSession: (input: ManualSessionCreate, idempotencyKey: string) =>
@@ -50,17 +51,21 @@ export const vaultRepo = {
     apiFetch<void>(`/v1/sessions/${id}`, { method: "DELETE" }),
 
   /**
-   * POST /api/v1/me/sessions (multipart) — webcam capture upload (B4).
-   * Returns a `pending_save` session with per-measurement confidence; QC
-   * failures surface as 422 with the capture-qc.md code + guidance.
+   * POST /api/v1/me/sessions (multipart) — two-photo upload capture (B4,
+   * M-10/M-12): `image_front` + `image_side` + height ride one request with
+   * one Idempotency-Key. Returns a `pending_save` session with
+   * per-measurement confidence; QC failures surface as 422 with the
+   * capture-qc.md code + guidance + failing pose (per-pose QC).
    */
   createCaptureSession: (
-    image: File,
+    imageFront: File,
+    imageSide: File,
     inputHeightCm: number,
     idempotencyKey: string,
   ) => {
     const form = new FormData();
-    form.set("image", image);
+    form.set("image_front", imageFront);
+    form.set("image_side", imageSide);
     form.set("input_height_cm", String(inputHeightCm));
     return apiFetch<MeasurementSession>("/v1/me/sessions", {
       method: "POST",


### PR DESCRIPTION
Web wave for the 2026-07-22 rulings (M-10/M-11/M-12, all merged @ #157) + the parity-audit fixes. One PR, `web/` only (plus `docs/api/openapi.yaml` and the CHANGELOG). The web program's re-open is the ratified correctness exception.

## Rulings

| Item | Ruling | What shipped |
| --- | --- | --- |
| B4 capture rebuild | M-10 (two photos) + M-12 (web upload-only) | The vault measurement flow is the two-file upload per canvas frame `549:2`: labeled **Front/Side dropzones** with per-pose states (empty / uploaded thumbnail + Replace / QC-error + `QCHintChip`), **Height (cm)** FormRow (100–230, prefilled from the latest capture session — never a fabricated default), "Get measurements" → MI-12 constellation → results stagger → Save. Submit posts multipart `image_front` + `image_side` + `input_height_cm` with one Idempotency-Key. |
| Per-pose QC | capture-qc.md §2 | The 422 names the failing pose; only that pose's file re-picks (an accepted pose is never discarded; the retry never advances a pose counter). `QCHintChip` gains the **`not_side_profile`** code ("Turn your right side to the camera") and the side-pose `arms_position` copy ("Let your arms hang relaxed at your sides"). |
| Webcam deletion | M-12 | See the register below. The options sheet + upload view carry "Best experience: guided capture on the Apparule app". |
| Manual entry | nullable ruling + §2 advisory table | No height row (`input_height_cm: null` for `method: manual` — the fabricated 168 default is gone end to end: sheet, controller, repo, mock, seed, entity type); out-of-range values render the non-blocking "Double-check this one — outside the usual {min}–{max} cm." advisory; `waist_girth` advisory max **160 → 150** (canonical table). |
| Mocks + contract | FIX-6c | `mocks/store.ts` reports the FIRST failure by the contract table order (§1 pre-checks before §2 pose rows), per pose, front before side; `openapi.yaml` POST `/me/sessions` takes the two-image multipart schema, the per-pose 422 code list (incl. `not_side_profile`), and nullable `input_height_cm`. |
| Create chooser | M-11 (frame `548:9490`) | The rail's Create pillar opens the two-option chooser: "Take measurements" (primary, accent border) → `/dashboard/vault?capture=1` (B4 options sheet opens on landing); "Post an outfit" → B5 (designers: "Share a look with its fit data"; non-designers: "Become a designer to post" — the B5 upsell owns the gate). NavRail items gain an `onSelect` action form (button + `aria-haspopup="dialog"`); decorative marketing rails stay inert. |
| FIX-2 author links | entity-navigation rule | `PostCard` gains prop-gated `authorHref` (header avatar+username + caption leading username → designer profile; marketing mocks/gallery stay inert); `PostDetailView` header link now wraps the avatar (no dead zone); `CommentRow` gains `authorHref`, wired in the detail view. |
| FIX-3 signin guard | flows/auth.md §2 | `SignInGate` wraps `/signin` (server component + metadata intact): `signed_in` → `router.replace("/dashboard")`, restore-in-flight → the aria-busy spinner gate, `signed_out` → CTA. `AuthContext` restore gains the `.catch` second net (failed restore reads as signed out — no stranded spinner); the provider contract (resolve null, never reject) is documented on `AuthProviderAdapter.restore()`. |
| FIX-5 danger ladder | design.md §8.2 + Figma `501:2` | `Button` gains `kind="quiet-danger"` (quiet chrome + error-token label); `AccountDataView` row-level "Delete all" drops to the row rung; the armed sheet carries the **typed-DELETE gate** (exact token, disarms on close), the **"Export everything first"** escape hatch, and Cancel — filled destructive only on the armed surface. |
| FIX-6a advisory | flows/vault.md §2 | Folded into the manual-entry rework above (waist 150 + double-check hint). |
| FIX-7 AppBar centering | M-9 | Sub/over-media titles render as an **absolute, full-bar-width, center-aligned layer** (px-14 reserves the widest 44px slot; pointer-events-none) — never in-flow between the slots (the old layout sat ~22px off true center on back-only bars). Root's left wordmark exempt; dashboard in-content h1s untouched (chrome-scoped rule). Propagates to OrderDetailView, the settings sub-screens, /p/{id}, the phone mocks, the gallery. |

## Deleted-webcam register (M-12)

- `WebcamCaptureSheet` (CaptureSheets.tsx) — the whole sheet: idle tips ("Stand in good light…"), single-file input, hardcoded `useState("168")` height, non-converting unit toggle, qc_failed/results branches.
- `CaptureOptionMode` `"webcam-upload"` → `"photo-upload"` (component, options sheet, gallery, marketing thumb; the thumb keeps mobile C7's "Use your camera" title via a new `title` override — mobile keeps the live guided camera).
- `use-capture.ts` single-image `upload(image, heightCm)` → two-file `upload(imageFront, imageSide, heightCm)` with per-pose `QcFailure.pose` + `clearQcFailure`; the dead-end `qc_failed` phase is gone (failures return to the form).
- `vault-repo.createCaptureSession(image, …)` → `(imageFront, imageSide, …)`; mock route `image` field → `image_front`+`image_side` (both required).
- e2e "webcam QC failure" journey → the two-photo per-pose journey.
- No `getUserMedia`/permissions code existed to delete — the "webcam" flow was already file-pick; the deletion is the flow + its naming + the single-photo shape.

## Gates (all green, local)

- `npm run lint` — prettier ✓ eslint ✓ boundaries ✓ (332 files)
- `npm run typecheck` ✓
- `npm run test` — 87 files, 536 tests ✓
- `npm run build` ✓ (vault route now ƒ dynamic — chooser handoff searchParams)
- `PW_PORT=4451 npx playwright test --workers=2` — full suite ✓

New locks: upload happy + per-pose QC-fail e2e · chooser round-trip e2e · signin cold-start pair e2e · entity-nav e2e · delete-ladder e2e (last in the serial file — it flips the seeded account to deletion_pending) · unit: UploadMeasurementsView, CaptureSheets (advisory table locked to the §2 canon), QCHintChip ×12 + per-pose copy, CaptureOptionCard, NavRail action pillar, CreateChooserSheet, SignInGate, AuthContext restore net, Button quiet-danger, AccountDataView ladder, AppBar centering layer, store per-pose/table-order tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
