### PR TITLE
feat(deploy): run the web app in a local cluster without its backends

### DIFF
--- a/deploy/helm/templates/ingress.yaml
+++ b/deploy/helm/templates/ingress.yaml
@@ -1,0 +1,44 @@
+{{- /*
+Optional Ingress, off by default so existing consumers of this chart are
+unaffected. Enable it to publish ONE service under a hostname; everything else
+stays cluster-internal.
+
+Why hostname routing rather than a NodePort per service: several products in this
+fleet listen on the same ports (web on 3000, api-common on 8080), so exposing
+them by port reintroduces the collision that in-cluster DNS already solved. One
+ingress controller on :80 keeps the host side to a single port no matter how many
+services or releases exist.
+
+The backend port is read from .Values.services so it cannot drift from the
+Service definition.
+*/ -}}
+{{- if .Values.ingress.enabled }}
+{{- $svcName := required "ingress.service must name a key in .Values.services" .Values.ingress.service }}
+{{- $svc := index .Values.services $svcName }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    {{- include "chart.selectorLabels" (dict "name" $svcName "root" $) | nindent 4 }}
+    {{- include "chart.labels" $ | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    - host: {{ required "ingress.host is required when ingress.enabled" .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path | default "/" }}
+            pathType: {{ .Values.ingress.pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ $svcName }}
+                port:
+                  number: {{ $svc.port }}
+{{- end }}

--- a/deploy/helm/values-local.yaml
+++ b/deploy/helm/values-local.yaml
@@ -1,0 +1,47 @@
+# Local Kubernetes overlay: frontend only, no backends.
+#
+# The backends are deliberately absent — they are what's under active
+# development, so running them here would mean rebuilding an image per edit and
+# every frontend breaking on each restart. The web app is self-contained in
+# TEST_MODE: auth resolves to the TestModeAuthProvider and the API client targets
+# the in-app mock server at /api/mock/v1/*, so nothing outbound is required.
+#
+# NOTE: NEXT_PUBLIC_TEST_MODE is NOT set here on purpose. Next inlines
+# NEXT_PUBLIC_* at `next build`, so a runtime env var would be silently ignored.
+# It is baked into the image instead:
+#   docker build -f web/Dockerfile -t cuesoft/apparule-web:testmode --build-arg NEXT_PUBLIC_TEST_MODE=1 .
+#
+#   helm upgrade --install apparule deploy/helm -n apparule --create-namespace \
+#     -f deploy/helm/values.yaml -f deploy/helm/values-local.yaml
+
+services:
+  # Backends removed, not merely omitted: Helm deep-merges maps, so a key
+  # left out of this overlay would still come through from values.yaml.
+  # `null` is what actually deletes it.
+  api-common: null
+  api-measure: null
+  web:
+    image: cuesoft/apparule-web:testmode
+    imagePullPolicy: IfNotPresent   # image is imported into the cluster, never pulled
+    port: 3000
+    runAsUser: 1000                 # the node user in the web image
+    replicas: 1
+    env:
+      PORT: "3000"
+      HOSTNAME: "0.0.0.0"
+    # Sized to coexist with the Postiz stack on a ~8GB host. Next standalone
+    # idles well under 128Mi; the limit is headroom for a traffic spike, not a
+    # target.
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+ingress:
+  enabled: true
+  className: traefik
+  host: apparule.localtest.me
+  service: web

--- a/deploy/helm/values-local.yaml
+++ b/deploy/helm/values-local.yaml
@@ -11,6 +11,13 @@
 # It is baked into the image instead:
 #   docker build -f web/Dockerfile -t cuesoft/apparule-web:testmode --build-arg NEXT_PUBLIC_TEST_MODE=1 .
 #
+# Then load it into the cluster. kind/k3d/minikube/k3s nodes run their own
+# container runtime and cannot see the host Docker image store, so with
+# imagePullPolicy: IfNotPresent the node would try to pull this unpublished
+# tag and land in ImagePullBackOff. For k3d:
+#   k3d image import cuesoft/apparule-web:testmode -c <cluster>
+# (kind: `kind load docker-image`; minikube: `minikube image load`.)
+#
 #   helm upgrade --install apparule deploy/helm -n apparule --create-namespace \
 #     -f deploy/helm/values.yaml -f deploy/helm/values-local.yaml
 
@@ -25,7 +32,12 @@ services:
     imagePullPolicy: IfNotPresent   # image is imported into the cluster, never pulled
     port: 3000
     runAsUser: 1000                 # the node user in the web image
-    replicas: 1
+    # templates/deployment.yaml reads $svc.replicaCount (falling back to the
+    # global replicaCount) — `replicas` here would be silently ignored.
+    # Pinning to 1 is required, not cosmetic: the TEST_MODE mock server keeps
+    # its seeded store in process memory, so a second replica would serve a
+    # separate database and reads after writes would be inconsistent.
+    replicaCount: 1
     env:
       PORT: "3000"
       HOSTNAME: "0.0.0.0"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -33,3 +33,15 @@ services:
     healthPath: /
     env:
       PORT: "3000"
+
+# Optional Ingress (see templates/ingress.yaml). Disabled by default: the chart's
+# existing consumers publish through Cloud Run / App Hosting, not an ingress
+# controller. Enable per-environment via a values overlay, e.g. values-local.yaml.
+ingress:
+  enabled: false
+  # className: traefik
+  # host: example.localtest.me
+  # service: web          # must be a key under `services` above
+  # path: /
+  # pathType: Prefix
+  # annotations: {}

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -20,6 +20,11 @@ COPY docs/api/openapi.yaml /app/docs/api/openapi.yaml
 # NEXT_PUBLIC_* are inlined at build time, so they must be provided here.
 ARG NEXT_PUBLIC_BASE_URL
 ENV NEXT_PUBLIC_BASE_URL=$NEXT_PUBLIC_BASE_URL
+# TEST_MODE is a build-time switch like every other NEXT_PUBLIC_*: Next inlines
+# it at `next build`, so a container env var at runtime would be ignored. Unset
+# by default, so production images are byte-identical to before.
+ARG NEXT_PUBLIC_TEST_MODE
+ENV NEXT_PUBLIC_TEST_MODE=$NEXT_PUBLIC_TEST_MODE
 RUN mkdir -p public
 RUN npm run build
 


### PR DESCRIPTION
Launching every product on one host means only the first `web` can bind 3000 and only the first `api-common` can bind 8080. In a cluster that stops being a problem — each pod gets its own network namespace — **provided** the host side is one ingress rather than a port per service.

Verified end to end on a local k3d cluster: all three products' web apps serving **simultaneously**, each on its own hostname, over a **single host port (80)**.

```
apparule.localtest.me  -> HTTP 200
upstat.localtest.me    -> HTTP 200
expendit.localtest.me  -> HTTP 200

NAMESPACE   NAME   PORT
apparule    web    3000
upstat      web    3000     <- all three on 3000, no collision
expendit    web    3000
```

## What changed

**`web/Dockerfile` gains `ARG NEXT_PUBLIC_TEST_MODE`.** This is the piece that makes a backendless image possible at all. Next inlines `NEXT_PUBLIC_*` at `next build`, so TEST_MODE **cannot** be switched on by a container env var or a Helm value — setting it there looks like it works and does nothing. Unset by default, so production images are unchanged.

Not optional for expendit: `web/src/auth/index.ts` throws `"FirebaseAuthProvider not yet wired — run with NEXT_PUBLIC_TEST_MODE=1"`, so its image could not serve a page without this.

**`templates/ingress.yaml`**, gated on `ingress.enabled` and therefore inert for existing consumers, which publish via Cloud Run / App Hosting. The backend port is read from `.Values.services` so it cannot drift from the Service definition.

**`values-local.yaml`**, a frontend-only overlay. Backends are set to `null`, not omitted — Helm deep-merges maps, so a key left out still arrives from `values.yaml`. I found this by rendering: the first version silently emitted the backends too.

## Verification

- `helm template` and `helm install --dry-run=server`: one Deployment, one Service, one Ingress. No backends.
- Pod Running, **0 restarts**, using **~51 MiB against a 512 MiB limit**.
- **TEST_MODE genuinely active**, not assumed: `POST /api/mock/v1/testing/reset` answers through the ingress, and `test-mode-token` is present in the built `.next` bundle.
- Postiz stack on the same host untouched — all 7 containers healthy, `temporal-ui` still owns 8080.

## Notes for review

- Namespace **per product**, not one shared namespace: Services are named bare (`web`, `api-common`), so three releases in one namespace would collide on `Service/web`. This matches `deploy/terraform`'s existing default.
- TEST_MODE is deliberately **absent** from the overlay's `env` block, for the build-time reason above.
- Local runs use `imagePullPolicy: IfNotPresent` against an image imported into the cluster; nothing is pulled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
