### PR TITLE
fix(e2e): capture journey scrolls to the save CTA (A-10b full-template results)

### DIFF
--- a/mobile/flutter/integration_test/smoke_journeys_test.dart
+++ b/mobile/flutter/integration_test/smoke_journeys_test.dart
@@ -103,14 +103,16 @@ void main() {
       await $(find.bySemanticsLabel('Height slider')).tap();
       await $('Continue').tap();
 
-      // Processing resolves into results (§4 confidences)…
+      // Processing resolves into results (§4 confidences). A-10b: the
+      // scan maps the FULL tailor template (women = 17 for the seeded
+      // profile), so the save CTA sits below the fold — scroll to it.
       await $('Your measurements').waitUntilVisible();
-      await $('Save to vault').waitUntilVisible();
+      await $('Save to vault').scrollTo();
 
       // …and saving lands in C7 with the just-captured session.
       await $('Save to vault').tap();
       await $('Measured today').waitUntilVisible();
-      await $('Up to date · 2 measurements').waitUntilVisible();
+      await $('Up to date · 17 measurements').waitUntilVisible();
     },
   );
 


### PR DESCRIPTION
The nightly (run 30604247719) failed after A-10b: the scan maps the full women template — 17 result cards — pushing "Save to vault" below the fold; patrol found the widget but it wasn't hit-testable. The journey now `scrollTo()`s the CTA and asserts the post-save vault meta at 17 measurements.

**Proven on this branch**: mobile-e2e dispatch run 30613596764 — all 5 journeys green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)