### PR TITLE
feat(mobile): §8 gate-5 patrol E2E smoke journeys + nightly mobile-e2e lane

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -114,7 +114,7 @@ jobs:
       # analysis excludes.
       - name: Format check
         run: |
-          find lib test test_goldens tool -name '*.dart' \
+          find lib test test_goldens integration_test tool -name '*.dart' \
             -not -path 'lib/l10n/generated/*' \
             -not -name '*.g.dart' \
             -not -name '*.freezed.dart' \

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -7,6 +7,10 @@ name: mobile-e2e
 
 on:
   workflow_dispatch:
+  # TEMPORARY (reverted before merge): one pre-merge runtime run on this
+  # branch — workflow_dispatch only registers once the file is on main.
+  push:
+    branches: [feat/mobile-patrol-journeys]
   schedule:
     # Nightly; the offset dodges the top-of-hour scheduler crunch.
     - cron: "17 3 * * *"

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -7,10 +7,6 @@ name: mobile-e2e
 
 on:
   workflow_dispatch:
-  # TEMPORARY (reverted before merge): one pre-merge runtime run on this
-  # branch — workflow_dispatch only registers once the file is on main.
-  push:
-    branches: [feat/mobile-patrol-journeys]
   schedule:
     # Nightly; the offset dodges the top-of-hour scheduler crunch.
     - cron: "17 3 * * *"

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -1,0 +1,71 @@
+# E2E smoke — the §8 gate-5 patrol journeys (mobile-implementation.md):
+# the five critical paths (sign-in · capture · commerce · earnings ·
+# sign-out) over the dev flavor's fake set, on an Android emulator.
+# Scheduled NIGHTLY + manual dispatch, never per-PR (§8: patrol's
+# device-farm cost profile; PRs get analyze+test via build-and-test.yml).
+name: mobile-e2e
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Nightly; the offset dodges the top-of-hour scheduler crunch.
+    - cron: "17 3 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mobile-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  patrol-android:
+    name: mobile · patrol journeys (Android emulator, dev flavor)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    defaults:
+      run:
+        working-directory: mobile/flutter
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # Hardware-accelerated emulation on the Ubuntu runners
+      # (android-emulator-runner README, verified v2.38.0: KVM must be
+      # enabled before the action runs).
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      # AGP 9 builds on JDK 17+.
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Flutter (version pinned by .fvmrc)
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version-file: mobile/flutter/.fvmrc
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      # patrol_finders over the SDK's integration_test binding — plain
+      # `flutter test` on the emulator, no native-automation runner.
+      # x86_64 `default` image (no Play services: the dev flavor fakes
+      # every remote seam, mobile-implementation.md §6); the runner's
+      # default emulator-options disable window/audio/boot-anim and
+      # animations, matching the reduced-motion widget-test posture.
+      - name: Patrol journeys (dev flavor)
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          profile: pixel_7
+          working-directory: mobile/flutter
+          script: flutter test integration_test --flavor dev -d emulator-5554

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Mobile patrol E2E smoke journeys (mobile-implementation.md §8 gate 5 —
+  the standing nightly regression net, deferred since the skeleton):
+  - `integration_test/smoke_journeys_test.dart` — five journeys over the
+    dev flavor's fake set, asserting user-visible outcomes only (screens
+    reached, data shown): cold start signed-out → C1 → fake Google
+    sign-in → C1b → the seeded home feed; ➕ → chooser → the five-step
+    guide → front pose → side pose → height → processing → results →
+    save → the vault shows the session; explore → post detail → the
+    request stepper (snapshot · delivery · review) → submit → confetti →
+    order detail reads Requested; a designer session → C14's seeded
+    balances (₦82,500 available / ₦45,000 escrow) → a payout request
+    moves the balance into a processing row; Settings → Account & data →
+    Log out → C1.
+  - `patrol_finders` (3.6.0, promoted to a direct dev dependency from
+    the ratified patrol 4.7.1 pin) drives the SDK's own
+    `integration_test` binding — plain `flutter test integration_test
+    --flavor dev` on a device, no native-automation runner.
+  - `mobile-e2e` workflow — nightly + manual dispatch, never per-PR
+    (§8's device-farm cost profile): Android API 34 x86_64 emulator
+    (KVM-accelerated ubuntu runner) running the journey suite against
+    the dev flavor.
 - Mobile C15 designer post composer (M-11 — the create chooser's second
   option goes live; canvas 551:2866 / 551:4152 / 552:2):
   - The composer screen at `/create/post`: centered "New post" bar,

--- a/mobile/flutter/integration_test/helpers/journeys.dart
+++ b/mobile/flutter/integration_test/helpers/journeys.dart
@@ -1,0 +1,73 @@
+import 'package:apparule/src/features/auth/data/auth_repository_fake.dart';
+import 'package:apparule/src/features/earnings/data/earnings_repository.dart';
+import 'package:apparule/src/features/measurements/data/measurement_repository.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:patrol_finders/patrol_finders.dart';
+
+import '../../test/helpers/boot_app.dart';
+import '../../test/helpers/in_memory_persistence.dart';
+
+/// Patrol journey harness (mobile-implementation.md §8 gate 5): boots the
+/// SAME composition as the dev entrypoint — the full app over
+/// `fakeRepositoryOverrides` — inside the on-device integration_test
+/// binding, with `patrol_finders` driving it in real time.
+///
+/// Timeouts are generous because these run on cold CI emulators: the
+/// first frame pays shader compilation, and the C6 auto-capture spends
+/// real seconds per pose (align beat + 3-2-1 countdown).
+const PatrolTesterConfig journeyConfig = PatrolTesterConfig(
+  existsTimeout: Duration(seconds: 30),
+  visibleTimeout: Duration(seconds: 30),
+);
+
+/// Boots the full app (router included) the way `main_dev.dart` composes
+/// it, hermetically per journey: fresh in-memory persistence (each test
+/// owns its session lifecycle regardless of what an earlier journey left
+/// on the device) and mocked SharedPreferences.
+///
+/// [signedIn] pre-seeds the persisted session marker, so the journey
+/// cold-starts through the REAL restore gate as a returning user;
+/// signed-out boots land on C1. [firstActionSeen] mirrors the C1b flag —
+/// false replays the first-ever sign-in. [measurementRepository] and
+/// [earningsRepository] are the §6 seams journeys re-seed (empty vault
+/// for the first capture, the designer ledger for C14).
+Future<void> bootJourneyApp(
+  PatrolTester $, {
+  bool signedIn = true,
+  bool firstActionSeen = true,
+  MeasurementRepository? measurementRepository,
+  EarningsRepository? earningsRepository,
+}) async {
+  final persistence = InMemoryPersistenceService();
+  if (signedIn) {
+    persistence.sessionToken = AuthRepositoryFake.fakeSessionToken;
+  }
+  await pumpBootedApp(
+    $.tester,
+    // No pumpAndSettle at boot — the home feed skeletons shimmer; the
+    // journeys wait on visible outcomes instead.
+    settle: false,
+    persistenceService: persistence,
+    measurementRepository: measurementRepository,
+    earningsRepository: earningsRepository,
+    preferences: <String, Object>{
+      if (firstActionSeen) 'first_action_seen': true,
+    },
+  );
+  await $.pumpAndTrySettle();
+}
+
+/// Serves every dev seed EXCEPT the vault sessions — the first-capture
+/// user (no height on file, flows/vault.md §1): the capture journey
+/// walks the height step, and the vault ends the journey holding exactly
+/// the one session it just saved.
+class EmptyVaultSeedBundle extends CachingAssetBundle {
+  @override
+  Future<ByteData> load(String key) {
+    if (key.endsWith('vault_sessions.json')) {
+      throw FlutterError('Unable to load asset: $key');
+    }
+    return rootBundle.load(key);
+  }
+}

--- a/mobile/flutter/integration_test/smoke_journeys_test.dart
+++ b/mobile/flutter/integration_test/smoke_journeys_test.dart
@@ -1,0 +1,218 @@
+import 'package:apparule/src/core/ui/button.dart';
+import 'package:apparule/src/core/ui/confetti_burst.dart';
+import 'package:apparule/src/core/ui/post_card.dart';
+import 'package:apparule/src/core/ui/status_pill.dart';
+import 'package:apparule/src/features/earnings/data/earnings_repository_fake.dart';
+import 'package:apparule/src/features/measurements/data/measurement_repository_fake.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:patrol_finders/patrol_finders.dart';
+
+import 'helpers/journeys.dart';
+
+/// E2E smoke (mobile-implementation.md §8 gate 5): the five patrol
+/// journeys over the pages.md §8.4-equivalent critical paths — sign-in,
+/// take measurement, place order, view earnings, sign-out — on the dev
+/// flavor's fake set. The standing regression net: run NIGHTLY + on
+/// dispatch (.github/workflows/mobile-e2e.yml), never per-PR (§8's
+/// device-farm cost profile).
+///
+/// Every assertion is a USER-VISIBLE outcome — a screen reached, data
+/// shown — never repository or provider state. Locally:
+///
+/// ```sh
+/// flutter test integration_test --flavor dev -d <device>
+/// ```
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  patrolWidgetTest(
+    'sign-in: cold start signed out boots to C1, the fake Google sign-in '
+    'hands off to C1b first-action, and skipping lands the seeded home feed',
+    config: journeyConfig,
+    ($) async {
+      await bootJourneyApp($, signedIn: false, firstActionSeen: false);
+
+      // C1 — the single Google CTA (flows/auth.md §5).
+      await $('Continue with Google').waitUntilVisible();
+
+      // The fake sign-in resolves instantly; a FIRST sign-in redirects
+      // to the C1b interstitial (pages.md C1b).
+      await $('Continue with Google').tap();
+      await $('Welcome, Kiki 👋').waitUntilVisible();
+      await $('Take your first measurement').waitUntilVisible();
+
+      // Skip for now → the home feed, telling the seeded §6 story:
+      // kiki's followed designers on the story rail and their posts in
+      // the column.
+      await $('Skip for now').tap();
+      await $('amara.designs').waitUntilVisible();
+      await $(PostCard).waitUntilVisible();
+    },
+  );
+
+  patrolWidgetTest(
+    'capture: ➕ → chooser → the five-step guide → front pose → side pose '
+    '→ height → processing → results → save → the vault shows the session',
+    config: journeyConfig,
+    ($) async {
+      // First-capture user: no vault seed, so no height on file — the
+      // height step interposes and the vault ends with ONE session.
+      await bootJourneyApp(
+        $,
+        measurementRepository: MeasurementRepositoryFake(
+          bundle: EmptyVaultSeedBundle(),
+        ),
+      );
+      await $('amara.designs').waitUntilVisible();
+
+      // ➕ → the M-11 create chooser.
+      await $(find.bySemanticsLabel('Create')).tap();
+      await $('Take measurements').waitUntilVisible();
+
+      // First run → the C6 guide (M-8/M-10), five canvas steps.
+      await $('Take measurements').tap();
+      await $('Guide A-Z').waitUntilVisible();
+      await $('Next').tap();
+      await $('Get ready').waitUntilVisible();
+      await $('Next').tap();
+      await $('Set your phone up').waitUntilVisible();
+      await $('Next').tap();
+      await $('Strike the pose').waitUntilVisible();
+      await $('Next').tap();
+      await $('Turn to the side').waitUntilVisible();
+
+      // Into the viewfinder: auto-capture (no shutter) fires the 3-2-1
+      // per pose by itself — the journey just watches the pose bar
+      // advance front → side (M-10).
+      await $('Start capture').tap();
+      await $('Pose 1 of 2').waitUntilVisible();
+      await $('Pose 2 of 2').waitUntilVisible();
+
+      // Height interposes after Pose 2 (flows/vault.md §1 — nothing on
+      // file), gated 100–230 cm.
+      await $('Your height').waitUntilVisible();
+      await $(find.bySemanticsLabel('Height value')).enterText('170');
+      await $('Continue').tap();
+
+      // Processing resolves into results (§4 confidences)…
+      await $('Your measurements').waitUntilVisible();
+      await $('Save to vault').waitUntilVisible();
+
+      // …and saving lands in C7 with the just-captured session.
+      await $('Save to vault').tap();
+      await $('Measured today').waitUntilVisible();
+      await $('Up to date · 2 measurements').waitUntilVisible();
+    },
+  );
+
+  patrolWidgetTest(
+    'commerce: post detail → request → stepper (snapshot, delivery, '
+    'review) → submit → confetti → the order detail reads requested',
+    config: journeyConfig,
+    ($) async {
+      await bootJourneyApp($);
+      await $('amara.designs').waitUntilVisible();
+
+      // Explore grid → the seeded ankara post's C4 detail.
+      await $(find.bySemanticsLabel('Explore')).tap();
+      await $(
+        find.bySemanticsLabel(
+          'Model in an ankara maxi skirt on the runway',
+        ),
+      ).tap();
+      await $('Request this outfit').waitUntilVisible();
+
+      // C5 step 1 — the vault snapshot picker, newest preselected (D63).
+      await $('Request this outfit').tap();
+      await $('New request · 1 of 3').waitUntilVisible();
+      await $('Pick a measurement snapshot').waitUntilVisible();
+      await $('Fresh').waitUntilVisible();
+      await $('Continue').tap();
+
+      // Step 2 — delivery pre-fills from the most recent order (§6.3).
+      await $('New request · 2 of 3').waitUntilVisible();
+      await $('14 Adeola Odeku St').waitUntilVisible();
+      await $('Continue').tap();
+
+      // Step 3 — review retells the request, then submit.
+      await $('Review your request').waitUntilVisible();
+      await $(
+        'Ankara maxi skirt with structured waistband — amara.designs',
+      ).waitUntilVisible();
+      await $('Submit request').tap();
+
+      // Success: the MI-10 confetti burst over "Request sent".
+      await $('Request sent').waitUntilVisible();
+      await $(ConfettiBurst).waitUntilVisible();
+
+      // View order → C8 detail in the requested state.
+      await $('View order').tap();
+      await $(
+        find.descendant(
+          of: find.byType(StatusPill),
+          matching: find.text('Requested'),
+        ),
+      ).waitUntilVisible();
+    },
+  );
+
+  patrolWidgetTest(
+    'earnings: a designer session reaches C14 with the seeded balances, '
+    'and a payout request MOVES the balance into a processing row',
+    config: journeyConfig,
+    ($) async {
+      // The §6 designer perspective: amara.designs carries the ratified
+      // C14 canvas ledger (₦82,500 available / ₦45,000 escrow).
+      await bootJourneyApp(
+        $,
+        earningsRepository: EarningsRepositoryFake(
+          viewer: 'amara.designs',
+          resolveDelay: Duration.zero,
+        ),
+      );
+      await $('amara.designs').waitUntilVisible();
+
+      // Profile tab → B7 settings → the creator section's earnings row.
+      await $(find.bySemanticsLabel('Profile')).tap();
+      await $(find.byTooltip('Settings')).tap();
+      await $.scrollUntilVisible(finder: $('Earnings & payouts'));
+      await $('Earnings & payouts').tap();
+
+      // C14 — the seeded summary cards.
+      await $('₦82,500').waitUntilVisible();
+      await $('₦45,000').waitUntilVisible();
+
+      // Request the payout (top-bar ⋯ → confirm sheet). The released
+      // balance MOVES: available zeroes, processing absorbs it.
+      await $(find.byTooltip('Request payout')).tap();
+      await $('Request payout').waitUntilVisible();
+      await $(find.widgetWithText(Button, 'Request payout')).tap();
+      await $('₦0').waitUntilVisible();
+      await $('₦127,500').waitUntilVisible();
+      await $.scrollUntilVisible(finder: $('−₦82,500'));
+    },
+  );
+
+  patrolWidgetTest(
+    'sign-out: Settings → Account & data → Log out purges the session '
+    'and lands back on C1',
+    config: journeyConfig,
+    ($) async {
+      await bootJourneyApp($);
+      await $('amara.designs').waitUntilVisible();
+
+      // Profile tab → B7 settings → Account & data (the danger ladder
+      // screen — log out lives here).
+      await $(find.bySemanticsLabel('Profile')).tap();
+      await $(find.byTooltip('Settings')).tap();
+      await $.scrollUntilVisible(finder: $('Account & data'));
+      await $('Account & data').tap();
+      await $.scrollUntilVisible(finder: $('Log out'));
+
+      // Sign out → the live redirect lands C1 (flows/auth.md §2).
+      await $('Log out').tap();
+      await $('Continue with Google').waitUntilVisible();
+    },
+  );
+}

