### PR TITLE
perf(mobile): right-size the Gradle heap ceiling

### DIFF
--- a/mobile/flutter/android/gradle.properties
+++ b/mobile/flutter/android/gradle.properties
@@ -1,4 +1,11 @@
-org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
+# Heap is a ceiling the JVM grows into, not an upfront reservation — but an
+# 8G ceiling lets it balloon before GC reclaims, and peak RSS is what trips
+# memory-pressure OOM policies on 16GB dev laptops. 3G is enough: a CLEAN
+# `flutter build apk --debug --flavor dev` succeeds at this setting (verified
+# 2026-08-09). That build peaks ~6.7G across the whole toolchain — Gradle plus
+# the Kotlin daemon, dex, javac and the Dart compile — so the Gradle heap is
+# only one slice of the footprint, and capping it bounds the total.
+org.gradle.jvmargs=-Xmx3G -XX:MaxMetaspaceSize=1G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 # This newDsl flag was added by the Flutter template
 android.newDsl=false


### PR DESCRIPTION
## What

`mobile/flutter/android/gradle.properties`:

```diff
--org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx3G -XX:MaxMetaspaceSize=1G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
```

`ReservedCodeCacheSize` and `HeapDumpOnOutOfMemoryError` are unchanged.

## Why

`-Xmx8G -XX:MaxMetaspaceSize=4G` is the stock Flutter template value. An 8G ceiling does not reserve 8G — the JVM grows into it — but it lets the heap balloon before GC reclaims, and **peak RSS is what memory-pressure OOM policies react to**.

On a 16GB laptop this is not theoretical. Ubuntu 24.04 ships `systemd-oomd` configured to kill the user slice at 50% memory pressure sustained for 20s (`/usr/lib/systemd/system/user@.service.d/10-oomd-user-service-defaults.conf`). A local build was killed mid-run along with 32 sibling processes; the same policy had killed GNOME Shell and Chrome on other days.

## Validation

A **clean** `flutter build apk --debug --flavor dev` succeeds at these values, with no environment override — `gradle.properties` exactly as committed:

- `Result=success`, exit 0, APK produced (175M)
- peak **6.7G** across the whole toolchain, 1.4G swap
- no oomd kill

The 6.7G is the full cgroup — Gradle, the Kotlin daemon, dex, javac and the Dart compile. The Gradle heap is one slice of that, which is the point: capping it bounds the total.

`-Xmx3G` is directly measured. `MaxMetaspaceSize=1G` is a conventional value (AGP guidance sits at 512m–1g) rather than an independently measured one, but it is exercised by the clean build above.

## CI caveat

`mobile-e2e.yml` is `workflow_dispatch` + nightly cron, **never per-PR** — by design, per its header comment on patrol's device-farm cost. So green checks on this PR do **not** mean the Android build path was tested. The nightly 03:17 run is the first CI exercise of this change. Worth a manual dispatch before merge if the reviewer prefers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)