### PR TITLE
feat(web): inches are the default display unit (A-9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,6 +317,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Inches are the default measurement display unit on web (A-9 — Nigerian
+  tailors work in inches; storage, API payloads and the QC pipeline stay
+  canonical cm): `formatCm` defaults to `"in"` ("16.7 in", one decimal +
+  tnum kept), MeasurementCard and the MI-13 manual-entry toggle render
+  with "in" active (cm stays one flip away), and the B4 upload flow's
+  height field gains the MI-13 toggle — inches by default, entry converts
+  to canonical cm so the payload stays `user_height_cm` (a prefilled 168
+  survives unit flips and submits as exactly 168). The out-of-range
+  advisory and the height helper speak the active unit, and the marketing
+  accuracy claim reads "±0.8 in" (the canvas's inches display of the
+  pipeline's canonical ±2 cm target). Seeds stay canonical cm (#173).
 - Web toolchain on Node 24 end-to-end: the `build-and-test` web jobs move
   from Node 22 to 24 and a new `web/.nvmrc` pins 24 — the runtime major
   the web Dockerfile already ships, and the file dependabot's

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -90,6 +90,17 @@ before public launch. Alternative: commission the brand pass first.
 
 ☑ Ratified
 
+## A-9 · Inches are the default display unit
+
+**Recommendation ⭐:** inches as the default measurement DISPLAY unit —
+Nigerian tailors work in inches. Scope: display + input defaults on web AND
+mobile (formatters, measurement cards, manual entry, the capture height
+field); cm stays canonical in storage, API payloads (`value_cm`,
+`user_height_cm`), and the QC pipeline; the MI-13 cm/in toggle persists the
+user's choice.
+
+☑ Ratified 2026-07-23
+
 ## Cross-cutting (shared with expendit/upstat)
 
 - **X-1 account.cuesoft.io / identity (RATIFIED)**: interim + sandbox identity

--- a/docs/design.md
+++ b/docs/design.md
@@ -135,7 +135,7 @@ Numbered so pages.md can reference them as `MI-n`.
 | MI-10 | **Request stepper** | 3-step sheet (Measurements → Notes/Budget → Review); progress bar fills with 300ms ease; step transitions slide 24px; final CTA shows inline spinner then ✓ morph + confetti burst ≤ 800ms (once per order) |
 | MI-11 | **Measurement freshness ring** | vault-header avatar ring: gradient if measured <30d, amber 30–90d, gray >90d; tooltip "Measured 12 days ago — retake?" — the ring is a vault affordance; profile avatars, including the viewer's own B6 profile, render plain **[Decided 2026-07-20]** |
 | MI-12 | **Capture flow** | camera overlay silhouette guide pulses gently; countdown 3-2-1 rings; processing state: landmark constellation animates over photo (the "AI is working" moment — also the SMPL demo asset); results cards stagger-in 60ms apart |
-| MI-13 | **Manual measure input** | tape-measure themed slider + numeric field; value change animates sparkline preview; unit toggle cm/in flips with 3D x-rotation 200ms |
+| MI-13 | **Manual measure input** | tape-measure themed slider + numeric field; value change animates sparkline preview; unit toggle cm/in flips with 3D x-rotation 200ms — inches active by default (A-9), the toggle persists the user's choice; storage stays canonical cm |
 | MI-14 | **Order status pill** | status changes pulse once (scale 1→1.06→1) + color crossfade; timeline dot draws its connector line 400ms |
 | MI-15 | **Payment states** | pay button → inline spinner → shield-check morph; escrow explainer expands beneath on first payment |
 | MI-16 | **Badge counts** | Orders tab badge increments with springy scale; clears on tab visit |
@@ -354,8 +354,9 @@ Stage 5 and non-blocking; everything else feeds Stages 1–4.
 | FAQItem | question + chevron · state: collapsed / expanded · one-open-at-a-time group, rows deep-linkable (pages.md A9b) · theme ×2 · **as built (2026-07-18):** ≈720px accordion row; chevron rotates 180° on expand/collapse (`base` 200ms) — the iteration addition the note below anticipated |
 
 *Accuracy standard (2026-07-18):* the marketing stat band (StatCard ×3,
-pages.md A3) carries **product claims only** — ±2 cm target accuracy · 2
-photos · 30-day photo auto-delete — never invented research statistics; the
+pages.md A3) carries **product claims only** — ±0.8 in target accuracy (the
+A-9 inches display of the pipeline's canonical ±2 cm target) · 2 photos ·
+30-day photo auto-delete — never invented research statistics; the
 same rule keeps master badges neutral (no star or member counts on canvases).
 
 *Iteration note (2026-07-18):* the home FAQ section (pages.md A9b) implies a

--- a/docs/mobile-implementation.md
+++ b/docs/mobile-implementation.md
@@ -453,8 +453,10 @@ The pose progress renders as a centered over-media bar title ("Pose 1 of
   upload (`image_front` + `image_side` + height, one request) →
   processing state → results.
 - **Height input**: collected once per session (`user_height_cm`, api.md
-  `POST /measure` form field), feeding the `scale = (user_height_cm × 0.93)
-  / body_height_px` correction from the front image (capture-qc.md §3,
+  `POST /measure` form field — the field displays inches by default per
+  A-9, entry converts to canonical cm), feeding the
+  `scale = (user_height_cm × 0.93) / body_height_px` correction from the
+  front image (capture-qc.md §3,
   `method: mediapipe_2d_v2`); girths estimate from the two views — the
   **[Directive: measurement pipeline recalibration needed]** marker lives
   in capture-qc.md §3 and lands with the backend phase.
@@ -468,7 +470,9 @@ The pose progress renders as a centered over-media bar title ("Pose 1 of
   counter. One actionable retake instruction, never a stacked list.
 - **Results**: measurement cards stagger in with per-measurement
   `confidence` (capture-qc.md §4; values under 0.7 render a "low
-  confidence — consider retaking" chip); "Save to vault" is primary,
+  confidence — consider retaking" chip); values display in inches by
+  default (A-9 — the MI-13 toggle flips to cm; storage stays canonical
+  cm); "Save to vault" is primary,
   "Retake" is quiet; a manual-entry fallback exists for QC that never
   clears. Saved results route into the `measurements` feature's vault
   screen (C7) — the same vault a request's measurement-snapshot picker

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -341,10 +341,12 @@ from the Figma ↔ code divergence audit (seed-side details live in §6):
   same-day messages, `MMM d, HH:mm` (the OrderTimelineRow idiom) when
   older, side-aligned under the bubble; delivered messages only — never
   sending or typing bubbles.
-- Measurement values render **one decimal everywhere** ("92.0 cm", the
-  frame's "58.0 cm" idiom) via `formatCm` — MeasurementCard, SessionRow,
-  snapshot chips and the request stepper share the single formatter, so
-  tnum columns stay aligned.
+- Measurement values render **one decimal everywhere** ("16.7 in" —
+  inches are the default display unit, A-9; the frame's "58.0 cm" idiom
+  set the one-decimal rule, and cm stays available via the MI-13 toggle)
+  via `formatCm` — MeasurementCard, SessionRow, snapshot chips and the
+  request stepper share the single formatter, so tnum columns stay
+  aligned. Stored values and payloads stay canonical cm.
 - Profile avatars render PLAIN — the measurement-freshness ring is a
   vault-header affordance (MI-11 **[Decided 2026-07-20]**, design.md §2);
   own profiles (regular-user and designer-self branches) carry no ring

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -294,11 +294,12 @@ test("B4 vault: two-photo upload — per-pose QC failure → re-pick side only �
     "Best experience: guided capture on the Apparule app",
   );
 
-  // Height prefills from the latest capture session (seed: 168) — never a
-  // fabricated default.
-  const height = page.getByLabel("Height in centimeters");
-  await expect(height).toHaveValue("168");
-  await height.fill("170");
+  // Height prefills from the latest capture session (seed: 168 cm) and
+  // displays in inches — the A-9 default unit — never a fabricated
+  // default. Entry converts back to canonical cm for the payload.
+  const height = page.getByLabel("Height in inches");
+  await expect(height).toHaveValue("66.1");
+  await height.fill("67");
 
   // Front passes; the side file is a designated QC fixture (a file name
   // containing a capture-qc code — per-pose QC, M-10).

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -21,7 +21,7 @@ test.describe("Marketing site — home page", () => {
     await expect(page.getByTestId("dev-star-badge")).toContainText("Star");
 
     // A3 stat band — the honest product claims
-    await expect(page.getByText("±2 cm", { exact: true })).toBeVisible();
+    await expect(page.getByText("±0.8 in", { exact: true })).toBeVisible();
     await expect(page.getByText("2 photos", { exact: true })).toBeVisible();
     await expect(page.getByText("30 days")).toBeVisible();
 
@@ -663,7 +663,7 @@ test.describe("type contract — Figma Home frame roles", () => {
       },
       {
         role: "stat value (Display/32 Bold)",
-        locator: page.getByText("±2 cm", { exact: true }),
+        locator: page.getByText("±0.8 in", { exact: true }),
         weight: "700",
         size: "32px",
         lineHeight: "40px",

--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -321,7 +321,8 @@ export function ComponentGallery() {
   const [tabBarKey, setTabBarKey] = useState("home");
   const [countdown, setCountdown] = useState<1 | 2 | 3>(3);
   const [iconTab, setIconTab] = useState<"first" | "second">("first");
-  const [unit, setUnit] = useState<"cm" | "in">("cm");
+  // Inches are the default display unit (A-9) — the gallery mirrors it.
+  const [unit, setUnit] = useState<"cm" | "in">("in");
   const [shoulder, setShoulder] = useState<number | null>(42.5);
   const [selectValue, setSelectValue] = useState<string | undefined>();
   const [date, setDate] = useState<Date | null>(null);
@@ -1116,7 +1117,7 @@ export function ComponentGallery() {
 
       <Section title="Marketing — StatCard / WalkthroughStep">
         <div className="grid max-w-2xl grid-cols-3 gap-4">
-          <StatCard stat="±2 cm" label="target measurement accuracy" />
+          <StatCard stat="±0.8 in" label="target measurement accuracy" />
           <StatCard stat="2" label="photos per capture" />
           <StatCard stat="30 days" label="photo auto-delete" />
         </div>
@@ -1163,7 +1164,7 @@ export function ComponentGallery() {
       <Section title="Marketing — FAQItem">
         <FAQGroup defaultOpenId="faq-1">
           <FAQItem id="faq-1" question="How accurate are the measurements?">
-            The pipeline targets ±2 cm against tape measurements — and every
+            The pipeline targets ±0.8 in against tape measurements — and every
             value carries a confidence score, so you know when to re-measure.
           </FAQItem>
           <FAQItem id="faq-2" question="Who can see my measurements?">

--- a/web/src/components/dashboard/vault/CaptureSheets.test.tsx
+++ b/web/src/components/dashboard/vault/CaptureSheets.test.tsx
@@ -1,6 +1,7 @@
 // B4 capture sheets — options (photo upload / manual entry + the M-12
 // mobile-app hint) and manual entry (no height row — input_height_cm is
-// null for method: manual; out-of-range advisory per flows/vault.md §2).
+// null for method: manual; out-of-range advisory per flows/vault.md §2;
+// inches are the default display unit per A-9, storage stays cm).
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -42,14 +43,20 @@ describe("ManualEntrySheet (MI-13)", () => {
   });
 
   it("out-of-range values prompt the double-check advisory, never a block", () => {
+    // The DEFAULT display unit is inches (A-9) — the canonical cm range
+    // converts for display so it matches what the user typed.
     expect(manualAdvisory(155, 40, 150)).toBe(
+      "Double-check this one — outside the usual 15.7–59.1 in.",
+    );
+    // cm stays available via the toggle — the range reads canonical cm.
+    expect(manualAdvisory(155, 40, 150, "cm")).toBe(
       "Double-check this one — outside the usual 40–150 cm.",
     );
     expect(manualAdvisory(78, 40, 150)).toBeUndefined();
     expect(manualAdvisory(null, 40, 150)).toBeUndefined();
   });
 
-  it("collects no height and saves measurements only", async () => {
+  it("collects no height and saves inches-entered values as canonical cm", async () => {
     const onSave = vi.fn().mockResolvedValue(undefined);
     render(<ManualEntrySheet open onOpenChange={() => {}} onSave={onSave} />);
 
@@ -60,15 +67,51 @@ describe("ManualEntrySheet (MI-13)", () => {
     const save = screen.getByRole("button", { name: "Save to vault" });
     expect(save).toBeDisabled();
 
+    // Entry is in inches by default (A-9): 61 in = 154.94 cm — over the
+    // 150 cm waist ceiling, so the advisory renders in inches.
     const waist = screen.getByLabelText("Waist Girth value");
     await userEvent.clear(waist);
-    await userEvent.type(waist, "155");
+    await userEvent.type(waist, "61");
     // The advisory renders inline and saving stays possible (non-blocking).
     expect(
-      screen.getByText("Double-check this one — outside the usual 40–150 cm."),
+      screen.getByText(
+        "Double-check this one — outside the usual 15.7–59.1 in.",
+      ),
     ).toBeInTheDocument();
     expect(save).toBeEnabled();
     await userEvent.click(save);
+    // The payload stays canonical cm whatever the display unit.
+    expect(onSave).toHaveBeenCalledWith([
+      { name: "waist_girth", value_cm: expect.closeTo(154.94, 2) },
+    ]);
+  });
+
+  it("defaults the MI-13 toggle to inches; cm stays one flip away (A-9)", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<ManualEntrySheet open onOpenChange={() => {}} onSave={onSave} />);
+
+    // Every row renders the toggle with "in" active by default.
+    const toggles = screen.getAllByRole("button", {
+      name: "Switch units (currently in)",
+    });
+    expect(toggles).toHaveLength(MANUAL_METRICS.length);
+
+    // One shared unit state drives all rows: flip once, all flip.
+    await userEvent.click(toggles[0]);
+    expect(
+      screen.getAllByRole("button", { name: "Switch units (currently cm)" }),
+    ).toHaveLength(MANUAL_METRICS.length);
+
+    // cm entry passes through unconverted (storage is canonical cm) and
+    // the advisory reads the canonical cm range.
+    const waist = screen.getByLabelText("Waist Girth value");
+    await userEvent.type(waist, "155");
+    expect(
+      screen.getByText("Double-check this one — outside the usual 40–150 cm."),
+    ).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Save to vault" }),
+    );
     expect(onSave).toHaveBeenCalledWith([
       { name: "waist_girth", value_cm: 155 },
     ]);

--- a/web/src/components/dashboard/vault/CaptureSheets.tsx
+++ b/web/src/components/dashboard/vault/CaptureSheets.tsx
@@ -9,6 +9,7 @@
 // sheet. The webcam capture sheet was DELETED per M-12 (full-body webcam
 // capture is rejected UX: desk-height lens, unreachable controls).
 import { useState } from "react";
+import { CM_PER_IN } from "@/lib/format";
 import { Banner } from "@/components/ui/Banner";
 import { Button } from "@/components/ui/Button";
 import { CaptureOptionCard } from "@/components/ui/CaptureOptionCard";
@@ -60,14 +61,23 @@ export const MANUAL_METRICS = [
   { name: "waist_girth", min: 40, max: 150 },
 ] as const;
 
-/** The non-blocking out-of-range advisory (flows/vault.md §2). */
+/**
+ * The non-blocking out-of-range advisory (flows/vault.md §2). Ranges are
+ * canonical cm; the message speaks the active display unit (inches by
+ * default, A-9) so it matches what the user typed.
+ */
 export function manualAdvisory(
   value: number | null,
   min: number,
   max: number,
+  unit: MeasureUnit = "in",
 ): string | undefined {
   if (value === null || (value >= min && value <= max)) return undefined;
-  return `Double-check this one — outside the usual ${min}–${max} cm.`;
+  const range =
+    unit === "cm"
+      ? `${min}–${max} cm`
+      : `${Math.round((min / CM_PER_IN) * 10) / 10}–${Math.round((max / CM_PER_IN) * 10) / 10} in`;
+  return `Double-check this one — outside the usual ${range}.`;
 }
 
 export function ManualEntrySheet({
@@ -79,7 +89,8 @@ export function ManualEntrySheet({
   onOpenChange: (open: boolean) => void;
   onSave: (measurements: { name: string; value_cm: number }[]) => Promise<void>;
 }) {
-  const [unit, setUnit] = useState<MeasureUnit>("cm");
+  // Inches are the default display unit (A-9); stored values stay cm.
+  const [unit, setUnit] = useState<MeasureUnit>("in");
   const [values, setValues] = useState<Record<string, number | null>>({});
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -134,6 +145,7 @@ export function ManualEntrySheet({
                 values[metric.name] ?? null,
                 metric.min,
                 metric.max,
+                unit,
               )}
             />
           ))}

--- a/web/src/components/dashboard/vault/UploadMeasurementsView.test.tsx
+++ b/web/src/components/dashboard/vault/UploadMeasurementsView.test.tsx
@@ -1,7 +1,8 @@
 // B4 upload view (Figma 549:2, M-10/M-12): header + hint line, labeled
-// per-pose dropzones, height prefill (no fabricated default), and the
-// submit gate (both files + valid height). The per-pose QC round-trip is
-// e2e-covered (dashboard.spec.ts).
+// per-pose dropzones, height prefill (no fabricated default; inches are
+// the default display unit per A-9 — the payload stays user_height_cm),
+// and the submit gate (both files + valid height). The per-pose QC
+// round-trip is e2e-covered (dashboard.spec.ts).
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -14,6 +15,7 @@ vi.mock("@/models/repositories/vault-repo", () => ({
   },
 }));
 
+import { vaultRepo } from "@/models/repositories/vault-repo";
 import { UploadMeasurementsView } from "./UploadMeasurementsView";
 
 beforeEach(() => {
@@ -58,7 +60,7 @@ describe("UploadMeasurementsView (B4 upload, 549:2)", () => {
     expect(screen.getByText("Side photo")).toBeInTheDocument();
   });
 
-  it("prefills height from the latest capture session — empty when none", () => {
+  it("prefills height in inches (A-9 default) — empty when none", () => {
     const { unmount } = render(
       <UploadMeasurementsView
         prefillHeightCm={168}
@@ -66,7 +68,13 @@ describe("UploadMeasurementsView (B4 upload, 549:2)", () => {
         onSaved={() => {}}
       />,
     );
-    expect(screen.getByLabelText("Height in centimeters")).toHaveValue("168");
+    // 168 cm canonical renders as 66.1 in — inches are the default
+    // display unit; the field is labeled for the active unit.
+    expect(screen.getByLabelText("Height in inches")).toHaveValue("66.1");
+    expect(screen.getByText("Height (in)")).toBeInTheDocument();
+    expect(
+      screen.getByText("Used to scale your photos — 39–91 in"),
+    ).toBeInTheDocument();
     unmount();
     render(
       <UploadMeasurementsView
@@ -76,10 +84,48 @@ describe("UploadMeasurementsView (B4 upload, 549:2)", () => {
       />,
     );
     // Nullable ruling: no fabricated default.
-    expect(screen.getByLabelText("Height in centimeters")).toHaveValue("");
+    expect(screen.getByLabelText("Height in inches")).toHaveValue("");
   });
 
-  it("gates the CTA on both poses + a valid height (100–230)", async () => {
+  it("unit toggle round-trips exactly and the payload stays user_height_cm", async () => {
+    render(
+      <UploadMeasurementsView
+        prefillHeightCm={168}
+        onBack={() => {}}
+        onSaved={() => {}}
+      />,
+    );
+
+    // Flip to cm: same physical height, canonical figure restored exactly.
+    await userEvent.click(
+      screen.getByRole("button", { name: "Switch units (currently in)" }),
+    );
+    expect(screen.getByLabelText("Height in centimeters")).toHaveValue("168");
+    expect(screen.getByText("Height (cm)")).toBeInTheDocument();
+    expect(
+      screen.getByText("Used to scale your photos — 100–230 cm"),
+    ).toBeInTheDocument();
+
+    // And back to inches — the display round-trips with no drift.
+    await userEvent.click(
+      screen.getByRole("button", { name: "Switch units (currently cm)" }),
+    );
+    expect(screen.getByLabelText("Height in inches")).toHaveValue("66.1");
+
+    // Submitting the untouched prefill sends exactly 168 — the 1-decimal
+    // inch display never drifts into the user_height_cm payload.
+    pickPose("front", "front.jpg");
+    pickPose("side", "side.jpg");
+    await userEvent.click(screen.getByTestId("get-measurements"));
+    expect(vaultRepo.createCaptureSession).toHaveBeenCalledWith(
+      expect.any(File),
+      expect.any(File),
+      168,
+      expect.any(String),
+    );
+  });
+
+  it("gates the CTA on both poses + a valid height (100–230 cm canonical)", async () => {
     render(
       <UploadMeasurementsView
         prefillHeightCm={null}
@@ -94,11 +140,13 @@ describe("UploadMeasurementsView (B4 upload, 549:2)", () => {
     pickPose("side", "side.jpg");
     expect(cta).toBeDisabled(); // still no height
 
-    const height = screen.getByLabelText("Height in centimeters");
-    await userEvent.type(height, "99");
+    // Entry is in inches by default: 39 in = 99.1 cm (under the 100 cm
+    // floor) stays gated; 67 in = 170.2 cm passes.
+    const height = screen.getByLabelText("Height in inches");
+    await userEvent.type(height, "39");
     expect(cta).toBeDisabled(); // out of range
     await userEvent.clear(height);
-    await userEvent.type(height, "170");
+    await userEvent.type(height, "67");
     expect(cta).toBeEnabled();
 
     // Uploaded state shows the file meta + Replace affordance (549:2).

--- a/web/src/components/dashboard/vault/UploadMeasurementsView.tsx
+++ b/web/src/components/dashboard/vault/UploadMeasurementsView.tsx
@@ -2,10 +2,12 @@
 
 // B4 — Upload measurements (Figma 549:2; M-10 two-photo canon + M-12
 // upload-only): labeled Front/Side dropzones with per-pose states (empty /
-// uploaded thumbnail + Replace / QC-error + QCHintChip), a Height (cm)
-// FormRow (100–230, prefilled from the latest capture session — never a
-// fabricated default), the "Get measurements" CTA into the MI-12 processing
-// constellation, and the results stagger → Save to vault. A QC failure
+// uploaded thumbnail + Replace / QC-error + QCHintChip), a Height FormRow
+// with the MI-13 cm/in toggle — inches active by default (A-9), entry
+// converts to canonical cm before the repository (the payload stays
+// `user_height_cm`, 100–230; prefilled from the latest capture session —
+// never a fabricated default), the "Get measurements" CTA into the MI-12
+// processing constellation, and the results stagger → Save to vault. A QC failure
 // re-opens only the failing pose (per-pose QC, capture-qc.md §2) — the
 // accepted pose's file is kept. Renders as a page takeover of the vault
 // content (in-content left-aligned h1 — the IG-desktop idiom, M-9 scope).
@@ -16,8 +18,9 @@ import type { MeasurementSession } from "@/models";
 import { useCapture, type CapturePose } from "@/controllers/use-capture";
 import { Button } from "@/components/ui/Button";
 import { CaptureResults } from "@/components/ui/CaptureResults";
+import { CM_PER_IN } from "@/lib/format";
 import { FormRow } from "@/components/ui/FormRow";
-import { Input } from "@/components/ui/Input";
+import { Input, type MeasureUnit } from "@/components/ui/Input";
 import { MeasurementCard } from "@/components/ui/MeasurementCard";
 import { ProcessingConstellation } from "@/components/ui/ProcessingConstellation";
 import {
@@ -33,6 +36,22 @@ const ACCEPT = "image/jpeg,image/png,image/heic";
 const POSE_LABEL: Record<CapturePose, string> = {
   front: "Front photo",
   side: "Side photo",
+};
+
+/** Canonical cm → the height field's display string in the active unit
+ * (1-decimal rounding, the MI-13 conversion canon). */
+const heightDisplay = (cm: number, unit: MeasureUnit) =>
+  String(Math.round((unit === "cm" ? cm : cm / CM_PER_IN) * 10) / 10);
+
+/** flows/vault.md §1 height contract: 100–230 cm (39–91 in). */
+const HEIGHT_RANGE: Record<MeasureUnit, string> = {
+  cm: "100–230 cm",
+  in: "39–91 in",
+};
+
+const HEIGHT_UNIT_WORD: Record<MeasureUnit, string> = {
+  cm: "centimeters",
+  in: "inches",
 };
 
 interface PickedImage {
@@ -183,13 +202,42 @@ export function UploadMeasurementsView({
   const [localErrors, setLocalErrors] = useState<
     Record<CapturePose, string | null>
   >({ front: null, side: null });
+  // Height rides in canonical cm; the field displays the active unit —
+  // inches by default (A-9). Keeping the cm number alongside the text means
+  // a prefilled 168 survives unit flips and submits as exactly 168 (the
+  // 1-decimal inch display never round-trips drift into the payload).
+  const [heightUnit, setHeightUnit] = useState<MeasureUnit>("in");
+  const [heightCm, setHeightCm] = useState<number | null>(prefillHeightCm);
   const [height, setHeight] = useState(
-    prefillHeightCm === null ? "" : String(prefillHeightCm),
+    prefillHeightCm === null ? "" : heightDisplay(prefillHeightCm, "in"),
   );
 
-  const heightCm = Number(height);
+  const editHeight = (raw: string) => {
+    setHeight(raw);
+    if (raw.trim() === "") {
+      setHeightCm(null);
+      return;
+    }
+    const num = Number(raw);
+    setHeightCm(
+      Number.isFinite(num)
+        ? heightUnit === "cm"
+          ? num
+          : num * CM_PER_IN
+        : Number.NaN,
+    );
+  };
+
+  const switchHeightUnit = (next: MeasureUnit) => {
+    setHeightUnit(next);
+    // Re-render the entered value in the new unit — same physical height.
+    if (heightCm !== null && Number.isFinite(heightCm)) {
+      setHeight(heightDisplay(heightCm, next));
+    }
+  };
+
   const heightValid =
-    height.trim() !== "" &&
+    heightCm !== null &&
     Number.isFinite(heightCm) &&
     heightCm >= 100 &&
     heightCm <= 230;
@@ -223,7 +271,11 @@ export function UploadMeasurementsView({
     capture.qcFailure === null;
 
   const submit = () => {
-    if (!images.front || !images.side || !heightValid) return;
+    if (!images.front || !images.side || heightCm === null || !heightValid) {
+      return;
+    }
+    // The payload stays canonical cm (`user_height_cm`) whatever the
+    // display unit — conversion happened at input time.
     void capture.upload(images.front.file, images.side.file, heightCm);
   };
 
@@ -327,16 +379,18 @@ export function UploadMeasurementsView({
           </div>
 
           <FormRow
-            label="Height (cm)"
-            helper="Used to scale your photos — 100–230 cm"
+            label={`Height (${heightUnit})`}
+            helper={`Used to scale your photos — ${HEIGHT_RANGE[heightUnit]}`}
             required
             className="max-w-xs"
           >
             <Input
               kind="numeric"
-              aria-label="Height in centimeters"
+              aria-label={`Height in ${HEIGHT_UNIT_WORD[heightUnit]}`}
               value={height}
-              onChange={(e) => setHeight(e.target.value)}
+              onChange={(e) => editHeight(e.target.value)}
+              unit={heightUnit}
+              onUnitChange={switchHeightUnit}
             />
           </FormRow>
 

--- a/web/src/components/home/FaqSection.tsx
+++ b/web/src/components/home/FaqSection.tsx
@@ -15,7 +15,7 @@ const FAQS = [
     id: "faq-1",
     question: "How accurate are camera measurements?",
     answer:
-      "We target within ±2 cm of a professional tape measure for most values. Good lighting and a full-body frame matter — the capture guide checks both, and you can correct any value manually.",
+      "We target within ±0.8 in of a professional tape measure for most values. Good lighting and a full-body frame matter — the capture guide checks both, and you can correct any value manually.",
   },
   {
     id: "faq-2",

--- a/web/src/components/home/StatBand.tsx
+++ b/web/src/components/home/StatBand.tsx
@@ -1,10 +1,12 @@
 // A3 Problem strip — heading + 3 StatCards (canvas 186:38/186:39).
-// Accuracy standard: product claims only (±2 cm target · 2 photos ·
-// 30-day photo auto-delete), never invented research statistics.
+// Accuracy standard: product claims only (±0.8 in target · 2 photos ·
+// 30-day photo auto-delete), never invented research statistics. The
+// accuracy claim reads in inches — the default display unit (A-9); the
+// QC pipeline's canonical ±2 cm target is unchanged.
 import { StatCard } from "@/components/ui/StatCard";
 
 const STATS = [
-  { stat: "±2 cm", label: "target accuracy vs a professional tape measure" },
+  { stat: "±0.8 in", label: "target accuracy vs a professional tape measure" },
   {
     stat: "2 photos",
     label: "all it takes to build a full measurement profile",

--- a/web/src/components/home/interactive.test.tsx
+++ b/web/src/components/home/interactive.test.tsx
@@ -159,7 +159,7 @@ describe("FaqSection (A9b)", () => {
   it("renders all five product questions with honest answers", () => {
     render(<FaqSection />);
     expect(
-      screen.getByText(/±2 cm of a professional tape measure/),
+      screen.getByText(/±0.8 in of a professional tape measure/),
     ).toBeInTheDocument();
     for (const q of [
       "How accurate are camera measurements?",

--- a/web/src/components/home/sections.test.tsx
+++ b/web/src/components/home/sections.test.tsx
@@ -20,7 +20,7 @@ afterEach(() => setAnalyticsTransport(null));
 describe("StatBand (A3)", () => {
   it("renders the three product claims — and only honest ones", () => {
     render(<StatBand />);
-    expect(screen.getByText("±2 cm")).toBeInTheDocument();
+    expect(screen.getByText("±0.8 in")).toBeInTheDocument();
     expect(screen.getByText("2 photos")).toBeInTheDocument();
     expect(screen.getByText("30 days")).toBeInTheDocument();
     expect(

--- a/web/src/components/ui/FAQItem.test.tsx
+++ b/web/src/components/ui/FAQItem.test.tsx
@@ -7,7 +7,7 @@ function renderGroup() {
   return render(
     <FAQGroup defaultOpenId="faq-1">
       <FAQItem id="faq-1" question="How accurate are the measurements?">
-        ±2 cm target.
+        ±0.8 in target.
       </FAQItem>
       <FAQItem id="faq-2" question="Who can see my measurements?">
         No one.
@@ -35,7 +35,7 @@ describe("FAQItem (§8.2b as built)", () => {
       screen.getByRole("button", { name: "Who can see my measurements?" }),
     );
     expect(screen.getByText("No one.")).toBeInTheDocument();
-    expect(screen.queryByText("±2 cm target.")).not.toBeInTheDocument();
+    expect(screen.queryByText("±0.8 in target.")).not.toBeInTheDocument();
   });
 
   it("rows are deep-linkable via DOM ids (#faq-n)", () => {
@@ -51,6 +51,6 @@ describe("FAQItem (§8.2b as built)", () => {
     });
     await userEvent.click(first);
     expect(first).toHaveAttribute("aria-expanded", "false");
-    expect(screen.queryByText("±2 cm target.")).not.toBeInTheDocument();
+    expect(screen.queryByText("±0.8 in target.")).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/ui/Input.test.tsx
+++ b/web/src/components/ui/Input.test.tsx
@@ -42,6 +42,22 @@ describe("Input (§8.2 + §8.2b kinds)", () => {
     expect(onUnitChange).toHaveBeenCalledWith("in");
   });
 
+  it("the toggle flips back to cm from the inches default (A-9)", async () => {
+    const onUnitChange = vi.fn();
+    render(
+      <Input
+        kind="numeric"
+        aria-label="shoulder"
+        unit="in"
+        onUnitChange={onUnitChange}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Switch units (currently in)" }),
+    );
+    expect(onUnitChange).toHaveBeenCalledWith("cm");
+  });
+
   it("currency kind shows the ₦ prefix", () => {
     render(<Input kind="currency" aria-label="budget" />);
     expect(screen.getByText("₦")).toBeInTheDocument();

--- a/web/src/components/ui/ManualMeasureRow.tsx
+++ b/web/src/components/ui/ManualMeasureRow.tsx
@@ -5,6 +5,7 @@
 // state default / active / error (MI-13). Value changes animate the
 // caller's sparkline preview via onChange.
 import clsx from "clsx";
+import { CM_PER_IN } from "@/lib/format";
 import { Input, type MeasureUnit } from "./Input";
 
 export interface ManualMeasureRowProps {
@@ -28,8 +29,6 @@ export function humanizeMeasureName(name: string): string {
     .map((w) => w[0]?.toUpperCase() + w.slice(1))
     .join(" ");
 }
-
-const CM_PER_IN = 2.54;
 
 export function ManualMeasureRow({
   name,

--- a/web/src/components/ui/MeasurementCard.test.tsx
+++ b/web/src/components/ui/MeasurementCard.test.tsx
@@ -3,12 +3,13 @@ import { render, screen } from "@testing-library/react";
 import { MeasurementCard } from "./MeasurementCard";
 
 describe("MeasurementCard (§8.2)", () => {
-  it("renders name, tabular value, and source chip", () => {
+  it("renders name, tabular value (inches by default, A-9), and source chip", () => {
     render(
       <MeasurementCard name="shoulder_width" valueCm={42.5} source="scan" />,
     );
     expect(screen.getByText("Shoulder Width")).toBeInTheDocument();
-    expect(screen.getByText("42.5 cm")).toBeInTheDocument();
+    // valueCm stays canonical cm; the DEFAULT display unit is inches.
+    expect(screen.getByText("16.7 in")).toBeInTheDocument();
     // Figma master (48:208): sentence-case source chip
     expect(screen.getByText("Scan")).toBeInTheDocument();
   });
@@ -60,15 +61,15 @@ describe("MeasurementCard (§8.2)", () => {
     expect(screen.queryByTestId("sparkline")).not.toBeInTheDocument();
   });
 
-  it("renders inches when the unit toggle flips", () => {
+  it("renders cm when the unit toggle flips (cm stays available)", () => {
     render(
       <MeasurementCard
         name="shoulder_width"
         valueCm={50.8}
-        unit="in"
+        unit="cm"
         source="manual"
       />,
     );
-    expect(screen.getByText("20.0 in")).toBeInTheDocument();
+    expect(screen.getByText("50.8 cm")).toBeInTheDocument();
   });
 });

--- a/web/src/components/ui/MeasurementCard.tsx
+++ b/web/src/components/ui/MeasurementCard.tsx
@@ -27,7 +27,7 @@ export interface MeasurementCardProps {
 export function MeasurementCard({
   name,
   valueCm,
-  unit = "cm",
+  unit = "in",
   source,
   confidence = null,
   history,

--- a/web/src/components/ui/SessionRow.test.tsx
+++ b/web/src/components/ui/SessionRow.test.tsx
@@ -12,7 +12,8 @@ describe("SessionRow (§8.2b)", () => {
     );
     expect(container.querySelector('[data-context="history"]')).not.toBeNull();
     expect(screen.getByText("Scan")).toBeInTheDocument();
-    expect(screen.getByText(/Shoulder Width 42.5 cm/)).toBeInTheDocument();
+    // 42.5 cm canonical renders in inches — the A-9 default display unit.
+    expect(screen.getByText(/Shoulder Width 16.7 in/)).toBeInTheDocument();
     await userEvent.click(
       screen.getByRole("button", { name: "Delete session" }),
     );

--- a/web/src/components/ui/StatCard.test.tsx
+++ b/web/src/components/ui/StatCard.test.tsx
@@ -4,8 +4,8 @@ import { StatCard } from "./StatCard";
 
 describe("StatCard (§8.2b marketing, pages.md A3)", () => {
   it("renders the product-claim stat + label", () => {
-    render(<StatCard stat="±2 cm" label="target measurement accuracy" />);
-    expect(screen.getByText("±2 cm")).toBeInTheDocument();
+    render(<StatCard stat="±0.8 in" label="target measurement accuracy" />);
+    expect(screen.getByText("±0.8 in")).toBeInTheDocument();
     expect(screen.getByText("target measurement accuracy")).toBeInTheDocument();
   });
 

--- a/web/src/components/ui/StatCard.tsx
+++ b/web/src/components/ui/StatCard.tsx
@@ -2,13 +2,14 @@
 
 // StatCard — design.md §8.2b Home section kit: 3 stat cards, fade-up on
 // scroll-into-view (once, pages.md A3). Accuracy standard (2026-07-18):
-// product claims only — ±2 cm target accuracy · 2 photos · 30-day photo
-// auto-delete — never invented research statistics.
+// product claims only — ±0.8 in target accuracy (the A-9 inches display of
+// the pipeline's canonical ±2 cm) · 2 photos · 30-day photo auto-delete —
+// never invented research statistics.
 import { useEffect, useRef, useState } from "react";
 import clsx from "clsx";
 
 export interface StatCardProps {
-  /** The claim headline, e.g. "±2 cm". */
+  /** The claim headline, e.g. "±0.8 in". */
   stat: string;
   label: string;
   className?: string;

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -17,11 +17,17 @@ describe("format utilities", () => {
     expect(formatNaira(-620_000)).toBe("−₦6,200");
   });
 
-  it("formats centimetres and inches — always one decimal (Figma '58.0 cm' idiom)", () => {
-    expect(formatCm(42.5)).toBe("42.5 cm");
-    expect(formatCm(42)).toBe("42.0 cm");
-    expect(formatCm(92)).toBe("92.0 cm");
+  it("defaults to inches (A-9) — always one decimal (Figma '58.0 cm' idiom)", () => {
+    // Values are canonical cm in; inches are the default display out.
+    expect(formatCm(42.5)).toBe("16.7 in");
+    expect(formatCm(50.8)).toBe("20.0 in");
     expect(formatCm(50.8, "in")).toBe("20.0 in");
+  });
+
+  it("keeps cm available via the unit toggle (storage stays canonical cm)", () => {
+    expect(formatCm(42.5, "cm")).toBe("42.5 cm");
+    expect(formatCm(42, "cm")).toBe("42.0 cm");
+    expect(formatCm(92, "cm")).toBe("92.0 cm");
   });
 
   it("formats relative ages", () => {

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -11,14 +11,19 @@ export function formatNaira(cents: number, currency = "NGN"): string {
   return `${cents < 0 ? "−" : ""}${symbol}${formatted}`;
 }
 
+/** Unit-toggle conversion canon (MI-13): storage is always cm. */
+export const CM_PER_IN = 2.54;
+
 /**
- * 42.5 → "42.5 cm" (or inches when the vault unit toggle flips, MI-13).
- * Always one decimal — the Figma idiom ("58.0 cm") keeps tabular columns
- * aligned; "92 cm" next to "78.5 cm" broke the tnum grid (audit 2026-07-20).
+ * 42.5 → "16.7 in" (inches are the default display unit, A-9 — Nigerian
+ * tailors work in inches; cm stays available via the MI-13 toggle, and
+ * stored values stay canonical cm). Always one decimal — the Figma idiom
+ * ("58.0 cm") keeps tabular columns aligned; "92 cm" next to "78.5 cm"
+ * broke the tnum grid (audit 2026-07-20).
  */
-export function formatCm(valueCm: number, unit: "cm" | "in" = "cm"): string {
+export function formatCm(valueCm: number, unit: "cm" | "in" = "in"): string {
   if (unit === "in") {
-    const inches = valueCm / 2.54;
+    const inches = valueCm / CM_PER_IN;
     return `${inches.toFixed(1)} in`;
   }
   return `${valueCm.toFixed(1)} cm`;


### PR DESCRIPTION
## Summary

Inches become the default measurement DISPLAY unit on web (**A-9**, ratified 2026-07-23 — Nigerian tailors work in inches). Storage, API payloads (`value_cm`, `user_height_cm`) and the QC pipeline stay canonical cm; only display + input defaults flip, and cm stays one MI-13 flip away.

## Where the default now originates

- `web/src/lib/format.ts` — `formatCm(valueCm, unit = "in")` ("16.7 in"; one decimal + tnum kept). Drives SessionRow, the request stepper's snapshot chips and OrderDetailView, which call it unitless.
- `web/src/components/ui/MeasurementCard.tsx` — `unit = "in"` default prop (vault grid + capture results).
- `web/src/components/dashboard/vault/CaptureSheets.tsx` — the manual-entry sheet's shared MI-13 unit state initializes `"in"`; the out-of-range advisory now speaks the active unit ("outside the usual 15.7–59.1 in." / canonical "40–150 cm" when toggled).
- `web/src/components/dashboard/vault/UploadMeasurementsView.tsx` — the height field gains the MI-13 cm/in toggle, inches active by default: label "Height (in)", helper "Used to scale your photos — 39–91 in" (canvas copy; flows/vault.md's 100–230 cm ⇄ 39–91 in). Entry converts to canonical cm at input time — the payload stays `user_height_cm`, and a prefilled 168 survives unit flips and submits as **exactly 168** (no 1-decimal display drift).
- `web/src/app/dev/components/gallery.tsx` — the gallery's toggle mirrors the default.
- Marketing accuracy copy per the updated canvas: StatBand + FAQ read **±0.8 in** (the inches display of the pipeline's canonical ±2 cm target — capture-qc.md untouched).

There is no persisted unit preference on web — the defaults live in the initializers/params above; within a sheet the toggle choice persists in its shared state.

## Docs (this lane owns them)

- `docs/decisions.md` — **A-9 · Inches are the default display unit** added after A-8, Ratified 2026-07-23.
- `docs/design.md` — MI-13 row notes the inches default; the accuracy-standard passage reads ±0.8 in.
- `docs/web-implementation.md` — formatter statement now leads with "16.7 in" (one-decimal rule kept, canonical-cm statement added).
- `docs/mobile-implementation.md` — height-input and results bullets carry the A-9 display notes (canonical `user_height_cm` scale math untouched).
- `docs/pages.md` shows no unit examples — unchanged. `capture-qc.md` canonical math untouched. Seeds stay canonical cm.

## Tests

- `cd web && npm run lint && npm test && npm run typecheck` — all green (88 files, 551 tests).
- New/adjusted: default-is-inches assertions in `format.test.ts`, `MeasurementCard.test.tsx`, `SessionRow.test.tsx`; cm-remains-available toggle tests (`Input.test.tsx`, CaptureSheets, upload view); manual entry saves inches-typed values as canonical cm; the upload height round-trip test locks in→cm→in with zero payload drift; e2e specs updated (`dashboard.spec.ts` height in inches, `home.spec.ts` ±0.8 in).

Scope note: web/ + docs/ only — the mobile lane ships its own flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)