### PR TITLE
chore(deps): bump share_plus to 13.3.0 (supersedes #183)

### DIFF
--- a/mobile/flutter/pubspec.lock
+++ b/mobile/flutter/pubspec.lock
@@ -1176,18 +1176,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "02180b01c1237b9706b663d9402b2cf2402b3407f48cce99cc19e3200f095b8a"
+      sha256: "34f00f9becd2743c1fb05363d624f9f70d37f7ccdcdda47450bc0b8c9d327b8c"
       url: "https://pub.dev"
     source: hosted
-    version: "13.2.1"
+    version: "13.3.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: "7f7ae28cf400d13f811e297ff37742dba83b79e0a6f5dce14eec0248274e6ce9"
+      sha256: "365ef7379fc22507256adda3385152942ffce08935452bc972c2e52a0bebae41"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.2.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -1667,4 +1667,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.44.7"
+  flutter: "3.44.7"

--- a/mobile/flutter/pubspec.yaml
+++ b/mobile/flutter/pubspec.yaml
@@ -51,7 +51,7 @@ dependencies:
   # package, glyphs referenced as `LucideIcons.*`.
   lucide_icons_flutter: ^3.1.15
   riverpod_annotation: ^4.0.3
-  share_plus: ^13.2.1
+  share_plus: ^13.3.0
   shared_preferences: ^2.5.5
   # Pin-ledger addition (auth cutover): C1's legal links open the
   # canonical Cuesoft policies in the system browser (flows/auth.md §5).


### PR DESCRIPTION
Manual bump with a clean `pub get` — dependabot's lockfile omitted the `share_plus_platform_interface` 7.1.0 → 7.2.0 transitive, so its PR kept failing the codegen-fresh gate. Analyzer clean.

Closes #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)