### PR TITLE
fix(web): create public/ in the builder stage

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -20,6 +20,7 @@ COPY docs/api/openapi.yaml /app/docs/api/openapi.yaml
 # NEXT_PUBLIC_* are inlined at build time, so they must be provided here.
 ARG NEXT_PUBLIC_BASE_URL
 ENV NEXT_PUBLIC_BASE_URL=$NEXT_PUBLIC_BASE_URL
+RUN mkdir -p public
 RUN npm run build
 
 # ---- runner ----


### PR DESCRIPTION
## What

Adds `RUN mkdir -p public` to the builder stage of `web/Dockerfile`, before `npm run build`.

## Why

The runner stage does `COPY --from=builder /app/web/public ./public`, which hard-fails the image build when the repo has no `web/public/`.

**upstat has none** — its favicon ships via the App Router metadata file (`src/app/favicon.ico`), not as a static asset — so its web image could not be built at all. apparule and expendit both have a committed `public/`, so there the line is a deliberate no-op kept for template parity.

This brings all three repos in line with the fleet template, `Dockerfile.web` in oss-engineering-standards, which already carries this line — the repos had drifted behind it.

## Scope

One line, build-time only. No runtime, dependency, or application change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)