### PR TITLE
chore: fleet alignment — project manifest + v2 template sync

### DIFF
--- a/.cuelabs/project.yaml
+++ b/.cuelabs/project.yaml
@@ -1,0 +1,23 @@
+schemaVersion: 1
+name: apparule
+profile: cuelabs
+
+surfaces:
+  web: active
+  backend:
+    common: planned
+    measure: planned
+  mobile:
+    flutter: active
+
+capabilities:
+  grpc: absent
+  firebaseAuth: planned
+
+deployment:
+  web: firebase-app-hosting
+  api: none
+  selfHost: helm
+  infrastructure: terraform
+
+deviations: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - `.cuelabs/project.yaml` — the CueLABS project manifest (standards
   catalog v2): declares surface truth — web and mobile flutter active; `api/common` + `api/measure` planned pending the backend go —
-  so standards tooling audits declared state instead of inferring it.
+  so standards tooling audits declared state instead of inferring it (#178).
 
 ### Changed
 
@@ -371,7 +371,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `SECURITY.md` and `CONTRIBUTING.md` synced to the v2 standards
   templates: the security policy gains the private-vulnerability-reporting
   flow with the dedicated `security@cuesoft.io` mailbox, and contributor
-  setup routes through the README, `.env.example`, and `make help`.
+  setup routes through the README, `.env.example`, and `make help` (#178).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     subtitle; routes to C13 become-a-designer for everyone until the
     C15 composer ships) (#164).
 
+- `.cuelabs/project.yaml` — the CueLABS project manifest (standards
+  catalog v2): declares surface truth — web and mobile flutter active; `api/common` + `api/measure` planned pending the backend go —
+  so standards tooling audits declared state instead of inferring it.
+
 ### Changed
 
 - Inches are the default measurement display unit on web (A-9 — Nigerian
@@ -363,6 +367,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   and Flutter to feature-first `lib/src` with `snake_case.dart` (#47).
 - Aligned README + docs (overview, setup) to the shared CueLABS™ section
   structure; run commands use `make up` / `go run ./cmd/server` (#47).
+
+- `SECURITY.md` and `CONTRIBUTING.md` synced to the v2 standards
+  templates: the security policy gains the private-vulnerability-reporting
+  flow with the dedicated `security@cuesoft.io` mailbox, and contributor
+  setup routes through the README, `.env.example`, and `make help`.
 
 ### Removed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,11 @@ repositories, which share a common structure and conventions.
 
 1. Fork and clone the repository.
 2. Create a feature branch: `git checkout -b feature/short-description`.
-3. Install dependencies for the area you're working on — see the repository's
-   [docs/setup.md](docs/setup.md).
+3. Read `README.md` for repository-specific prerequisites.
+4. Copy `.env.example` to `.env` when the repository provides one, then supply
+   development-safe values. Never reuse production secrets.
+5. Run `make help` to discover the supported setup, development, lint, and test
+   targets, then run the targets relevant to your change.
 
 ## Repository layout
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,8 +11,11 @@ expected to track `main`.
 
 Report privately using GitHub's
 [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
-(the **Security → Report a vulnerability** tab), or email the maintainers listed
-in CODEOWNERS.
+through the repository's **Security → Report a vulnerability** tab. CueLABS™
+public repositories must enable private vulnerability reporting before
+publishing this policy. If that tab is unavailable, email `security@cuesoft.io`
+with the subject `Security vulnerability: <repository name>`. Do not disclose
+the vulnerability in an issue, discussion, or pull request.
 
 Please include a description and impact, steps to reproduce, and the affected
 component. We aim to acknowledge within 3 business days.


### PR DESCRIPTION
## Summary

- adds `.cuelabs/project.yaml` — the CueLABS project manifest (standards catalog v2), recording surface truth per program state (gated programs are `planned`, shipped surfaces `active`)
- syncs `SECURITY.md` to the v2 template: private-vulnerability-reporting flow + dedicated `security@cuesoft.io` mailbox (reporting is verified enabled on this repo)
- syncs `CONTRIBUTING.md` to the v2 template: setup routes through README, `.env.example`, and `make help`

## Validation

- `cuelabs_standard.py audit` against standards v2.0.1: manifest **valid**, **Baseline conforming: yes**
- SECURITY.md / CONTRIBUTING.md md5-match the v2.0.1 templates byte-for-byte

🤖 Generated with [Claude Code](https://claude.com/claude-code)