### PR TITLE
fix(web): derive profile counts from the follow graph — designer onboarding zeroed them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Web profile counts derive from the follow graph (user-reported live
+  bug): completing become-a-designer onboarding zeroed the profile
+  header's follower/following counts — `enableDesigner` created the
+  DESIGNER_PROFILE with stored zero counts and the B6 header switched
+  to reading them, while the graph-backed followers/following sheets
+  kept the real lists. The mock store now derives
+  `followers_count`/`following_count`/`posts_count` from the follow
+  graph and post list at every read through the same helpers that back
+  the sheets (header-vs-sheet disagreement is structurally impossible;
+  the stored-tick era's missing `posts_count` decrement on post delete
+  is fixed by the same move). Locked by store unit tests
+  (create-designer-profile preserves counts; follow/unfollow moves both
+  sides; posts_count through create+delete — parity with mobile's
+  unit-gated invariant) and an e2e assertion that onboarding preserves
+  the pre-onboarding counts; documented as the pages.md B6
+  derived-counts rule.
 - Web author links (entity-navigation rule; the web sibling of the
   user-found mobile PostCard bug): PostCard header avatar+username and
   the caption's leading username link to the designer profile

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -128,6 +128,9 @@ toggle, support (`clients.cuesoft.io`).
 - Followers/following lists **[Directive 2026-07-18]**: tapping either count
   opens a UserRow list sheet (Follow/Following morph MI-7; tabs switch the
   two lists).