--- a/mobile/flutter/integration_test/smoke_journeys_test.dart
+++ b/mobile/flutter/integration_test/smoke_journeys_test.dart
@@ -90,9 +90,14 @@ void main() {
       await $('Pose 2 of 2').waitUntilVisible();
 
       // Height interposes after Pose 2 (flows/vault.md §1 — nothing on
-      // file), gated 100–230 cm.
+      // file), gated 100–230 cm. The MI-13 value field commits on the
+      // keyboard's done action, not per keystroke — press it like a
+      // user would (the CI-proven repro: skipping it strands the step
+      // on the 100–230 error).
       await $('Your height').waitUntilVisible();
       await $(find.bySemanticsLabel('Height value')).enterText('170');
+      await $.tester.testTextInput.receiveAction(TextInputAction.done);
+      await $.pump();
       await $('Continue').tap();
 
       // Processing resolves into results (§4 confidences)…

--- a/mobile/flutter/integration_test/smoke_journeys_test.dart
+++ b/mobile/flutter/integration_test/smoke_journeys_test.dart
@@ -90,14 +90,17 @@ void main() {
       await $('Pose 2 of 2').waitUntilVisible();
 
       // Height interposes after Pose 2 (flows/vault.md §1 — nothing on
-      // file), gated 100–230 cm. The MI-13 value field commits on the
-      // keyboard's done action, not per keystroke — press it like a
-      // user would (the CI-proven repro: skipping it strands the step
-      // on the 100–230 error).
+      // file), gated 100–230 cm. Set it on the MI-13 tape ruler — a
+      // centre tap commits exactly 165 cm (mid-band) through a pure
+      // pointer gesture. Injected keyboard text is NOT reliable here:
+      // the live integration_test binding never registers the test
+      // text input (`registerTestTextInput => false`), so enterText
+      // rides the debug client--1 path against the device's REAL IME
+      // connection — the flutter_test-documented confusion risk, and
+      // this suite's CI-proven repro (runs 29977089254/29977634721).
+      // Typed entry stays covered by the capture widget tests.
       await $('Your height').waitUntilVisible();
-      await $(find.bySemanticsLabel('Height value')).enterText('170');
-      await $.tester.testTextInput.receiveAction(TextInputAction.done);
-      await $.pump();
+      await $(find.bySemanticsLabel('Height slider')).tap();
       await $('Continue').tap();
 
       // Processing resolves into results (§4 confidences)…

--- a/mobile/flutter/pubspec.lock
+++ b/mobile/flutter/pubspec.lock
@@ -470,6 +470,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.2"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -597,6 +602,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   glob:
     dependency: transitive
     description:
@@ -789,6 +799,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   intl:
     dependency: "direct main"
     description:
@@ -1030,7 +1045,7 @@ packages:
     source: hosted
     version: "4.7.1"
   patrol_finders:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: patrol_finders
       sha256: "8608cdacaab90a3b00ecd7b09df11f13a62b01dea13c211b9f13fd86854e103a"
@@ -1085,6 +1100,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.5.0"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   pub_semver:
     dependency: transitive
     description:
@@ -1378,6 +1401,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   synchronized:
     dependency: transitive
     description:
@@ -1586,6 +1617,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:

--- a/mobile/flutter/pubspec.yaml
+++ b/mobile/flutter/pubspec.yaml
@@ -72,9 +72,20 @@ dev_dependencies:
   # analyzer-12 compatibility build and the only co-resolvable version.
   freezed: ^3.2.5
   go_router_builder: ^4.3.1
+  # The §8 gate-5 journeys run over the SDK's own on-device harness —
+  # patrol_finders drives it; no native-automation runner is wired.
+  integration_test:
+    sdk: flutter
   json_serializable: ^6.14.0
   mocktail: ^1.0.5
   patrol: ^4.7.1
+  # Pin-ledger verification (patrol E2E wave): patrol 4.7.1 is the
+  # ratified pin and resolves patrol_finders 3.6.0; the finder layer is
+  # promoted to a direct dev dependency because integration_test/
+  # imports it directly (PatrolTester/$ over integration_test above —
+  # the full patrol harness stays a dependency, unused at runtime until
+  # a native-automation lane earns patrol_cli).
+  patrol_finders: ^3.6.0
   riverpod_generator: ^4.0.4
   very_good_analysis: ^10.3.0
 


### PR DESCRIPTION
## Summary
- Lands the §8.5 E2E smoke net (mobile-implementation.md §8 gate 5, deferred since the skeleton): five patrol journeys in `mobile/flutter/integration_test/`, driven by `patrol_finders` over the SDK's own `integration_test` binding (no native-automation runner) against the dev flavor's fake set — the mobile sibling of web's Playwright TEST_MODE suite.
- Journeys assert **user-visible outcomes only** (screens reached, data shown — never repository/provider state):
  1. **sign-in** — cold start signed-out → C1 → fake Google sign-in → C1b first-action → home feed with the seeded story
  2. **capture** — ➕ → chooser → five-step guide → front pose → side pose (auto-capture, no shutter) → height → processing → results → save → the vault shows the session
  3. **commerce** — explore → post detail → request stepper (snapshot · delivery · review) → submit → confetti → order detail reads **Requested**
  4. **earnings** — designer session → C14's seeded ledger (₦82,500 / ₦45,000) → payout request MOVES the balance into a processing row
  5. **sign-out** — Settings → Account & data → Log out → C1
- Each journey boots the dev entrypoint's exact composition hermetically (fresh in-memory persistence + mocked SharedPreferences per test), through the real boot/restore gate and the live auth redirect.
- **Pins**: `patrol 4.7.1` stays the ratified pin; `patrol_finders` is promoted transitive → direct dev dependency at the resolver-verified `3.6.0` (same sha), `integration_test` added from the SDK — rationale comments in `pubspec.yaml` per the pin-corrections ledger pattern.
- **CI**: new `mobile-e2e` workflow — `workflow_dispatch` + nightly cron, **never per-PR** (§8's device-farm cost profile): KVM-accelerated API 34 x86_64 emulator via `reactivecircus/android-emulator-runner@v2` (inputs verified against its README, v2.38.0) running `flutter test integration_test --flavor dev`. The per-PR format gate now also covers `integration_test/`.

## Related issues
Mobile program phase 3 closeout — the standing regression net (§8.5).

## Type of change
- [x] New feature

## Affected areas
- [x] `mobile`

## Checklist
- [x] I followed the Contributing guide.
- [x] Commits follow Conventional Commits (`feat:`, `fix:`, `chore:`…).
- [x] Lint and tests pass locally.
- [x] No secrets, credentials, or `.env` files are committed.
- [x] Documentation updated where relevant (CHANGELOG; §8 gate 5 already documents this suite).

## Verification
- `dart format` clean · codegen-fresh clean · `flutter analyze --fatal-infos` clean · `flutter test` 563/563 · `flutter test test_goldens` pass (CI variants assert on the Linux lane).
- Journey suite **compile-verified** locally via `flutter build apk --debug --flavor dev -t integration_test/smoke_journeys_test.dart` (89.7s, APK built). No AVD/system image exists on this host (multi-GB download; iOS runtime blocked by the CoreSimulator wedge) — **runtime verification is the `mobile-e2e` lane**: dispatch it on this branch via `gh workflow run mobile-e2e --ref feat/mobile-patrol-journeys`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)