+- Counts derive from the FOLLOW graph / post list at read time — never from
+  stored per-profile fields — so a header count and its list sheet can never
+  disagree, and creating a designer profile preserves the account's counts.
 
 ### B7a `/dashboard/admin/moderation` (staff only)
 - Moderation queue (A-6): open reports with subject preview, reporter

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -445,6 +445,23 @@ test("B5/B8: creator upsell → onboarding with Paystack resolution states → p
   // The post lands on the designer's own B6 grid.
   await page.goto("/dashboard/kiki.adeyemi");
   await expect(page.getByTestId("profile-grid").locator("li")).toHaveCount(1);
+
+  // Counts survive onboarding: the header derives from the follow graph, so
+  // completing designer onboarding must NOT zero it (live bug 2026-07-22:
+  // the fresh DESIGNER_PROFILE's stored zeros shadowed the graph while the
+  // graph-backed sheets kept the real lists). kiki's graph at this point in
+  // the serial file: amara + maisonbisi (seed) + tunde (B1 journey).
+  await expect(page.getByTestId("following-count")).toContainText(
+    "3 following",
+  );
+  await expect(page.getByTestId("followers-count")).toContainText(
+    "0 followers",
+  );
+  // Header == sheet: the count opens a list of exactly that many rows.
+  await page.getByTestId("following-count").click();
+  await expect(page.getByTestId("following-list").locator("> li")).toHaveCount(
+    3,
+  );
 });
 
 test("B6 own profile: the avatar renders plain — no freshness ring (MI-11, Decided 2026-07-20)", async ({

--- a/web/src/components/dashboard/profile/ProfileView.tsx
+++ b/web/src/components/dashboard/profile/ProfileView.tsx
@@ -334,6 +334,7 @@ export function ProfileView({ username }: { username: string }) {
                 type="button"
                 className="hover:underline"
                 onClick={() => setListSheet("following")}
+                data-testid="following-count"
               >
                 <span className="tnum font-semibold">
                   {formatCount(d.following_count)}

--- a/web/src/mocks/store.test.ts
+++ b/web/src/mocks/store.test.ts
@@ -76,10 +76,25 @@ describe("seed narrative", () => {
     }
   });
 
-  it("designer follower counts mirror the follow graph (P1 realism)", () => {
+  it("designer counts mirror the follow graph (P1 realism)", () => {
     for (const designer of store.designers) {
-      expect(designer.followers_count, designer.username).toBe(
+      const served = store.profileFor(designer.username, "kiki.adeyemi");
+      expect(served.kind).toBe("designer");
+      if (served.kind !== "designer") continue;
+      // Served counts derive from the graph (pages.md B6 derived-counts rule)…
+      expect(served.designer.followers_count, designer.username).toBe(
         store.followersOf(designer.username, "kiki.adeyemi").length,
+      );
+      expect(served.designer.following_count, designer.username).toBe(
+        store.followingOf(designer.username, "kiki.adeyemi").length,
+      );
+      // …and the seeded entity fields mirror the seeded graph verbatim
+      // (the mobile accounts.json pattern) — a drifted seed is a seed bug.
+      expect(designer.followers_count, designer.username).toBe(
+        served.designer.followers_count,
+      );
+      expect(designer.following_count, designer.username).toBe(
+        served.designer.following_count,
       );
     }
   });
@@ -544,6 +559,77 @@ describe("profiles & social lists", () => {
     expect(store.savedPosts("kiki.adeyemi").map((p) => p.id)).toContain(
       "post-agbada",
     );
+  });
+
+  // Counts DERIVE from the follow graph / post list at read time — never
+  // from stored fields (pages.md B6; parity with the mobile fake's
+  // unit-gated invariant). Live bug 2026-07-22: enableDesigner's stored
+  // zeros wiped the profile-header counts while the graph-backed sheets
+  // kept the real lists.
+  describe("counts mirror the graph (derived, never stored)", () => {
+    function designerCounts(username: string) {
+      const profile = store.profileFor(username, "kiki.adeyemi");
+      if (profile.kind !== "designer") {
+        throw new Error(`${username} is not a designer`);
+      }
+      return profile.designer;
+    }
+
+    it("creating a designer profile preserves the account's counts", () => {
+      // kiki follows amara + maisonbisi from seed.
+      const enabled = store.enableDesigner("kiki.adeyemi", "Kiki Ade Studio");
+      expect(enabled.following_count).toBe(2);
+      const served = designerCounts("kiki.adeyemi");
+      expect(served.following_count).toBe(
+        store.followingOf("kiki.adeyemi", "kiki.adeyemi").length,
+      );
+      expect(served.following_count).toBe(2);
+      expect(served.followers_count).toBe(
+        store.followersOf("kiki.adeyemi", "kiki.adeyemi").length,
+      );
+    });
+
+    it("follow/unfollow moves both sides' counts; header == sheet", () => {
+      store.enableDesigner("kiki.adeyemi", "Kiki Ade Studio");
+      const tundeBefore = designerCounts("tunde.o").followers_count; // 4 seeded
+
+      store.setFollow("kiki.adeyemi", "tunde.o", true);
+      expect(designerCounts("tunde.o").followers_count).toBe(tundeBefore + 1);
+      expect(designerCounts("kiki.adeyemi").following_count).toBe(3);
+      // idempotent re-follow must not double-count
+      store.setFollow("kiki.adeyemi", "tunde.o", true);
+      expect(designerCounts("tunde.o").followers_count).toBe(tundeBefore + 1);
+
+      store.setFollow("kiki.adeyemi", "tunde.o", false);
+      expect(designerCounts("tunde.o").followers_count).toBe(tundeBefore);
+      expect(designerCounts("kiki.adeyemi").following_count).toBe(2);
+
+      // After the churn, both headers still equal their sheets.
+      expect(designerCounts("tunde.o").followers_count).toBe(
+        store.followersOf("tunde.o", "kiki.adeyemi").length,
+      );
+      expect(designerCounts("kiki.adeyemi").following_count).toBe(
+        store.followingOf("kiki.adeyemi", "kiki.adeyemi").length,
+      );
+    });
+
+    it("posts_count mirrors the grid through create AND delete", () => {
+      const before = designerCounts("amara.designs").posts_count;
+      const post = store.createPost("amara.designs", {
+        caption: "Count fixture",
+        style_tags: ["test"],
+        base_price_cents: null,
+        turnaround_days: 7,
+        media: [{ url: "/demo/outfit-w00.jpg", alt_text: "Look" }],
+      });
+      expect(designerCounts("amara.designs").posts_count).toBe(before + 1);
+      // The stored-tick era never decremented on delete — derivation does.
+      store.deletePost(post.id, "amara.designs");
+      expect(designerCounts("amara.designs").posts_count).toBe(before);
+      expect(designerCounts("amara.designs").posts_count).toBe(
+        store.postsBy("amara.designs", "kiki.adeyemi").length,
+      );
+    });
   });
 });
 

--- a/web/src/mocks/store.ts
+++ b/web/src/mocks/store.ts
@@ -563,7 +563,8 @@ export class MockStore {
       created_at: new Date().toISOString(),
     };
     this.posts.unshift(post);
-    designer.posts_count += 1;
+    // posts_count derives from the post list at read time (projectDesigner) —
+    // delete needs no mirror bookkeeping either.
     return deepClone(post);
   }
 
@@ -644,6 +645,42 @@ export class MockStore {
 
   // -- profiles & social lists (pages.md B6/B2 — mock-ahead-of-contract) ----
 
+  /** The accounts following a designer — one derivation backs the B6
+   *  followers sheet AND the profile-header count. */
+  private followerAccountsOf(designerUsername: string): Account[] {
+    return this.accounts.filter((a) =>
+      this.follows.has(`${a.id}:${designerUsername}`),
+    );
+  }
+
+  /** The accounts an account follows — backs the following sheet + count. */
+  private followingAccountsOf(accountId: string): Account[] {
+    return [...this.follows]
+      .filter((k) => k.startsWith(`${accountId}:`))
+      .map((k) => this.accounts.find((a) => a.username === k.split(":")[1]))
+      .filter((a): a is Account => a !== undefined);
+  }
+
+  /**
+   * DESIGNER_PROFILE projection: the social counts DERIVE from the follow
+   * graph and the post list at read time — stored count fields are never
+   * served (pages.md B6 derived-counts rule). Deriving through the exact
+   * helpers that back the followers/following sheets makes header-vs-sheet
+   * disagreement structurally impossible (live bug 2026-07-22: enabling a
+   * designer profile served the fresh entity's stored zeros while the
+   * graph-backed sheets kept the real lists).
+   */
+  private projectDesigner(designer: DesignerProfile): DesignerProfile {
+    return {
+      ...deepClone(designer),
+      followers_count: this.followerAccountsOf(designer.username).length,
+      following_count: this.followingAccountsOf(designer.account_id).length,
+      posts_count: this.posts.filter(
+        (p) => p.designer.username === designer.username,
+      ).length,
+    };
+  }
+
   private summaryOf(account: Account, viewer: Account): UserSummary {
     const designer = this.designerByUsername(account.username);
     return {
@@ -665,7 +702,7 @@ export class MockStore {
     if (designer) {
       return {
         kind: "designer",
-        designer: deepClone(designer),
+        designer: this.projectDesigner(designer),
         viewer_follows: this.follows.has(`${viewer.id}:${username}`),
         viewer_is_self: viewer.username === username,
       };
@@ -705,24 +742,17 @@ export class MockStore {
       throw new MockApiError("not_found", "Designer not found", 404);
     }
     const viewer = this.accountByUsername(viewerUsername);
-    return this.accounts
-      .filter((a) => this.follows.has(`${a.id}:${designerUsername}`))
-      .map((a) => this.summaryOf(a, viewer));
+    return this.followerAccountsOf(designerUsername).map((a) =>
+      this.summaryOf(a, viewer),
+    );
   }
 
   followingOf(username: string, viewerUsername: string): UserSummary[] {
     const subject = this.accountByUsername(username);
     const viewer = this.accountByUsername(viewerUsername);
-    return [...this.follows]
-      .filter((k) => k.startsWith(`${subject.id}:`))
-      .map((k) => k.split(":")[1])
-      .map((designerUsername) => {
-        const account = this.accounts.find(
-          (a) => a.username === designerUsername,
-        );
-        return account ? this.summaryOf(account, viewer) : null;
-      })
-      .filter((row): row is UserSummary => row !== null);
+    return this.followingAccountsOf(subject.id).map((a) =>
+      this.summaryOf(a, viewer),
+    );
   }
 
   suggestedDesigners(viewerUsername: string): UserSummary[] {
@@ -759,15 +789,11 @@ export class MockStore {
       throw new MockApiError("not_found", "Designer not found", 404);
     }
     const key = `${viewer.id}:${designerUsername}`;
-    const had = this.follows.has(key);
     if (on) this.follows.add(key);
     else this.follows.delete(key);
-    // followers_count mirrors the follow list exactly (P1 realism pass —
-    // the profile header and the followers sheet must never disagree).
-    if (had !== on) {
-      const designer = this.designerByUsername(designerUsername)!;
-      designer.followers_count += on ? 1 : -1;
-    }
+    // No stored count to tick: followers/following counts derive from the
+    // graph at read time (projectDesigner), so the profile header and the
+    // followers sheet can never disagree (P1 realism pass).
   }
 
   // -- vault ----------------------------------------------------------------
@@ -1488,6 +1514,10 @@ export class MockStore {
         },
         verified: false,
         location: account.profile_location,
+        // Wire-shape placeholders only — every read derives the counts from
+        // the follow graph / post list via projectDesigner, so enabling a
+        // designer profile preserves the account's existing graph (the
+        // 2026-07-22 live bug zeroed the header counts here).
         followers_count: 0,
         following_count: 0,
         posts_count: 0,
@@ -1495,7 +1525,7 @@ export class MockStore {
       this.designers.push(designer);
     }
     account.designer.enabled = true;
-    return deepClone(designer);
+    return this.projectDesigner(designer);
   }
 
   /**


### PR DESCRIPTION
## Summary

User-reported live bug: completing become-a-designer onboarding dropped the account's follower count to zero while the following relationships (2) survived.

**Root cause** — stored count fields shadowing the follow graph:
- `enableDesigner` (`web/src/mocks/store.ts`) created the DESIGNER_PROFILE with stored `followers_count: 0` / `following_count: 0`, and `profileFor` switched the B6 header from the user projection to that entity — the header served the fresh zeros.
- The followers/following **sheets** kept deriving from the follow graph (`followersOf` / `followingOf`), which survives onboarding untouched — hence the asymmetry the user saw.
- Same class: `setFollow` hand-ticked the stored follower count, and `deletePost` never decremented the `createPost`-ticked `posts_count`.

**Fix (class, not instance)** — counts derive from the graph at every read:
- New `projectDesigner` projection derives `followers_count` / `following_count` / `posts_count` from the follow graph + post list through the *same private helpers that back the sheets* (`followerAccountsOf` / `followingAccountsOf`), so header-vs-sheet disagreement is structurally impossible.
- `profileFor` and `enableDesigner` emit through the projection; the `setFollow` / `createPost` manual ticks are removed (the `deletePost` decrement bug disappears with them).
- Seeded entity count fields remain as the graph-mirroring wire shape (the mobile `accounts.json` ↔ `seedFollows` pattern) and are now asserted against the graph for **both** followers and following.

**Locks**
- Store unit tests (`web/src/mocks/store.test.ts`): create-designer-profile preserves the account's graph-derived counts; follow/unfollow moves both sides' counts idempotently with header == sheet; `posts_count` mirrors the grid through create **and** delete — parity with mobile's unit-gated invariant ("publicProfile counts NEVER disagree with the lists").
- e2e (`web/e2e/dashboard.spec.ts` B5/B8 journey): after completing designer onboarding, the profile header still shows the pre-onboarding counts (3 following at that point in the serial narrative, 0 followers) and the following count opens a sheet with exactly that many rows.
- Docs: `docs/pages.md` B6 gains the one-line derived-counts rule (the contract was silent on count semantics; `data-model.md` §6.5 defines only the FOLLOW edge).

**Mobile**: checked read-only — does NOT share the bug (counts derive from `_graphEdges` at read time; `enableDesigner` carries no count fields). No mobile changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)